### PR TITLE
fix(ci): capture stderr when parsing helm push output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,9 @@ jobs:
 
           chart_repo="ghcr.io/nvidia/nodewright/charts"
           chart_subject="${chart_repo}/${CHART_NAME}"
-          push_output="$(helm push "dist/${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${chart_repo}")"
+          # `helm push` writes "Pushed:" and "Digest:" to stderr (helm 3.16+),
+          # so capture both streams or awk sees an empty string.
+          push_output="$(helm push "dist/${CHART_NAME}-${CHART_VERSION}.tgz" "oci://${chart_repo}" 2>&1)"
           printf '%s\n' "${push_output}"
           chart_digest="$(awk '/^Digest:/ {print $2}' <<< "${push_output}")"
           if ! [[ "${chart_digest}" =~ ^sha256:[a-f0-9]{64}$ ]]; then


### PR DESCRIPTION
## Summary

The chart-publish step in \`release.yml\` failed for \`chart/v0.16.0\` with:

\`\`\`
Pushed: ghcr.io/nvidia/nodewright/charts/nodewright:v0.16.0
Digest: sha256:e487043f621145fe7dc6b21eb48cf560d2357beb6ff459d88bfb448657096b12

Error: failed to parse Helm chart digest from helm push output
\`\`\`

The push itself succeeded — the parser bailed. Root cause: \`helm push\` (3.16+) writes the \`Pushed:\` and \`Digest:\` lines to **stderr**, while the workflow only captured stdout via \`\$(helm push ...)\`. The GHA runner displays both streams in the job log, which is why the lines were visible above the error.

Fix: redirect stderr into stdout for the command substitution. The subsequent \`sha256:[a-f0-9]{64}\` regex check is unchanged, so malformed input still fails fast.

## Test plan

- [ ] Re-run the failed chart release workflow with this fix applied — \`Push chart to ghcr.io\` step now produces a parsed digest, downstream cosign sign + provenance attestation steps proceed.