### PR TITLE
fix(operator): mount configMap keys as subPaths to preserve image defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Part of how the operator works is the [NodeWright agent](agent/README.md). Packa
 └── config.json
 ```
 
+When a Skyhook's `configMap` is set, the operator projects each key as an individual file at `/skyhook-package/configmaps/<key>`. These files overlay any files the package image baked in under that directory rather than replacing the whole directory: a package can ship default files there and a user's `configMap` overrides only the keys it supplies. (Because the files are mounted via `subPath`, live ConfigMap edits are not propagated into a running pod, but package pods are recreated per stage and on version bumps.)
+
 ## Examples
 
 See the [examples/](examples/) directory for sample manifests, usage patterns, and demo configurations to help you get started with NodeWright.

--- a/k8s-tests/chainsaw/skyhook/explicit-uninstall/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/skyhook/explicit-uninstall/chainsaw-test.yaml
@@ -103,14 +103,18 @@ spec:
             ((volumes[?name == 'mypkg'].configMap.name)[0] == 'explicit-uninstall-mypkg-2.1.4'): true
             initContainers:
               - name: mypkg-init
-                ## init container mounts the configmap so scripts land in /root at copy time
-                ((volumeMounts[?name == 'mypkg'].mountPath)[0] == '/skyhook-package/configmaps'): true
+                ## init container mounts each configMap key as its own subPath so scripts
+                ## land in /root at copy time and image-baked files under
+                ## /skyhook-package/configmaps are not clobbered (issue #208)
+                ((volumeMounts[?name == 'mypkg' && subPath == 'install.sh'].mountPath)[0] == '/skyhook-package/configmaps/install.sh'): true
+                ((volumeMounts[?name == 'mypkg' && subPath == 'uninstall.sh'].mountPath)[0] == '/skyhook-package/configmaps/uninstall.sh'): true
               - name: mypkg-uninstall
                 args:
                   ([0]): uninstall
                 ## user-supplied env var from skyhook.yaml is propagated to the uninstall container
                 ((env[?name == 'MY_VAR'].value)[0] == 'hello'): true
-                ((volumeMounts[?name == 'mypkg'].mountPath)[0] == '/skyhook-package/configmaps'): true
+                ((volumeMounts[?name == 'mypkg' && subPath == 'install.sh'].mountPath)[0] == '/skyhook-package/configmaps/install.sh'): true
+                ((volumeMounts[?name == 'mypkg' && subPath == 'uninstall.sh'].mountPath)[0] == '/skyhook-package/configmaps/uninstall.sh'): true
               - name: mypkg-uninstallcheck
                 args:
                   ([0]): uninstall-check

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -82,6 +82,9 @@ const (
 	volumeNameRootMount = "root-mount"
 	mountPathRoot       = "/root"
 
+	// Directory inside package containers where the SCR's configMap is projected.
+	mountPathConfigMaps = "/skyhook-package/configmaps"
+
 	// Environment variable names propagated into package containers.
 	envSkyhookResourceID = "SKYHOOK_RESOURCE_ID"
 	envSkyhookNodeOrder  = "SKYHOOK_NODE_ORDER"
@@ -2231,11 +2234,6 @@ func createPodFromPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Packag
 	}
 
 	if len(_package.ConfigMap) > 0 {
-		volumeMounts = append(volumeMounts, corev1.VolumeMount{
-			Name:      _package.Name,
-			MountPath: "/skyhook-package/configmaps",
-		})
-
 		volumes = append(volumes, corev1.Volume{
 			Name: _package.Name,
 			VolumeSource: corev1.VolumeSource{
@@ -2246,6 +2244,29 @@ func createPodFromPackage(opts SkyhookOperatorOptions, _package *v1alpha1.Packag
 				},
 			},
 		})
+
+		// Mount each configMap key as its own subPath rather than mounting the
+		// whole configMap as a directory. A directory mount replaces the entire
+		// path, hiding any files the package image baked in under
+		// mountPathConfigMaps; per-key subPath mounts overlay individual files
+		// on top of the image content instead. Trade-off: subPath mounts do not
+		// receive live configMap updates, which is fine here because package
+		// pods are recreated per stage / version bump. Keys are iterated in
+		// sorted order so the generated pod spec is deterministic.
+		configMapKeys := make([]string, 0, len(_package.ConfigMap))
+		for key := range _package.ConfigMap {
+			configMapKeys = append(configMapKeys, key)
+		}
+		sort.Strings(configMapKeys)
+
+		for _, key := range configMapKeys {
+			volumeMounts = append(volumeMounts, corev1.VolumeMount{
+				Name:      _package.Name,
+				MountPath: fmt.Sprintf("%s/%s", mountPathConfigMaps, key),
+				SubPath:   key,
+				ReadOnly:  true,
+			})
+		}
 	}
 
 	copyDir := fmt.Sprintf("%s/%s/%s-%s-%s-%d",

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -1262,6 +1262,77 @@ var _ = Describe("skyhook controller tests", func() {
 		}
 	})
 
+	It("should mount each configMap key as a subPath so image defaults are not clobbered", func() {
+		testPackage := &v1alpha1.Package{
+			PackageRef: v1alpha1.PackageRef{
+				Name:    "foo",
+				Version: "1.1.2",
+			},
+			Image: "foo/bar",
+			ConfigMap: map[string]string{
+				"b.sh": "echo b",
+				"a.sh": "echo a",
+				"c.sh": "echo c",
+			},
+		}
+		testSkyhook := &wrapper.Skyhook{
+			Skyhook: &v1alpha1.Skyhook{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-skyhook"},
+			},
+		}
+
+		pod := createPodFromPackage(operator.opts, testPackage, testSkyhook, "node1", v1alpha1.StageApply)
+
+		container := pod.Spec.InitContainers[0]
+
+		// The configMap must never be mounted as a bare directory: that hides
+		// any files the package image baked in at /skyhook-package/configmaps.
+		for _, vm := range container.VolumeMounts {
+			if vm.MountPath == "/skyhook-package/configmaps" {
+				Fail("configMap must not be mounted as a directory; expected per-key subPath mounts")
+			}
+		}
+
+		// Collect the configMap mounts (those backed by the package volume).
+		configMapMounts := make([]corev1.VolumeMount, 0)
+		for _, vm := range container.VolumeMounts {
+			if vm.Name == testPackage.Name {
+				configMapMounts = append(configMapMounts, vm)
+			}
+		}
+
+		Expect(configMapMounts).To(HaveLen(3))
+		// Sorted-key order for a deterministic pod spec.
+		Expect(configMapMounts[0]).To(Equal(corev1.VolumeMount{
+			Name:      testPackage.Name,
+			MountPath: "/skyhook-package/configmaps/a.sh",
+			SubPath:   "a.sh",
+			ReadOnly:  true,
+		}))
+		Expect(configMapMounts[1]).To(Equal(corev1.VolumeMount{
+			Name:      testPackage.Name,
+			MountPath: "/skyhook-package/configmaps/b.sh",
+			SubPath:   "b.sh",
+			ReadOnly:  true,
+		}))
+		Expect(configMapMounts[2]).To(Equal(corev1.VolumeMount{
+			Name:      testPackage.Name,
+			MountPath: "/skyhook-package/configmaps/c.sh",
+			SubPath:   "c.sh",
+			ReadOnly:  true,
+		}))
+
+		// The underlying configMap volume is still mounted exactly once.
+		configMapVolumes := 0
+		for _, v := range pod.Spec.Volumes {
+			if v.Name == testPackage.Name {
+				configMapVolumes++
+				Expect(v.ConfigMap).NotTo(BeNil())
+			}
+		}
+		Expect(configMapVolumes).To(Equal(1))
+	})
+
 	It("should generate valid configmap names", func() {
 		tests := []struct {
 			name        string


### PR DESCRIPTION
## Summary

Fixes #208.

A package's `configMap` was mounted as a single directory volume at `/skyhook-package/configmaps`. Per standard Kubernetes ConfigMap-as-volume behavior, a directory mount **replaces the entire directory**, hiding any files the package image baked in at that path. This forced an all-or-nothing choice on package authors: ship a complete config via the SCR, or accept whatever the image provides; you could not ship sensible defaults in the image and let users override individual files.

This change mounts each ConfigMap key as its own `subPath` (`MountPath: /skyhook-package/configmaps/<key>`, `SubPath: <key>`, `ReadOnly: true`). The underlying volume is still mounted once; only the specific keys the user supplies overlay on top of the image content, so image-side files for un-supplied keys remain visible. Keys are iterated in sorted order so the generated pod spec is deterministic.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Image ships file `A`; user supplies `{B}` | only `B` (whole dir replaced) | `A` (image) + `B` (configMap) |
| User supplies `{A, B}` | `A`, `B` from configMap | same |
| No image defaults; user supplies `{A}` | only `A` | only `A` (unchanged) |
| ConfigMap edited mid-pod-run | propagates (dir mount) | does **not** propagate (subPath is static) |

The last row is the only regression, and it was never actually exercised: package pods are short-lived and recreated by the operator on version bump / generation change, so they never observed live ConfigMap edits.

## Tests

- New envtest Ginkgo spec in `operator/internal/controller/skyhook_controller_test.go` verifying per-key subPath mounts, sorted order, read-only, no bare directory mount, and a single backing volume. Written test-first (RED → GREEN).
- Full controller suite: 167/167 pass. `go vet` and `golangci-lint` clean.
- Updated the `explicit-uninstall` chainsaw e2e, which asserted the old directory `mountPath`, to assert the new per-key subPath mounts. (Chainsaw run pending a cluster; static assertions match the verified pod spec.)

## Docs

- README package section documents the new overlay behavior at `/skyhook-package/configmaps`.

> Note: no `CHANGELOG.md` edit — the operator changelog is generated by git-cliff from the conventional-commit message.