### PR TITLE
feat(ci): add support rc releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,10 +94,25 @@ jobs:
         # Idempotent: skip create if the release already exists so workflow
         # re-runs on the same tag can still reach the upload step below.
         run: |
+          PRERELEASE_FLAG=""
+          # Release candidate tags (e.g. operator/v0.16.0-rc1) → mark as
+          # prerelease so they don't become "Latest" on the Releases page.
+          # Only -rc<N> is accepted; any other suffix after the version is
+          # rejected to keep the tag format predictable.
+          VERSION="${GITHUB_REF_NAME#*/}"
+          if [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            : # plain release
+          elif [[ "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc[0-9]+$ ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          else
+            echo "ERROR: tag '${GITHUB_REF_NAME}' does not match v<MAJOR>.<MINOR>.<PATCH> or v<MAJOR>.<MINOR>.<PATCH>-rc<N>" >&2
+            exit 1
+          fi
           if ! gh release view "${{ github.ref_name }}" >/dev/null 2>&1; then
             gh release create "${{ github.ref_name }}" \
               --title "${{ github.ref_name }}" \
-              --notes "${{ steps.release_notes.outputs.notes }}"
+              --notes "${{ steps.release_notes.outputs.notes }}" \
+              ${PRERELEASE_FLAG}
           fi
 
       - name: Upload third-party notices to release

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -82,6 +82,32 @@ git tag chart/v0.9.1         # Patch chart to reference new agent
 git push origin agent/v6.4.1 chart/v0.9.1
 ```
 
+### Release Candidates
+
+Cut a release candidate with an `-rc<N>` suffix on the component tag. The workflow detects the suffix and marks the GitHub release as a prerelease so it doesn't become "Latest" on the Releases page.
+
+Only `v<MAJOR>.<MINOR>.<PATCH>` and `v<MAJOR>.<MINOR>.<PATCH>-rc<N>` are accepted — any other suffix (`-beta`, `-alpha`, `-rc.1`, etc.) is rejected by the workflow so the tag format stays predictable.
+
+```bash
+# Operator RC
+git tag operator/v0.16.0-rc1
+git push origin operator/v0.16.0-rc1
+
+# Chart RC — Chart.yaml must match the tag, including the suffix
+# Edit chart/Chart.yaml:
+version: v0.16.0-rc1
+appVersion: v0.16.0-rc1
+
+git commit -am "release: prepare v0.16.0-rc1"
+git tag chart/v0.16.0-rc1
+git push origin chart/v0.16.0-rc1
+```
+
+Notes:
+
+- Helm OCI accepts pre-release versions, so `chart/v0.16.0-rc1` pushes `skyhook-operator-v0.16.0-rc1.tgz` to `oci://ghcr.io/nvidia/nodewright/charts`. Install with `--version v0.16.0-rc1`.
+- `git cliff --latest` scopes release notes to commits since the previous tag of the same component, so each RC's notes only cover commits since the prior RC (or the prior stable, for `-rc1`).
+
 ### Legacy: Individual Component Releases (Deprecated)
 
 *The following workflows are deprecated in favor of the release branch strategy above.*


### PR DESCRIPTION
## Summary

- Adds release candidate support to `.github/workflows/release.yml` for `operator/`, `agent/`, and `chart/` tags. Tags matching `v<MAJOR>.<MINOR>.<PATCH>-rc<N>`
  are published with `--prerelease` so they don't become "Latest" on the Releases page.
- Validates tag shape in the workflow: only `vX.Y.Z` and `vX.Y.Z-rcN` are accepted; any other suffix (`-beta`, `-rc.1`, `-rc1a`, etc.) fails the job with a
clear error so the tag format stays predictable.
- CLI release workflow (`cli-release.yaml`) already auto-detects prereleases via `softprops/action-gh-release@v3`, so no change there.
- Documents the RC flow in `docs/release-process.md` (tag commands, `Chart.yaml` mirroring requirement, Helm OCI behavior, `git cliff --latest` scoping).


## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
