### PR TITLE
fix(test): clean up downgraded package in downgrade-after-uninstall

### DIFF
--- a/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/README.md
+++ b/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/README.md
@@ -20,6 +20,10 @@ the complementary case where no uninstall is required.
 3. Update the spec to v1.2.3. The webhook accepts the downgrade because the
    package is absent from all tracked nodes. The new version installs and
    reaches `stage=config, state=complete`.
+4. Flip `uninstall.apply: true` on v1.2.3 and wait for the package to be
+   absent from node state again. This is purely operational — it leaves the
+   CR with no installed packages so chainsaw's automatic CLEANUP can delete
+   it without waiting on the delete-time uninstall finalizer.
 
 ## Key Features Tested
 
@@ -31,7 +35,8 @@ the complementary case where no uninstall is required.
 
 ## Files
 
-- `chainsaw-test.yaml` — Main test: install v2 → uninstall v2 → downgrade to v1
+- `chainsaw-test.yaml` — Main test: install v2 → uninstall v2 → downgrade to v1 → uninstall v1
 - `skyhook.yaml` — Initial v2.1.4 Skyhook, `uninstall.enabled: true`
-- `update-trigger-uninstall.yaml` — Patch setting `uninstall.apply: true`
+- `update-trigger-uninstall.yaml` — Patch setting `uninstall.apply: true` on v2.1.4
 - `update-downgrade.yaml` — Patch changing version to v1.2.3
+- `update-trigger-uninstall-v1.yaml` — Patch setting `uninstall.apply: true` on v1.2.3 to clear node state before cleanup

--- a/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/chainsaw-test.yaml
@@ -99,3 +99,21 @@ spec:
             name: downgrade-after-uninstall
           status:
             status: complete
+
+  - name: uninstall-v1
+    description: >
+      Uninstall the downgraded v1.2.3 package so the CR has no installed
+      packages at chainsaw cleanup time — keeps the finalizer's delete-time
+      uninstall flow off the cleanup critical path.
+    try:
+    - update:
+        file: update-trigger-uninstall-v1.yaml
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            labels:
+              skyhook.nvidia.com/test-node: skyhooke2e
+            annotations:
+              skyhook.nvidia.com/nodeState_downgrade-after-uninstall: '{}'

--- a/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/update-trigger-uninstall-v1.yaml
+++ b/k8s-tests/chainsaw/skyhook/downgrade-after-uninstall/update-trigger-uninstall-v1.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: skyhook.nvidia.com/v1alpha1
+kind: Skyhook
+metadata:
+  name: downgrade-after-uninstall
+spec:
+  nodeSelectors:
+    matchLabels:
+      skyhook.nvidia.com/test-node: skyhooke2e
+  interruptionBudget:
+    count: 1
+  packages:
+    mypkg:
+      version: "1.2.3"
+      image: ghcr.io/nvidia/skyhook/agentless
+      uninstall:
+        enabled: true
+        apply: true


### PR DESCRIPTION
## Summary

- `chainsaw/downgrade-after-uninstall` was failing in CI with `context deadline exceeded` during chainsaw's automatic CLEANUP (the only failing test in the suite).
- Root cause: after #200 introduced the delete-time uninstall finalizer, the CR-delete path now waits for uninstall pods to complete on every selected node before releasing. This test left `mypkg@1.2.3` freshly installed (`uninstall.enabled: true`, `apply: false`) at cleanup time, so the finalizer had real work to do — more than chainsaw's default cleanup window allows.
- Fix: add a final `uninstall-v1` step that flips `uninstall.apply: true` on the downgraded v1.2.3 spec and asserts `nodeState_…: '{}'` before chainsaw's auto-CLEANUP runs. With node state empty, the finalizer has nothing to do at delete time and the CR drops promptly.

This mirrors the approach the other uninstall-pool tests already take (they either own the delete inside the test body or have node state empty by the end of the last asserted step).

## Test plan

- [ ] `chainsaw/downgrade-after-uninstall` passes in CI (uninstall pool)
- [ ] Other tests in the uninstall pool still pass
- [ ] No new operator code changes — this is a test-only fix