### PR TITLE
feat(ci): add issue and PR management automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -17,7 +17,8 @@
 name: Bug Report
 description: File a bug report for Skyhook
 title: "[BUG]: "
-labels: ["bug"]
+type: Bug
+labels: ["needs-triage"]
 
 body:
   - type: markdown
@@ -52,6 +53,24 @@ body:
       label: Kubernetes Version
       description: Output of `kubectl version --short` or your cluster version.
       placeholder: "example: v1.30.2"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part(s) of the project are affected? Select all that apply; this helps us route the issue.
+      multiple: true
+      options:
+        - Operator (controller-manager)
+        - Agent (package executor)
+        - Helm chart
+        - CLI (kubectl-skyhook)
+        - CI / tooling
+        - Tests (e2e / chainsaw)
+        - Docs / examples
+        - Other / Unknown
     validations:
       required: true
 
@@ -94,9 +113,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/skyhook/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/nodewright/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow Skyhook's Code of Conduct
           required: true
-        - label: I have searched the [open bugs](https://github.com/NVIDIA/skyhook/issues?q=is%3Aopen+is%3Aissue+label%3Abug) and have found no duplicates for this bug report
+        - label: I have searched the [open bugs](https://github.com/NVIDIA/nodewright/issues?q=is%3Aopen+is%3Aissue+type%3ABug) and have found no duplicates for this bug report
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -18,7 +18,8 @@
 name: Feature Request
 description: Request new or improved functionality
 title: "[FEA]: "
-labels: ["feature"]
+type: Enhancement
+labels: ["needs-triage"]
 
 body:
   - type: markdown
@@ -46,6 +47,24 @@ body:
         - High
         - Medium
         - Low (would be nice)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part(s) of the project would this affect? Select all that apply; this helps us route the request.
+      multiple: true
+      options:
+        - Operator (controller-manager)
+        - Agent (package executor)
+        - Helm chart
+        - CLI (kubectl-skyhook)
+        - CI / tooling
+        - Tests (e2e / chainsaw)
+        - Docs / examples
+        - Other / Unknown
     validations:
       required: true
 
@@ -91,9 +110,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/skyhook/blob/main/CODE_OF_CONDUCT.md).
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/nodewright/blob/main/CODE_OF_CONDUCT.md).
       options:
         - label: I agree to follow Skyhook's Code of Conduct
           required: true
-        - label: I have searched the [open feature requests](https://github.com/NVIDIA/skyhook/issues?q=is%3Aopen+is%3Aissue+label%3A%22feature+request%22) and have found no duplicates for this feature request
+        - label: I have searched the [open feature requests](https://github.com/NVIDIA/nodewright/issues?q=is%3Aopen+is%3Aissue+type%3AEnhancement) and have found no duplicates for this feature request
           required: true

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Path-based PR labels for actions/labeler. Kept in sync with the component/*
+# label family in .github/labels.yml and the triage keyword maps in
+# .github/workflows/triage.yaml.
+
+# Operator (controller-manager), excluding the CLI which lives under it.
+# The '!' exclude lives in any-glob-to-any-file (not all-globs-to-all-files) so a
+# PR touching both operator core and CLI still gets this label; an all-globs
+# negation would drop it whenever any CLI file is present.
+component/operator:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'operator/**'
+          - '!operator/cmd/cli/**'
+
+component/cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'operator/cmd/cli/**'
+
+component/agent:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'agent/**'
+
+component/chart:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'chart/**'
+
+component/ci:
+  - changed-files:
+      # The '!' vendor exclude stays in any-glob-to-any-file so a PR mixing a
+      # vendored Makefile with real CI changes still gets the label.
+      - any-glob-to-any-file:
+          - '.github/**'
+          - 'scripts/**'
+          - '.gitlab-ci.yml'
+          - '**/Makefile'
+          - '**/*.mk'
+          - '!**/vendor/**'
+
+component/tests:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'k8s-tests/**'
+
+doc:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'docs/**'
+          - '**/*.md'

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -19,83 +19,58 @@
 # Sync to GitHub with: make labels
 #
 # Label categories:
-#   Issue types  — applied automatically by issue templates
-#   Component    — which part of the project is affected
-#   Planning     — applied by engineering/product during triage (per DGXC OSS Policy)
-#   Priority     — P0/P1/P2 per DGXC OSS Policy, applied by engineering
-#   Lifecycle    — stale automation and freeze exemptions
-#   Standard     — common GitHub labels
+#   Type:      issue Type (Bug/Enhancement/Documentation/Task/Epic/Initiative) is
+#              a native GitHub Issue Type set by the org, not a label
+#   Triage:    needs-triage, cleared once a maintainer triages
+#   Component: which part of the project is affected
+#   Lifecycle: stale automation and freeze exemptions
+#   Standard:  common GitHub labels
 
-# ── Issue Types ───────────────────────────────────────────────────────────────
-# Applied automatically by issue templates
-
-- name: "bug"
-  color: "d73a4a"
-  description: "Something isn't working"
-
-- name: "feature request"
-  color: "a2eeef"
-  description: "New feature or improvement to existing functionality"
+# ── Type ──────────────────────────────────────────────────────────────────────
+# Bug / Enhancement / Documentation / Task / Epic / Initiative are native GitHub
+# Issue Types (org-level), assigned by the issue forms via their `type:` key, not
+# labels. `doc` stays as a label because the PR path labeler applies it to
+# docs-only PRs (issues use the Documentation type instead).
 
 - name: "doc"
   color: "0075ca"
-  description: "Documentation addition, correction, or improvement"
+  description: "Documentation change (PR path label; doc issues use the Documentation type)"
+
+# ── Triage ───────────────────────────────────────────────────────────────────
+# Applied automatically to new issues; removed once a maintainer triages.
+
+- name: "needs-triage"
+  color: "fbca04"
+  description: "Awaiting initial triage by a maintainer"
 
 # ── Component ────────────────────────────────────────────────────────────────
-# Which part of the project is affected
+# Which part of the project is affected. Applied automatically by issue triage
+# and PR path labeling. Each component gets a distinct hue so they pop apart at
+# a glance; the "component/" prefix keeps them grouped in label lists.
 
 - name: "component/operator"
-  color: "1d76db"
+  color: "0969da"
   description: "Skyhook operator (controller-manager)"
 
 - name: "component/agent"
-  color: "1d76db"
+  color: "1a7f37"
   description: "Skyhook agent (package executor)"
 
 - name: "component/chart"
-  color: "1d76db"
+  color: "8250df"
   description: "Helm chart"
 
 - name: "component/cli"
-  color: "1d76db"
+  color: "bc4c00"
   description: "kubectl-skyhook CLI plugin"
 
-# ── Planning Types ────────────────────────────────────────────────────────────
-# Applied by engineering/product during triage (DGXC OSS Policy issue types)
+- name: "component/ci"
+  color: "bf3989"
+  description: "CI workflows, GitHub Actions, and repo tooling"
 
-- name: "epic"
-  color: "7057ff"
-  description: "Roadmap feature — large body of work spanning multiple issues"
-
-- name: "feature"
-  color: "a2eeef"
-  description: "Goal of a feature request or enhancement (planning label)"
-
-- name: "task"
-  color: "e4e669"
-  description: "Sub-task of a feature or epic"
-
-- name: "initiative"
-  color: "f9d0c4"
-  description: "Container for a group of related features (optional)"
-
-# ── Priority ─────────────────────────────────────────────────────────────────
-# Set by engineering only. SLAs per DGXC OSS Policy:
-#   P0: major functionality broken, no workaround — 30 day fix SLA
-#   P1: product works but not as expected, workaround exists — 6 month SLA
-#   P2: minor defect, minor impact — no fix commitment
-
-- name: "P0"
-  color: "b60205"
-  description: "Critical: major functionality broken, no workaround. 30-day SLA."
-
-- name: "P1"
-  color: "e11d48"
-  description: "High: product works but not as expected. Workaround exists. 6-month SLA."
-
-- name: "P2"
-  color: "f97316"
-  description: "Medium: minor defect or minor impact. No fix commitment."
+- name: "component/tests"
+  color: "9a6700"
+  description: "End-to-end / chainsaw test suites (k8s-tests)"
 
 # ── Lifecycle ─────────────────────────────────────────────────────────────────
 # Used by stale automation

--- a/.github/workflows/inactive-pr-reminder.yaml
+++ b/.github/workflows/inactive-pr-reminder.yaml
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Inactive PR Reminder
+
+on:
+  schedule:
+    - cron: '0 7 * * *'  # daily at 07:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+
+  remind:
+    name: Nudge Inactive PRs
+    if: github.repository == 'NVIDIA/nodewright'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Check for inactive PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const now = new Date();
+            const msPerDay = 86400000;
+            const skipLabels = ['lifecycle/frozen', 'do-not-merge'];
+
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              // Skip PRs explicitly held open or parked.
+              if (pr.labels.some(l => skipLabels.includes(l.name))) continue;
+
+              const updated = new Date(pr.updated_at);
+              const daysInactive = Math.floor((now - updated) / msPerDay);
+
+              // Target the 14–29 day window, before the stale bot fires at 30.
+              if (daysInactive < 14 || daysInactive >= 30) continue;
+
+              // Don't double-remind: skip if a bot already left a reminder.
+              // Paginate so an earlier reminder past page 1 still counts.
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                per_page: 100,
+              });
+              const alreadyReminded = comments.some(c =>
+                c.user.type === 'Bot' && c.body.includes('inactive for')
+              );
+              if (alreadyReminded) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: `@${pr.user.login} this PR has been inactive for ${daysInactive} days. Do you need help finishing it, or should we close it for now? Feel free to reopen anytime.`,
+              });
+            }

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -14,12 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-blank_issues_enabled: true
+name: Auto-Label PRs
 
-contact_links:
-  - name: Ask a Question
-    url: https://github.com/NVIDIA/nodewright/discussions
-    about: Please ask any questions here.
-  - name: Report a Security Vulnerability
-    url: https://www.nvidia.com/object/submit-security-vulnerability.html
-    about: Please report security vulnerabilities through NVIDIA's web form, not GitHub issues.
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  label:
+    name: Label PRs by path
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Label by path
+        uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213  # v6.1.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          sync-labels: true

--- a/.github/workflows/lock-threads.yaml
+++ b/.github/workflows/lock-threads.yaml
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Lock Stale Threads
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # daily at 06:00 UTC
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+
+  lock:
+    name: Lock Closed Threads
+    if: github.repository == 'NVIDIA/nodewright'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 10
+    steps:
+      - name: Lock stale closed issues and PRs
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const now = new Date();
+            const msPerDay = 86400000;
+            const inactiveDays = 90;
+
+            // Lock stale closed issues.
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const issue of issues) {
+              if (issue.locked || issue.pull_request) continue;
+              const updated = new Date(issue.updated_at);
+              if ((now - updated) / msPerDay < inactiveDays) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: 'This issue has been automatically locked since it has been closed for 90 days with no further activity. Please open a new issue for related concerns.',
+              });
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                lock_reason: 'resolved',
+              });
+            }
+
+            // Lock stale closed PRs.
+            const prs = await github.paginate(github.rest.pulls.list, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'closed',
+              sort: 'updated',
+              direction: 'asc',
+              per_page: 100,
+            });
+
+            for (const pr of prs) {
+              if (pr.locked) continue;
+              const updated = new Date(pr.updated_at);
+              if ((now - updated) / msPerDay < inactiveDays) continue;
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                body: 'This pull request has been automatically locked since it has been closed for 90 days with no further activity. Please open a new pull request for related changes.',
+              });
+              await github.rest.issues.lock({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                lock_reason: 'resolved',
+              });
+            }

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -25,7 +25,7 @@
 #
 # Exemptions:
 #   - lifecycle/frozen: Never goes stale (use for long-running or intentionally open issues)
-#   - P0: Critical issues never go stale
+#   - good first issue: Kept open to stay available for newcomers
 #   - do-not-merge: PRs won't be closed
 
 name: Stale Issues and PRs
@@ -61,7 +61,7 @@ jobs:
             If this issue is no longer relevant, it's okay to let it close.
           days-before-stale: 90
           stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/frozen,P0,good first issue'
+          exempt-issue-labels: 'lifecycle/frozen,good first issue'
 
           stale-pr-message: |
             This PR has been marked as stale due to 30 days of inactivity.

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,0 +1,242 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Issue Triage
+
+on:
+  issues:
+    types: [opened, labeled]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+# Serialize per issue so a rapid open->label sequence doesn't race on the
+# needs-triage label. Don't cancel: every event must finish its labeling.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  triage:
+    name: Auto-Triage Issues
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    timeout-minutes: 5
+    steps:
+      - name: Add needs-triage on new issue
+        if: github.event.action == 'opened'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['needs-triage'],
+            });
+
+      - name: Infer component label on new issue
+        if: github.event.action == 'opened'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const title = context.payload.issue.title || '';
+            const body = context.payload.issue.body || '';
+            const existingLabels = new Set((context.payload.issue.labels || []).map(label => label.name));
+
+            // Match against the normalized value chosen in the issue-template
+            // Component dropdown (see .github/ISSUE_TEMPLATE/*).
+            const componentPatterns = [
+              { pattern: /\boperator\b|controller-manager/, label: 'component/operator' },
+              { pattern: /\bagent\b/, label: 'component/agent' },
+              { pattern: /\bhelm\b|\bchart\b/, label: 'component/chart' },
+              { pattern: /\bcli\b|kubectl/, label: 'component/cli' },
+              { pattern: /\bci\b|tooling/, label: 'component/ci' },
+              { pattern: /\btests?\b|chainsaw|e2e/, label: 'component/tests' },
+              { pattern: /\bdocs?\b|examples/, label: 'doc' },
+            ];
+
+            // Conventional-commit scope tokens, e.g. "fix(chart): ...".
+            const tokenMap = new Map([
+              ['operator', 'component/operator'],
+              ['controller', 'component/operator'],
+              ['reconcile', 'component/operator'],
+              ['agent', 'component/agent'],
+              ['chart', 'component/chart'],
+              ['helm', 'component/chart'],
+              ['cli', 'component/cli'],
+              ['kubectl', 'component/cli'],
+              ['ci', 'component/ci'],
+              ['actions', 'component/ci'],
+              ['workflow', 'component/ci'],
+              ['workflows', 'component/ci'],
+              ['test', 'component/tests'],
+              ['tests', 'component/tests'],
+              ['e2e', 'component/tests'],
+              ['chainsaw', 'component/tests'],
+              ['doc', 'doc'],
+              ['docs', 'doc'],
+              ['readme', 'doc'],
+            ]);
+
+            function normalize(value) {
+              return value.trim().toLowerCase();
+            }
+
+            // Sentinel values from the Component dropdown that don't map to a
+            // single component. When chosen, ignore the field and fall back to
+            // title/body inference.
+            const AMBIGUOUS_COMPONENTS = [
+              'multiple components',
+              'other / unknown',
+              'other',
+              'unknown',
+            ];
+
+            // The Component dropdown is multi-select, so its rendered value is a
+            // comma-separated list. Return every matching label, not just the first.
+            function inferFromComponent() {
+              const match = body.match(/^#{2,3}\s+Component\s*$[\r\n]+(?:[\r\n]*)([^\r\n]+)/im);
+              if (!match) {
+                return [];
+              }
+              const labels = [];
+              for (const raw of match[1].split(',')) {
+                const component = normalize(raw);
+                if (!component || AMBIGUOUS_COMPONENTS.includes(component)) {
+                  continue;
+                }
+                for (const { pattern, label } of componentPatterns) {
+                  if (pattern.test(component)) {
+                    labels.push(label);
+                    break;
+                  }
+                }
+              }
+              return labels;
+            }
+
+            function inferFromScope() {
+              const scopeMatch = title.toLowerCase().match(/^[a-z]+\(([^)]+)\):/);
+              if (!scopeMatch) {
+                return null;
+              }
+              for (const token of scopeMatch[1].split(/[^a-z0-9]+/)) {
+                const label = tokenMap.get(token);
+                if (label) {
+                  return label;
+                }
+              }
+              return null;
+            }
+
+            function inferFromText(text) {
+              const normalized = text.toLowerCase();
+              const orderedPatterns = [
+                { pattern: /\b(controller-manager|reconcile|the operator)\b/, label: 'component/operator' },
+                { pattern: /\b(skyhook-agent|package executor|agent)\b/, label: 'component/agent' },
+                { pattern: /\b(helm chart|helm|chart)\b/, label: 'component/chart' },
+                { pattern: /\b(kubectl[- ]skyhook|kubectl skyhook|cli plugin|cli)\b/, label: 'component/cli' },
+                { pattern: /\b(docs?|documentation|readme|examples)\b/, label: 'doc' },
+                { pattern: /\b(chainsaw|e2e|k8s-tests|tests?)\b/, label: 'component/tests' },
+                { pattern: /(?:\.github\/|github actions|\bworkflows?\b|\bci\b|tooling)/, label: 'component/ci' },
+              ];
+
+              for (const { pattern, label } of orderedPatterns) {
+                if (pattern.test(normalized)) {
+                  return label;
+                }
+              }
+              return null;
+            }
+
+            const componentLabels = new Set(
+              [...existingLabels].filter(label => label.startsWith('component/') || label === 'doc'),
+            );
+
+            // An explicit Component selection wins; only fall back to scope/text
+            // inference when the reporter gave us nothing to go on.
+            for (const label of inferFromComponent()) {
+              componentLabels.add(label);
+            }
+            if (componentLabels.size === 0) {
+              const inferred = inferFromScope() || inferFromText(title) || inferFromText(body);
+              if (inferred) {
+                componentLabels.add(inferred);
+              }
+            }
+
+            if (componentLabels.size === 0) {
+              core.info('No component label inferred for this issue');
+              return;
+            }
+
+            const toAdd = [...componentLabels].filter(label => !existingLabels.has(label));
+            if (toAdd.length > 0) {
+              core.info(`Adding component labels: ${toAdd.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                labels: toAdd,
+              });
+            } else {
+              core.info(`Issue already has all inferred component labels`);
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'needs-triage',
+              });
+              core.info('Removed needs-triage after component assignment');
+            } catch (error) {
+              if (error.status === 404) {
+                core.info('needs-triage label not present');
+                return;
+              }
+              throw error;
+            }
+
+      # Only a routing decision (a component/* or doc label) counts as triaged.
+      # Automated labels like lifecycle/stale must NOT clear needs-triage.
+      - name: Remove needs-triage when triaged
+        if: >-
+          github.event.action == 'labeled' &&
+          (startsWith(github.event.label.name, 'component/') ||
+           github.event.label.name == 'doc')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            if (labels.some(l => l.name === 'needs-triage')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'needs-triage',
+              });
+            }

--- a/.github/workflows/welcome.yaml
+++ b/.github/workflows/welcome.yaml
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Welcome First-Time Contributors
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+
+  welcome:
+    name: Welcome New Contributor
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    timeout-minutes: 5
+    steps:
+      - name: Welcome First-Time Issue Author
+        if: github.event_name == 'issues'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const creator = context.payload.issue.user.login;
+            const { data: { total_count } } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:issue author:${creator}`,
+            });
+
+            // Only greet on the very first issue this author has opened here.
+            if (total_count === 1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: [
+                  `Welcome to NodeWright, @${creator}! Thanks for opening your first issue.`,
+                  '',
+                  'A maintainer will triage this shortly. In the meantime:',
+                  `- Check the [Contributing Guide](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) for project conventions`,
+                  `- Browse existing [labels](https://github.com/${context.repo.owner}/${context.repo.repo}/labels) for related topics`,
+                  `- Ask questions in [Discussions](https://github.com/${context.repo.owner}/${context.repo.repo}/discussions)`,
+                ].join('\n'),
+              });
+            }
+
+      - name: Welcome First-Time PR Author
+        if: github.event_name == 'pull_request_target'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const creator = context.payload.pull_request.user.login;
+            const { data: { total_count } } = await github.rest.search.issuesAndPullRequests({
+              q: `repo:${context.repo.owner}/${context.repo.repo} type:pr author:${creator}`,
+            });
+
+            // Only greet on the very first PR this author has opened here.
+            if (total_count === 1) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: [
+                  `Welcome to NodeWright, @${creator}! Thanks for your first pull request.`,
+                  '',
+                  'Before review, please ensure:',
+                  `- All commits are signed off per the [DCO](https://github.com/${context.repo.owner}/${context.repo.repo}/blob/main/CONTRIBUTING.md) (\`git commit -s\`)`,
+                  '- Commits follow [Conventional Commits](https://www.conventionalcommits.org/)',
+                  '- CI checks pass (tests, lint, security scan)',
+                  '- The PR description explains the *why* behind your changes',
+                  '',
+                  'A maintainer will review this soon.',
+                ].join('\n'),
+              });
+            }


### PR DESCRIPTION
## What

Imports the issue/PR housekeeping automation adapted from [`NVIDIA/aicr`](https://github.com/NVIDIA/aicr), and migrates the issue taxonomy onto native GitHub Issue Types. Closes #260.

### New workflows (`.github/workflows/`)
- **triage** — labels new issues `needs-triage`, infers `component/*` labels from the Component dropdown → conventional-commit scope → title/body keywords (applies all selected components), and clears `needs-triage` once triaged.
- **labeler** — path-based `component/*` / `doc` labels on PRs (`actions/labeler`).
- **welcome** — greets first-time issue and PR authors.
- **lock-threads** — locks issues/PRs closed for 90+ days.
- **inactive-pr-reminder** — nudges PRs idle 14–29 days, before the stale bot fires at 30.

### Config / labels
- New `.github/labeler.yml` path→label map. `component/ci` covers `.github/`, `scripts/`, `.gitlab-ci.yml`, and Makefiles (vendored Makefiles excluded).
- `.github/labels.yml`: added `needs-triage`, `component/ci`, `component/tests`; gave the `component/*` family distinct hues; retired `bug`/`feature`/`epic`/`task`/`initiative` (now native Issue Types); kept `doc` as a PR path label.

### Issue templates
- Bug / Feature forms now set the **Bug** / **Enhancement** Issue Type instead of a label, and gain a multi-select **Component** dropdown.
- Repo links updated `NVIDIA/skyhook` → `NVIDIA/nodewright`.

### Other
- Dropped the dead `P0` exemption from `stale.yaml` (priority labels are gone).

## Already applied to the live repo
- Retyped the few issues carrying the old `bug`/`feature` labels and deleted `bug`/`feature`/`epic`/`task`/`initiative` (covered by org Issue Types).
- Ran `make labels` to sync the new label set/colors.

## Notes
- Only external actions are `actions/github-script` and `actions/labeler`, pinned to the same SHAs as aicr and explicitly on the org allowlist (`github_owned_allowed` + explicit patterns).
- Validated with `actionlint` (clean) and YAML parse on all touched files.
- No `docs/` page covers the label taxonomy / triage flow, so nothing there was stale to update.