### PR TITLE
chore(chart): bump to v0.16.1 with operator webhook cert deadlock fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Install NodeWright quickly using Helm without downloading the repository:
 # The chart is distributed as an OCI artifact on GitHub Container Registry.
 # Helm 3.8+ supports OCI natively — no `helm repo add` needed.
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.16.0-rc1 \
+  --version v0.16.1 \
   --namespace skyhook \
   --create-namespace
 ```

--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [chart/v0.16.1] - 2026-05-22
+
+### Component Versions
+
+- Operator: [`v0.16.1`](https://github.com/NVIDIA/nodewright/releases/tag/operator%2Fv0.16.1) (`ghcr.io/nvidia/nodewright/operator@sha256:e406cf0f51766c873ef6e2c103e0dedd43680ef57d608104edfc6aa378698b3c`)
+- Agent: [`v6.4.2`](https://github.com/NVIDIA/nodewright/releases/tag/agent%2Fv6.4.2) (`ghcr.io/nvidia/nodewright/agent@sha256:7cd80f5ef351266dc08c3979e802f9dc936a1ed9fd02e199233e7968a3a0de3e`)
+
+### Bug Fixes
+
+- Pull in operator v0.16.1, which fixes a webhook serving-cert bootstrap deadlock when upgrading from older operator versions.
+
 ## [chart/v0.16.0] - 2026-05-22
 
 ### Component Versions

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 # This is the chart version. This version number must be incremented each time you make changes to the helm chart. OR
 # it the agent version is updated, or operator version is updated.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.16.0
+version: v0.16.1
 # This is the version number operator container being deployed.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-appVersion: v0.16.0
+appVersion: v0.16.1
 # this is the minimum version of kubernetes that the operator supports/tested against.
 kubeVersion: ">=1.27.0-0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,8 +84,8 @@ controllerManager:
       pauseImage: registry.k8s.io/pause:3.10
     image:
       repository: ghcr.io/nvidia/nodewright/operator
-      tag: "v0.16.0" ## if both tag and digest are omitted, defaults to the chart appVersion
-      digest: "sha256:3dfeda5d8fbfe7b6778bb92ad4437caa2e73c1670d54ae29e55ca7d0d5ef5408" # manifest list digest (multi-arch) on ghcr.io/nvidia/nodewright/operator:v0.16.0
+      tag: "v0.16.1" ## if both tag and digest are omitted, defaults to the chart appVersion
+      digest: "sha256:e406cf0f51766c873ef6e2c103e0dedd43680ef57d608104edfc6aa378698b3c" # manifest list digest (multi-arch) on ghcr.io/nvidia/nodewright/operator:v0.16.1
     ## agentImage: is the image used for the agent container. This image is the default for this install, but can be overridden in the CR at package level.
     agent:
       repository: ghcr.io/nvidia/nodewright/agent

--- a/operator/CHANGELOG.md
+++ b/operator/CHANGELOG.md
@@ -2,7 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased — Explicit Uninstall
+## [operator/v0.16.1] - 2026-05-22
+
+### Bug Fixes
+
+- **Webhook serving-cert bootstrap deadlock on major upgrade.** During an
+  upgrade from older versions, an old-version leader holding the main
+  reconcile lease could deadlock the new webhook's serving-cert bootstrap
+  and prevent the new controller from coming up. The bootstrap now runs
+  under its own dedicated `ctrl.Manager` with a separate leader-election
+  lease (`nodewright-webhook-bootstrap.nvidia.com`), so it no longer
+  contends with the main reconcile lease and the upgrade proceeds even
+  while the old leader still holds the primary lease (#243).
+
+## [operator/v0.16.0] - 2026-05-19 — Explicit Uninstall
 
 Introduces an opt-in declarative uninstall workflow and reworks how downgrades
 and CR deletion behave. Affects the Operator, Webhook, and CRD.


### PR DESCRIPTION
## Summary

Pulls in operator v0.16.1, which fixes a webhook serving-cert bootstrap deadlock when an old-version reconcile leader is still holding the main lease during a major upgrade (#243).

- \`chart/values.yaml\` — pin operator v0.16.1 @ \`sha256:e406cf0f51766c873ef6e2c103e0dedd43680ef57d608104edfc6aa378698b3c\`. Agent is unchanged at v6.4.2.
- \`chart/Chart.yaml\` — \`version\` + \`appVersion\` → v0.16.1.
- \`operator/CHANGELOG.md\`:
  - Convert the hand-written "Unreleased — Explicit Uninstall" block into the dated \`operator/v0.16.0\` entry.
  - Add a new \`operator/v0.16.1\` entry capturing the webhook bootstrap fix.
- \`chart/CHANGELOG.md\` — add \`chart/v0.16.1\` section linking the bundled operator and agent releases and digests.
- \`README.md\` — bump the OCI install example to \`--version v0.16.1\`.

## Test plan

- [ ] CI passes (lint, helm tests)
- [ ] After merging and tagging \`chart/v0.16.1\`, \`helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright --version v0.16.1\` resolves the pinned operator digest.
- [ ] Verify the bundled chart pulls operator v0.16.1 and agent v6.4.2.