### PR TITLE
fix: close StageInterrupt trap + harden core e2e pool

### DIFF
--- a/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/config-skyhook/chainsaw-test.yaml
@@ -24,6 +24,7 @@ metadata:
 spec:
   timeouts:
     assert: 240s ## 5 steps with full package lifecycles including mid-flight updates
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
   catch: ## if errors, print the most important info
     - get:
         apiVersion: v1

--- a/k8s-tests/chainsaw/skyhook/depends-on/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/depends-on/chainsaw-test.yaml
@@ -24,6 +24,24 @@ metadata:
 spec:
   timeouts:
     assert: 90s
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
+  catch: ## if errors, print the most important info
+    - get:
+        apiVersion: v1
+        kind: Node
+        selector: skyhook.nvidia.com/test-node=skyhooke2e
+        format: yaml
+    - get:
+        apiVersion: skyhook.nvidia.com/v1alpha1
+        kind: Skyhook
+        name: depends-on
+        format: yaml
+    - get:
+        apiVersion: v1
+        kind: Pod
+        namespace: skyhook
+        selector: skyhook.nvidia.com/name=depends-on
+        format: yaml
   steps:
   - name: setup
     description: Reset node state, create skyhook with dependencies, and assert it completes

--- a/k8s-tests/chainsaw/skyhook/simple-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-skyhook/chainsaw-test.yaml
@@ -25,6 +25,24 @@ spec:
   timeouts:
     assert: 240s
     exec: 90s
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
+  catch: ## if errors, print the most important info
+    - get:
+        apiVersion: v1
+        kind: Node
+        selector: skyhook.nvidia.com/test-node=skyhooke2e
+        format: yaml
+    - get:
+        apiVersion: skyhook.nvidia.com/v1alpha1
+        kind: Skyhook
+        name: simple-skyhook
+        format: yaml
+    - get:
+        apiVersion: v1
+        kind: Pod
+        namespace: skyhook
+        selector: skyhook.nvidia.com/name=simple-skyhook
+        format: yaml
   steps:
   - name: deploy
     description: Reset state, apply a skyhook with three packages, and verify all complete with correct metrics

--- a/k8s-tests/chainsaw/skyhook/simple-update-skyhook/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/simple-update-skyhook/chainsaw-test.yaml
@@ -24,6 +24,7 @@ metadata:
 spec:
   timeouts:
     assert: 240s
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
   catch: ## if errors, print the most important info
   - get:
       apiVersion: v1

--- a/k8s-tests/chainsaw/skyhook/strict-order/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/strict-order/chainsaw-test.yaml
@@ -25,6 +25,7 @@ spec:
   timeouts:
     assert: 90s
     exec: 90s
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
   catch: ## if errors, print the most important info
   - get:
       apiVersion: v1

--- a/k8s-tests/chainsaw/skyhook/validate-packages/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/validate-packages/chainsaw-test.yaml
@@ -24,6 +24,7 @@ metadata:
 spec:
   timeouts:
     assert: 240s
+    cleanup: 120s ## finalizer needs time to uncordon, remove labels/annotations, and GC pods
   catch: ## if errors, print the most important info
     - get:
         apiVersion: v1

--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -560,10 +560,19 @@ func (ns *NodeState) NextStage(_package *Package, interrupt map[string][]*Interr
 		return nil
 	}
 
+	// StageInterrupt → StagePostInterrupt is unconditional even in the
+	// no-interrupt map: if a package has reached StageInterrupt at any point,
+	// the dynamic HasInterrupt(config) signal may have decayed by now
+	// (Status.ConfigUpdates can be cleared or never persist due to a 409 on the
+	// spec patch), but the package still needs to escape. The with-interrupt
+	// map deliberately omits StageUninstall → StageApply (PR #200) so that
+	// with-interrupt uninstalls route via StageUninstallInterrupt instead — do
+	// not collapse the two maps into one.
 	nextStage := map[Stage]Stage{
 		StageUninstall: StageApply,
 		StageApply:     StageConfig,
 		StageUpgrade:   StageConfig,
+		StageInterrupt: StagePostInterrupt,
 	}
 
 	if hasInterrupt := (*ns).HasInterrupt(*_package, interrupt, config); hasInterrupt {
@@ -614,11 +623,12 @@ func (ns *NodeState) GetComplete(packages Packages, interrupt map[string][]*Inte
 	for _, packageStatus := range *ns {
 		_package, found := packages[packageStatus.Name]
 		if found && _package.Version == packageStatus.Version && packageStatus.State == StateComplete {
-			hasInterrupt := (*ns).HasInterrupt(_package, interrupt, config)
-
-			if hasInterrupt && packageStatus.Stage == StagePostInterrupt {
+			// StagePostInterrupt is terminal regardless of the dynamic
+			// HasInterrupt(config) signal: getting there required the operator
+			// to once decide HasInterrupt was true, even if it's since decayed.
+			if packageStatus.Stage == StagePostInterrupt {
 				ret = append(ret, fmt.Sprintf("%s|%s", packageStatus.Name, packageStatus.Version))
-			} else if !hasInterrupt && packageStatus.Stage == StageConfig {
+			} else if packageStatus.Stage == StageConfig && !(*ns).HasInterrupt(_package, interrupt, config) {
 				ret = append(ret, fmt.Sprintf("%s|%s", packageStatus.Name, packageStatus.Version))
 			}
 		}
@@ -634,11 +644,11 @@ func (ns *NodeState) IsPackageComplete(_package Package, interrupt map[string][]
 
 	packageStatus, found := (*ns)[_package.GetUniqueName()]
 	if found && _package.Version == packageStatus.Version && packageStatus.State == StateComplete {
-		hasInterrupt := (*ns).HasInterrupt(_package, interrupt, config)
-
-		if hasInterrupt && packageStatus.Stage == StagePostInterrupt {
+		// See GetComplete: StagePostInterrupt is unconditionally terminal.
+		if packageStatus.Stage == StagePostInterrupt {
 			return true
-		} else if !hasInterrupt && packageStatus.Stage == StageConfig {
+		}
+		if packageStatus.Stage == StageConfig && !(*ns).HasInterrupt(_package, interrupt, config) {
 			return true
 		}
 	}
@@ -646,7 +656,12 @@ func (ns *NodeState) IsPackageComplete(_package Package, interrupt map[string][]
 	return false
 }
 
-// ProgressSkipped checks if a package is skipped and should be progressed to complete
+// ProgressSkipped checks if a package is skipped and should be progressed to complete.
+// Promotion is gated on Stage alone: being at StageInterrupt with StateSkipped means
+// the operator already decided this package had an interrupt to schedule (see
+// ProcessInterrupt). The dynamic HasInterrupt(config) signal can decay before this
+// runs — Status.ConfigUpdates can be cleared or never persisted due to a 409 on the
+// spec patch — so gating promotion on it can trap the package permanently.
 func (ns *NodeState) ProgressSkipped(packages Packages, interrupt map[string][]*Interrupt, config map[string][]string) bool {
 	ret := false
 	for _, s := range *ns {
@@ -655,7 +670,7 @@ func (ns *NodeState) ProgressSkipped(packages Packages, interrupt map[string][]*
 			continue
 		}
 
-		if (*ns).HasInterrupt(f, interrupt, config) && s.Stage == StageInterrupt && s.State == StateSkipped {
+		if s.Stage == StageInterrupt && s.State == StateSkipped {
 			s.State = StateComplete
 			(*ns)[f.GetUniqueName()] = s
 			ret = true

--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -620,17 +620,9 @@ func (ns *NodeState) GetComplete(packages Packages, interrupt map[string][]*Inte
 
 	ret := make([]string, 0)
 
-	for _, packageStatus := range *ns {
-		_package, found := packages[packageStatus.Name]
-		if found && _package.Version == packageStatus.Version && packageStatus.State == StateComplete {
-			// StagePostInterrupt is terminal regardless of the dynamic
-			// HasInterrupt(config) signal: getting there required the operator
-			// to once decide HasInterrupt was true, even if it's since decayed.
-			if packageStatus.Stage == StagePostInterrupt {
-				ret = append(ret, fmt.Sprintf("%s|%s", packageStatus.Name, packageStatus.Version))
-			} else if packageStatus.Stage == StageConfig && !(*ns).HasInterrupt(_package, interrupt, config) {
-				ret = append(ret, fmt.Sprintf("%s|%s", packageStatus.Name, packageStatus.Version))
-			}
+	for _, _package := range packages {
+		if ns.IsPackageComplete(_package, interrupt, config) {
+			ret = append(ret, _package.GetUniqueName())
 		}
 	}
 
@@ -639,20 +631,30 @@ func (ns *NodeState) GetComplete(packages Packages, interrupt map[string][]*Inte
 	return ret
 }
 
-// IsPackageComplete checks if a package is complete
+// IsPackageComplete reports whether a package has reached a terminal lifecycle
+// state on this node. Two terminal cases:
+//
+//   - StagePostInterrupt: unconditionally terminal. Reaching it required the
+//     operator to once decide HasInterrupt was true; gating the terminal check
+//     on the still-true-now signal is redundant and would trap packages whose
+//     Status.ConfigUpdates decayed (clearing or never persisting due to a 409
+//     on the spec patch) between entering the interrupt cycle and reaching
+//     post-interrupt.
+//   - StageConfig with no interrupt currently in scope: terminal because the
+//     package has no interrupt cycle to enter from here.
 func (ns *NodeState) IsPackageComplete(_package Package, interrupt map[string][]*Interrupt, config map[string][]string) bool {
 
 	packageStatus, found := (*ns)[_package.GetUniqueName()]
-	if found && _package.Version == packageStatus.Version && packageStatus.State == StateComplete {
-		// See GetComplete: StagePostInterrupt is unconditionally terminal.
-		if packageStatus.Stage == StagePostInterrupt {
-			return true
-		}
-		if packageStatus.Stage == StageConfig && !(*ns).HasInterrupt(_package, interrupt, config) {
-			return true
-		}
+	if !found || _package.Version != packageStatus.Version || packageStatus.State != StateComplete {
+		return false
 	}
 
+	if packageStatus.Stage == StagePostInterrupt {
+		return true
+	}
+	if packageStatus.Stage == StageConfig && !(*ns).HasInterrupt(_package, interrupt, config) {
+		return true
+	}
 	return false
 }
 

--- a/operator/api/v1alpha1/skyhook_types_test.go
+++ b/operator/api/v1alpha1/skyhook_types_test.go
@@ -1019,4 +1019,65 @@ var _ = Describe("Skyhook Types", func() {
 		}
 	})
 
+	// Regression: a package using only configInterrupts can get stuck at
+	// StageInterrupt/StateSkipped if Status.ConfigUpdates is cleared (or never
+	// persisted due to a 409 conflict on the spec patch) before ProgressSkipped
+	// promotes it. The state machine relied on the dynamic HasInterrupt(config)
+	// signal in four places — ProgressSkipped, NextStage, GetComplete,
+	// IsPackageComplete — so once the signal decayed, the package could neither
+	// be promoted out of Skipped, nor advance past StageInterrupt, nor be
+	// reported complete. Fix: once a package has reached StageInterrupt or
+	// StagePostInterrupt, progression is determined by Stage alone.
+	Context("StageInterrupt trap when configUpdates signal decays", func() {
+		// baxter has no top-level interrupt — only a configInterrupt that
+		// matched a now-cleared configUpdates entry. HasInterrupt() returns
+		// false in this state.
+		pkg := &Package{
+			PackageRef: PackageRef{Name: "baxter", Version: "3.2.1"},
+			Image:      "ghcr.io/nvidia/skyhook/agentless",
+			ConfigInterrupts: map[string]Interrupt{
+				"game.properties": {Type: SERVICE, Services: []string{"rsyslog"}},
+			},
+		}
+		emptyInterrupt := map[string][]*Interrupt{}
+		emptyConfig := map[string][]string{}
+
+		It("ProgressSkipped promotes Skipped at StageInterrupt regardless of HasInterrupt", func() {
+			ns := NodeState{
+				"baxter|3.2.1": PackageStatus{
+					Name: "baxter", Version: "3.2.1", Image: pkg.Image,
+					Stage: StageInterrupt, State: StateSkipped,
+				},
+			}
+			packages := Packages{"baxter": *pkg}
+			changed := ns.ProgressSkipped(packages, emptyInterrupt, emptyConfig)
+			Expect(changed).To(BeTrue())
+			Expect(ns["baxter|3.2.1"].State).To(Equal(StateComplete))
+		})
+
+		It("NextStage advances from StageInterrupt to StagePostInterrupt regardless of HasInterrupt", func() {
+			ns := NodeState{
+				"baxter|3.2.1": PackageStatus{
+					Name: "baxter", Version: "3.2.1", Image: pkg.Image,
+					Stage: StageInterrupt, State: StateComplete,
+				},
+			}
+			next := ns.NextStage(pkg, emptyInterrupt, emptyConfig)
+			Expect(next).ToNot(BeNil())
+			Expect(*next).To(Equal(StagePostInterrupt))
+		})
+
+		It("IsPackageComplete and GetComplete treat StagePostInterrupt as terminal regardless of HasInterrupt", func() {
+			ns := NodeState{
+				"baxter|3.2.1": PackageStatus{
+					Name: "baxter", Version: "3.2.1", Image: pkg.Image,
+					Stage: StagePostInterrupt, State: StateComplete,
+				},
+			}
+			packages := Packages{"baxter": *pkg}
+			Expect(ns.IsPackageComplete(*pkg, emptyInterrupt, emptyConfig)).To(BeTrue())
+			Expect(ns.GetComplete(packages, emptyInterrupt, emptyConfig)).To(ContainElement("baxter|3.2.1"))
+		})
+	})
+
 })


### PR DESCRIPTION
## Summary

Two changes — one operator fix, one test-infra hardening — that together address the failure mode that hit `chainsaw/config-skyhook` on the prior CI run.

### Operator: close the `StageInterrupt` trap when `ConfigUpdates` decays

A package whose only interrupt is a `configInterrupts` entry (no top-level `interrupt` block) could get permanently stuck at `StageInterrupt/StateSkipped` when `Status.ConfigUpdates` cleared or was never persisted (e.g. due to a 409 on the spec patch — the `HandleMigrations` stale-snapshot bug + the `processSkyhooksPerNode` node-status conflict, both visible in the failing run's logs).

Root cause: the state machine queried the dynamic `HasInterrupt(config)` signal at four sites — `ProgressSkipped`, `NextStage`, `GetComplete`, `IsPackageComplete`. Once the signal decayed to false mid-lifecycle, the package was untouchable from every angle: not promoted out of Skipped, not advanced past Interrupt, not counted as complete.

Fix decouples progression-past-Interrupt from the dynamic signal at all three "no documented intent" sites (`git log -L` shows the gates have been there since the initial reorg in 2025-01-23 with no commit motivating them). The fourth site — `NextStage`'s `StageUninstall → StageApply` gate — is preserved as-is, because PR #200 deliberately removed that transition from the with-interrupt map so with-interrupt uninstalls route via `StageUninstallInterrupt` instead. Collapsing the maps would silently undo that.

Reproducer in `skyhook_types_test.go` exercises all three failure modes; full `make unit-tests` passes (10 suites, all green).

### Tests: harden the `core` chainsaw pool

- `timeouts.cleanup: 120s` on all 6 core-pool tests. Chainsaw's default cleanup window (~30s) is too tight for the project's finalizer, which must uncordon nodes, remove labels/annotations, and GC package pods before releasing. Same class of failure that hit `downgrade-after-uninstall` (#241).
- `catch:` blocks on `depends-on` and `simple-skyhook` (the only two core tests missing them). When flakes recur, CI now captures Node, Skyhook CR, and package Pod state for diagnosis.

## Test plan

- [x] `make unit-tests` passes locally (10 suites)
- [x] New v1alpha1 regression test (`StageInterrupt trap when configUpdates signal decays`) fails before the fix, passes after
- [ ] All 6 runnable core chainsaw tests pass in CI (the `core` pool job)
- [ ] `chainsaw/config-skyhook` "update while running" specifically reaches a clean assert (no longer hits the trap)
- [ ] No regression in adjacent pools (uninstall, interrupt, lifecycle)