### PR TITLE
refactor(controller): collapse Skyhook and Node reconciles onto a glo…

### DIFF
--- a/operator/internal/controller/event_handler.go
+++ b/operator/internal/controller/event_handler.go
@@ -20,6 +20,7 @@ package controller
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/NVIDIA/nodewright/operator/api/v1alpha1"
@@ -111,7 +112,7 @@ func (h *globalDelayHandler) relevant(ctx context.Context, object client.Object)
 	case *corev1.Node:
 		list, err := h.dal.GetSkyhooks(ctx)
 		if err != nil {
-			return false, err
+			return false, fmt.Errorf("listing skyhooks for node relevance check: %w", err)
 		}
 		if list == nil {
 			return false, nil

--- a/operator/internal/controller/event_handler.go
+++ b/operator/internal/controller/event_handler.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -20,135 +20,110 @@ package controller
 
 import (
 	"context"
+	"time"
 
 	"github.com/NVIDIA/nodewright/operator/api/v1alpha1"
 	"github.com/NVIDIA/nodewright/operator/internal/dal"
 	"github.com/go-logr/logr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-type eventHandler struct {
+// globalReconcileKey is the single sentinel request that every relevant Skyhook
+// and Node event collapses onto. The heavy reconcile path ignores req identity
+// (it grabs the whole world), so routing all such events to one key lets the
+// workqueue dedup a burst into one pass; paired with MaxConcurrentReconciles: 1
+// it also guarantees only one heavy reconcile runs at a time. The Name is an
+// arbitrary sentinel (see globalReconcileName) — not a namespace or object
+// reference.
+var globalReconcileKey = reconcile.Request{
+	NamespacedName: types.NamespacedName{Name: globalReconcileName},
+}
+
+// globalDelayHandler enqueues globalReconcileKey after a fixed delay on any
+// watched event that is relevant to at least one Skyhook. A Skyhook event is
+// always relevant; a Node event is relevant only if some Skyhook's node
+// selector matches it — without that filter every kubelet heartbeat across the
+// cluster would wake the heavy reconcile.
+//
+// We enqueue via AddAfter rather than a plain EnqueueRequestsFromMapFunc because
+// the controller's priority queue only applies a delay on AddAfter/AddRateLimited:
+// a plain Add lands the item in the ready tree immediately, leaving no window for
+// the write storm a single pass produces across many Nodes to coalesce into one
+// follow-up pass. The delay is that coalescing window.
+type globalDelayHandler struct {
 	logger logr.Logger
 	dal    dal.DAL
+	delay  time.Duration
 }
 
 // force compiler to check that we implement the interface
-var _ handler.EventHandler = &eventHandler{}
+var _ handler.EventHandler = &globalDelayHandler{}
 
-// the EventHandler interface
-func (e *eventHandler) Create(ctx context.Context, event event.TypedCreateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+func (h *globalDelayHandler) Create(ctx context.Context, evt event.TypedCreateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueue(ctx, evt.Object, queue)
+}
 
-	matches, err := e.genericHandler(ctx, event.Object)
+func (h *globalDelayHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	// ignoring the old object: relevance is decided from current state.
+	h.enqueue(ctx, evt.ObjectNew, queue)
+}
+
+func (h *globalDelayHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueue(ctx, evt.Object, queue)
+}
+
+func (h *globalDelayHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	h.enqueue(ctx, evt.Object, queue)
+}
+
+func (h *globalDelayHandler) enqueue(ctx context.Context, object client.Object, queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	relevant, err := h.relevant(ctx, object)
 	if err != nil {
-		e.logger.Error(err, "error handling create event",
-			"namespace", event.Object.GetNamespace(),
-			"name", event.Object.GetName(),
-			"kind", event.Object.GetObjectKind())
+		// On error we skip rather than enqueue: a spurious global reconcile is
+		// cheap, but more importantly the next event (or the periodic resync)
+		// will retry, and we don't want a transient list error to amplify into
+		// a reconcile per event.
+		h.logger.Error(err, "error deciding event relevance for global reconcile",
+			"namespace", object.GetNamespace(),
+			"name", object.GetName(),
+			"kind", object.GetObjectKind())
+		return
 	}
 
-	// not sure if actually we want to many or one
-	for _, match := range matches {
-		queue.Add(reconcile.Request{NamespacedName: match})
+	if relevant {
+		queue.AddAfter(globalReconcileKey, h.delay)
 	}
 }
 
-func (e *eventHandler) Update(ctx context.Context, event event.TypedUpdateEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-
-	// ignoring the old for now, might need to do some comparing to decided
-	// if we want to do something, but for now starting simple
-
-	matches, err := e.genericHandler(ctx, event.ObjectNew)
-	if err != nil {
-		e.logger.Error(err, "error handling update event",
-			"namespace", event.ObjectNew.GetNamespace(),
-			"name", event.ObjectNew.GetName(),
-			"kind", event.ObjectNew.GetObjectKind())
-	}
-
-	// not sure if actually we want to many or one
-	for _, match := range matches {
-		queue.Add(reconcile.Request{NamespacedName: match})
-	}
-}
-
-func (e *eventHandler) Delete(ctx context.Context, event event.TypedDeleteEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-	matches, err := e.genericHandler(ctx, event.Object)
-	if err != nil {
-		e.logger.Error(err, "error handling delete event",
-			"namespace", event.Object.GetNamespace(),
-			"name", event.Object.GetName(),
-			"kind", event.Object.GetObjectKind())
-	}
-
-	// not sure if actually we want to many or one
-	for _, match := range matches {
-		queue.Add(reconcile.Request{NamespacedName: match})
-	}
-}
-
-// Generic not sure what Generic is, so just loging for now
-func (e *eventHandler) Generic(ctx context.Context, event event.TypedGenericEvent[client.Object], queue workqueue.TypedRateLimitingInterface[reconcile.Request]) {
-
-	matches, err := e.genericHandler(ctx, event.Object)
-	if err != nil {
-		e.logger.Error(err, "error handling generic event",
-			"namespace", event.Object.GetNamespace(),
-			"name", event.Object.GetName(),
-			"kind", event.Object.GetObjectKind())
-	}
-
-	// not sure if actually we want to many or one
-	for _, match := range matches {
-		queue.Add(reconcile.Request{NamespacedName: match})
-	}
-}
-
-// genericHandler should be able to handle most of the logic for all the different event types
-func (e *eventHandler) genericHandler(ctx context.Context, object client.Object) ([]types.NamespacedName, error) {
-
-	list, err := e.dal.GetSkyhooks(ctx)
-	if err != nil {
-
-		return nil, err
-	}
-	if list == nil {
-		return nil, nil
-	}
-
-	var matches []types.NamespacedName
-	// kind := "unknown"
+// relevant reports whether an event on object should wake the heavy reconcile.
+func (h *globalDelayHandler) relevant(ctx context.Context, object client.Object) (bool, error) {
 	switch obj := object.(type) {
-	case *corev1.Pod:
-		// kind = "pod"
-		node, err := e.dal.GetNode(ctx, obj.Spec.NodeName)
-		if err != nil {
-			return nil, err
-		}
-		matches = matchSelectors(list, node.Labels)
+	case *v1alpha1.Skyhook:
+		return true, nil
 	case *corev1.Node:
-		// kind = "node"
-		matches = matchSelectors(list, obj.Labels)
+		list, err := h.dal.GetSkyhooks(ctx)
+		if err != nil {
+			return false, err
+		}
+		if list == nil {
+			return false, nil
+		}
+		return len(matchSelectors(list, obj.Labels)) > 0, nil
+	default:
+		return false, nil
 	}
-
-	// e.logger.Info("Event Handler",
-	// 	"event_type", event_type,
-	// 	"match_labels", matches,
-	// 	"namespace", object.GetNamespace(),
-	// 	"name", object.GetName(),
-	// 	"kind", kind)
-
-	return matches, nil
 }
 
+// matchSelectors returns the Skyhooks whose node selector matches the given
+// labels.
 func matchSelectors(crs *v1alpha1.SkyhookList, lbs map[string]string) []types.NamespacedName {
 
 	ret := make([]types.NamespacedName, 0)
@@ -168,7 +143,7 @@ func matchSelectors(crs *v1alpha1.SkyhookList, lbs map[string]string) []types.Na
 		if match {
 			ret = append(ret, types.NamespacedName{
 				Name:      cr.Name,
-				Namespace: cr.Namespace, // guessing always empty string
+				Namespace: cr.Namespace,
 			})
 		}
 	}

--- a/operator/internal/controller/event_handler_test.go
+++ b/operator/internal/controller/event_handler_test.go
@@ -35,7 +35,7 @@ import (
 
 var _ = Describe("Global delay handler", func() {
 
-	const delay = 500 * time.Millisecond
+	const delay = 50 * time.Millisecond
 
 	matchingLabels := map[string]string{"foo": "bar"}
 

--- a/operator/internal/controller/event_handler_test.go
+++ b/operator/internal/controller/event_handler_test.go
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  *
  *
@@ -19,250 +19,88 @@
 package controller
 
 import (
-	"context"
 	"errors"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 
-	// . "github.com/onsi/gomega"
 	"github.com/NVIDIA/nodewright/operator/api/v1alpha1"
-	"github.com/NVIDIA/nodewright/operator/internal/dal"
 	dalmock "github.com/NVIDIA/nodewright/operator/internal/dal/mock"
-	MockClient "github.com/NVIDIA/nodewright/operator/internal/mocks/client"
 	"github.com/NVIDIA/nodewright/operator/internal/mocks/workqueue"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-var _ = Describe("Event Handler Tests", func() {
+var _ = Describe("Global delay handler", func() {
 
-	const (
-		nodename = "foonode"
-	)
+	const delay = 500 * time.Millisecond
 
-	It("Pod Event matches a Skyhook", func() {
+	matchingLabels := map[string]string{"foo": "bar"}
 
-		dalMock := dalmock.MockDAL{}
+	skyhookList := &v1alpha1.SkyhookList{
+		Items: []v1alpha1.Skyhook{{
+			ObjectMeta: metav1.ObjectMeta{Name: "test"},
+			Spec:       v1alpha1.SkyhookSpec{NodeSelector: metav1.LabelSelector{MatchLabels: matchingLabels}},
+		}},
+	}
+
+	It("enqueues the global key for a node matched by a skyhook, on every event type", func() {
+
+		dalMock := &dalmock.MockDAL{}
 		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
-		handler := eventHandler{
-			logger: GinkgoLogr,
-			dal:    &dalMock,
-		}
+		handler := &globalDelayHandler{logger: GinkgoLogr, dal: dalMock, delay: delay}
 
-		labels := map[string]string{
-			"foo": "bar",
-		}
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foonode", Labels: matchingLabels}}
 
-		pod := &corev1.Pod{
-			Spec: corev1.PodSpec{
-				NodeName: nodename,
-			},
-		}
+		dalMock.EXPECT().GetSkyhooks(ctx).Return(skyhookList, nil).Times(4)
+		queue.EXPECT().AddAfter(globalReconcileKey, delay).Times(4)
 
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: labels,
-				Name:   nodename,
-			},
-		}
-
-		skyhooks := v1alpha1.SkyhookList{
-			Items: []v1alpha1.Skyhook{{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "foobar_name",
-				},
-				Spec: v1alpha1.SkyhookSpec{
-					NodeSelector: metav1.LabelSelector{MatchLabels: labels},
-				},
-			},
-			},
-		}
-
-		dalMock.EXPECT().GetSkyhooks(ctx).Return(&skyhooks, nil).Once()
-
-		dalMock.EXPECT().GetNode(ctx, nodename).Return(node, nil).Once()
-
-		queue.EXPECT().Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: skyhooks.Items[0].Name}}).Once()
-
-		/// test
-		handler.Create(ctx, event.CreateEvent{Object: pod}, queue)
-
-	})
-
-	It("Pod Event does not match a Skyhook", func() {
-
-		clientMock := MockClient.NewClient(GinkgoT())
-		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
-		handler := eventHandler{
-			logger: GinkgoLogr,
-			dal:    dal.New(clientMock),
-		}
-
-		pod := &corev1.Pod{
-			Spec: corev1.PodSpec{
-				NodeName: nodename,
-			},
-		}
-
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"foobar": "2000",
-				},
-				Name: nodename,
-			},
-		}
-
-		skyhook := v1alpha1.Skyhook{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foobar_name",
-			},
-			Spec: v1alpha1.SkyhookSpec{
-				NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{
-					"foo": "Bar",
-				},
-				}},
-		}
-
-		clientMock.EXPECT().List(ctx, &v1alpha1.SkyhookList{}).
-			Return(nil).
-			Run(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) {
-				l := list.(*v1alpha1.SkyhookList)
-				l.Items = append(l.Items, skyhook)
-			})
-
-		clientMock.EXPECT().Get(ctx, types.NamespacedName{Name: nodename}, &corev1.Node{}).
-			Return(nil).
-			Run(func(ctx context.Context, key types.NamespacedName, obj client.Object, opts ...client.GetOption) {
-				n := obj.(*corev1.Node)
-				n.ObjectMeta = node.ObjectMeta
-			})
-
-		/// test
-		handler.Create(ctx, event.CreateEvent{Object: pod}, queue)
-	})
-
-	It("All Node Event matches a Skyhook", func() {
-		clientMock := MockClient.NewClient(GinkgoT())
-		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
-		handler := eventHandler{
-			logger: GinkgoLogr,
-			dal:    dal.New(clientMock),
-		}
-
-		node := &corev1.Node{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					"foo": "Bar",
-				},
-				Name: nodename,
-			},
-		}
-
-		skyhook := v1alpha1.Skyhook{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foobar_name",
-			},
-			Spec: v1alpha1.SkyhookSpec{
-				NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{
-					"foo": "Bar",
-				}},
-			},
-		}
-
-		clientMock.EXPECT().List(ctx, &v1alpha1.SkyhookList{}).
-			Return(nil).
-			Run(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) {
-				l := list.(*v1alpha1.SkyhookList)
-				l.Items = append(l.Items, skyhook)
-			}).
-			Times(4)
-
-		queue.
-			EXPECT().
-			Add(reconcile.Request{NamespacedName: types.NamespacedName{Name: skyhook.Name}}).
-			Times(4)
-
-		/// test
 		handler.Create(ctx, event.CreateEvent{Object: node}, queue)
+		handler.Update(ctx, event.UpdateEvent{ObjectNew: node, ObjectOld: node}, queue)
 		handler.Delete(ctx, event.DeleteEvent{Object: node}, queue)
 		handler.Generic(ctx, event.GenericEvent{Object: node}, queue)
-
-		oldNode := node.DeepCopy()
-		oldNode.Labels = map[string]string{
-			"foobar": "2000",
-		}
-		handler.Update(ctx, event.UpdateEvent{ObjectNew: node, ObjectOld: oldNode}, queue)
 	})
 
-	It("List Skyhook errors", func() {
-		clientMock := MockClient.NewClient(GinkgoT())
+	It("does not enqueue for a node no skyhook selects", func() {
 
-		handler := eventHandler{
-			logger: GinkgoLogr,
-			dal:    dal.New(clientMock),
-		}
+		dalMock := &dalmock.MockDAL{}
+		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
+		handler := &globalDelayHandler{logger: GinkgoLogr, dal: dalMock, delay: delay}
 
-		pod := &corev1.Pod{
-			Spec: corev1.PodSpec{
-				NodeName: nodename,
-			},
-		}
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foonode", Labels: map[string]string{"no": "match"}}}
 
-		err := errors.New("this is an error")
+		// no AddAfter expectation: the mock fails the test if AddAfter is called.
+		dalMock.EXPECT().GetSkyhooks(ctx).Return(skyhookList, nil).Once()
 
-		clientMock.EXPECT().List(ctx, &v1alpha1.SkyhookList{}).
-			Return(err).
-			Times(3)
-
-		handler.Create(ctx, event.CreateEvent{Object: pod}, nil)
-		handler.Delete(ctx, event.DeleteEvent{Object: pod}, nil)
-		handler.Generic(ctx, event.GenericEvent{Object: pod}, nil)
-
+		handler.Create(ctx, event.CreateEvent{Object: node}, queue)
 	})
 
-	It("Get Node errors on pod event", func() {
-		clientMock := MockClient.NewClient(GinkgoT())
+	It("always enqueues for a skyhook event without consulting selectors", func() {
 
-		handler := eventHandler{
-			logger: GinkgoLogr,
-			dal:    dal.New(clientMock),
-		}
+		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
+		// dal is intentionally nil: a skyhook event must not need to list skyhooks.
+		handler := &globalDelayHandler{logger: GinkgoLogr, delay: delay}
 
-		pod := &corev1.Pod{
-			Spec: corev1.PodSpec{
-				NodeName: nodename,
-			},
-		}
+		skyhook := &v1alpha1.Skyhook{ObjectMeta: metav1.ObjectMeta{Name: "test"}}
 
-		err := errors.New("this is an error")
-		skyhook := v1alpha1.Skyhook{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "foobar_name",
-			},
-			Spec: v1alpha1.SkyhookSpec{
-				NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{
-					"foo": "Bar",
-				}},
-			},
-		}
+		queue.EXPECT().AddAfter(globalReconcileKey, delay).Once()
 
-		clientMock.EXPECT().List(ctx, &v1alpha1.SkyhookList{}).
-			Return(nil).
-			Run(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) {
-				l := list.(*v1alpha1.SkyhookList)
-				l.Items = append(l.Items, skyhook)
-			}).Once()
+		handler.Create(ctx, event.CreateEvent{Object: skyhook}, queue)
+	})
 
-		clientMock.EXPECT().Get(ctx, types.NamespacedName{Name: nodename}, &corev1.Node{}).
-			Return(err).
-			Once()
+	It("does not enqueue when listing skyhooks errors", func() {
 
-		handler.Update(ctx, event.UpdateEvent{ObjectNew: pod, ObjectOld: pod}, nil)
+		dalMock := &dalmock.MockDAL{}
+		queue := workqueue.NewTypedRateLimitingInterface[reconcile.Request](GinkgoT())
+		handler := &globalDelayHandler{logger: GinkgoLogr, dal: dalMock, delay: delay}
 
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "foonode", Labels: matchingLabels}}
+
+		// no AddAfter expectation: a list error must not enqueue.
+		dalMock.EXPECT().GetSkyhooks(ctx).Return(nil, errors.New("boom")).Once()
+
+		handler.Create(ctx, event.CreateEvent{Object: node}, queue)
 	})
 })

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -95,10 +95,14 @@ const (
 	globalReconcileName = "nodewright"
 
 	// globalReconcileDelay is how long Skyhook and Node events wait before the
-	// global key becomes ready. It is the window the priority queue uses to
-	// coalesce a burst (e.g. the write storm one pass produces across Nodes)
-	// into a single follow-up reconcile.
-	globalReconcileDelay = 500 * time.Millisecond
+	// global key becomes ready. The bulk of coalescing is already free: a burst
+	// arriving while a pass is in flight dedups onto one follow-up via the
+	// priority queue's locked-key handling. This short window only lets a pass's
+	// own writes propagate to the cache and near-simultaneous events land before
+	// the follow-up runs. It is kept small on purpose: the interrupt flow
+	// advances one stage per Node event, so a larger delay (we started at 500ms)
+	// adds up across stages and blows the interrupt e2e timing budget.
+	globalReconcileDelay = 50 * time.Millisecond
 )
 
 type SkyhookOperatorOptions struct {

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -51,6 +51,7 @@ import (
 	"k8s.io/kubernetes/pkg/util/taints"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -84,6 +85,20 @@ const (
 	// Environment variable names propagated into package containers.
 	envSkyhookResourceID = "SKYHOOK_RESOURCE_ID"
 	envSkyhookNodeOrder  = "SKYHOOK_NODE_ORDER"
+
+	// globalReconcileName is both the controller's registered name (driving the
+	// reconcile metric and log labels) and the .Name of the sentinel request the
+	// heavy reconcile path collapses Skyhook and Node events onto. The sentinel
+	// value is arbitrary and ignored by Reconcile (which grabs the whole world);
+	// it only has to be constant and must not collide with the "pod---" dispatch
+	// prefix.
+	globalReconcileName = "nodewright"
+
+	// globalReconcileDelay is how long Skyhook and Node events wait before the
+	// global key becomes ready. It is the window the priority queue uses to
+	// coalesce a burst (e.g. the write storm one pass produces across Nodes)
+	// into a single follow-up reconcile.
+	globalReconcileDelay = 500 * time.Millisecond
 )
 
 type SkyhookOperatorOptions struct {
@@ -218,20 +233,35 @@ func (r *SkyhookReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	ehandler := &eventHandler{
+	globalHandler := &globalDelayHandler{
 		logger: mgr.GetLogger(),
 		dal:    dal.New(r.Client),
+		delay:  globalReconcileDelay,
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&v1alpha1.Skyhook{}).
+		Named(globalReconcileName).
+		WithOptions(controller.Options{
+			// Only one heavy "grab the world" pass may run at a time: it is a
+			// centralized scheduler reading across every SCR, Node and Pod, so
+			// concurrent passes would race each other's writes. This makes the
+			// global key the single in-flight reconcile.
+			MaxConcurrentReconciles: 1,
+		}).
+		// Heavy path: Skyhook and Node events collapse onto the global key.
 		Watches(
-			&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(podHandlerFunc),
+			&v1alpha1.Skyhook{},
+			globalHandler,
 		).
 		Watches(
 			&corev1.Node{},
-			ehandler,
+			globalHandler,
+		).
+		// Cheap path: Pod events keep their targeted "pod---<name>" routing,
+		// dispatched to PodReconcile in Reconcile below.
+		Watches(
+			&corev1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(podHandlerFunc),
 		).
 		Complete(r)
 }


### PR DESCRIPTION
…bal key

Route Skyhook and Node watch events onto a single sentinel reconcile key and run with MaxConcurrentReconciles: 1, so the heavy grab-the-world pass cannot race itself across SCRs or nodes. Events enqueue via AddAfter so the priority queue coalesces a burst into one pass; Node events keep the node selector matching so unrelated nodes do not wake the reconcile. The Pod 'pod---' targeted path is unchanged.

## Description
<!-- Provide a brief description of the changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". -->

## Checklist

- [ ] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [ ] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
