### PR TITLE
ci: publish helm chart to ghcr.io on chart/* tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,3 +76,41 @@ jobs:
           gh release create "${{ github.ref_name }}" \
             --title "${{ github.ref_name }}" \
             --notes "${{ steps.release_notes.outputs.notes }}"
+
+  publish-chart:
+    if: startsWith(github.ref_name, 'chart/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Verify chart version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#chart/}"
+          CHART_VERSION=$(yq '.version' chart/Chart.yaml)
+          if [ "${TAG_VERSION}" != "${CHART_VERSION}" ]; then
+            echo "Tag version ${TAG_VERSION} does not match chart/Chart.yaml version ${CHART_VERSION}" >&2
+            exit 1
+          fi
+
+      - name: Package chart
+        run: |
+          mkdir -p dist
+          helm package chart/ --destination dist/
+
+      - name: Log in to ghcr.io
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" \
+            | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push chart to ghcr.io
+        run: |
+          helm push dist/*.tgz oci://ghcr.io/nvidia/nodewright/charts

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -41,6 +41,12 @@ git push origin operator/v0.9.0 chart/v0.9.0  # Push operator + chart (add agent
 
 **Automated:** Tests → Multi-platform build → Publish to ghcr.io + nvcr.io + NGC
 
+A `chart/v*` tag push also publishes the Helm chart as an OCI artifact to `oci://ghcr.io/nvidia/nodewright/charts/skyhook-operator`. Consumers install with:
+
+```bash
+helm install skyhook-operator oci://ghcr.io/nvidia/nodewright/charts/skyhook-operator --version v0.9.0
+```
+
 ### Patch Release Workflow
 
 ```bash


### PR DESCRIPTION
## Summary
- Add a `publish-chart` job to `.github/workflows/release.yml` that fires when a `chart/v*` tag is pushed, verifies the tag matches `chart/Chart.yaml`, packages the chart, and pushes it as an OCI artifact to `ghcr.io/nvidia/nodewright/charts` using the workflow's `GITHUB_TOKEN` (granted `packages: write`).
- Document the new install path in `docs/release-process.md`. No nvcr.io/NGC changes — the existing docs claim there remains aspirational for those targets.

## Test plan
- [x] Bump `chart/Chart.yaml` to a throwaway version (e.g. `v0.15.1-test.1`) on a test branch, push a matching `chart/v0.15.1-test.1` tag, and confirm the `publish-chart` job runs and the artifact appears under `ghcr.io/nvidia/nodewright/charts/skyhook-operator`.
- [x] Delete the test GitHub Release and tag after verifying.
- [ ] First successful push will require a manual flip of the new package from private to public (or grant pull access to consuming teams) at github.com/orgs/NVIDIA/packages.
- [x] Verify `helm pull oci://ghcr.io/nvidia/nodewright/charts/skyhook-operator --version <test-version>` succeeds from a logged-in client.

## Notes
- Chart name remains `skyhook-operator` (chart hasn't been renamed yet); the OCI artifact name follows.
- Helm 3.10+ accepts the `v`-prefixed version used in `Chart.yaml`. If downstream tools (ArgoCD, Flux) push back on this, the prefix can be dropped in a follow-up.