### PR TITLE
fix(ci): authenticate docker so cosign can sign the published chart

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,6 +172,16 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" \
             | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
 
+      # cosign reads ~/.docker/config.json; helm registry login writes its own
+      # config so cosign can't see those creds. Authenticate docker too so the
+      # downstream sign/attest steps can upload the .sig and SBOM layers.
+      - name: Log in to ghcr.io (docker, for cosign)
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Push chart to ghcr.io
         id: push-chart
         env:


### PR DESCRIPTION
## Summary

Re-running the chart-release workflow for \`chart/v0.16.0\` (with PR #249 applied) got past the helm push, then failed at \`cosign sign\` with:

\`\`\`
Error: signing [ghcr.io/nvidia/nodewright/charts/nodewright@sha256:96bf4ed…]:
  signing digest: failed to upload layer: POST
  https://ghcr.io/v2/nvidia/nodewright/charts/nodewright/blobs/uploads/:
  UNAUTHORIZED: unauthenticated: User cannot be authenticated with the token provided.
\`\`\`

Root cause: \`helm registry login\` writes credentials to helm's own config (\`~/.config/helm/registry/config.json\`), which cosign doesn't consult. Cosign reads \`~/.docker/config.json\`, so it sees no creds for ghcr.io and can't push the \`.sig\` / SBOM attestation layers.

Fix: add a \`docker/login-action@v4\` step alongside the existing helm registry login (same pattern \`operator-ci.yaml\` uses for signing the operator image). The \`packages: write\` permission on the job is already in place.

## Test plan

- [ ] Re-run the failed chart release workflow with this fix applied — \`cosign sign\` and the CycloneDX SBOM attestation upload to \`ghcr.io/nvidia/nodewright/charts/nodewright\`.
- [ ] \`actions/attest-build-provenance\` push-to-registry step succeeds.
- [ ] Verify step (\`cosign verify --certificate-identity-regexp …refs/tags/chart/.*\`) passes against the freshly signed digest.