### PR TITLE
chore: update go to latest

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -41,7 +41,7 @@ If a doc above is silent on a question you need to answer, say so explicitly rat
 
 ## Three components, three toolchains
 
-- **`operator/`** — Go controller-manager (controller-runtime, Kubebuilder v4). Go 1.26.3, vendored (`GOFLAGS=-mod=vendor`). Also hosts the CLI (`cmd/cli`) built as a kubectl plugin.
+- **`operator/`** — Go controller-manager (controller-runtime, Kubebuilder v4). Go 1.26.4, vendored (`GOFLAGS=-mod=vendor`). Also hosts the CLI (`cmd/cli`) built as a kubectl plugin.
 - **`agent/skyhook-agent/`** — Python 3.10+ package (hatch-managed). Runs inside every package container; reads `/skyhook-package/config.json` and executes lifecycle steps (apply / config / interrupt / post-interrupt / upgrade / uninstall). Tests via pytest, vendored deps under `agent/vendor/`.
 - **`chart/`** — Helm chart. Generated from `operator/config/` via `helmify` (`make generate-helm`) but hand-edited after; don't regenerate blindly.
 

--- a/.github/workflows/agent-ci.yaml
+++ b/.github/workflows/agent-ci.yaml
@@ -39,7 +39,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   PYTHON_VERSION: 3.13
   DEBIAN_VERSION: trixie
   PUSH_TO_REGISTRY: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/agent-go-ci.yaml
+++ b/.github/workflows/agent-go-ci.yaml
@@ -30,7 +30,7 @@ on:
       - .github/workflows/agent-go-ci.yaml
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
 
 jobs:
   test:

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -23,7 +23,7 @@ on:
       - cli/*
 
 env:
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   # Opt all JS actions into Node 24 ahead of GitHub's Node 20 phase-out.
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -52,7 +52,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   DEBIAN_VERSION: trixie
   # Opt all JS actions into Node 24. Node 20 is being phased out by GitHub
   # Actions starting June 2026; this avoids the deprecation warnings without

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,7 @@ variables:
   KUBERNETES_CPU_REQUEST: "2"
   KUBERNETES_MEMORY_LIMIT: "6Gi"
   KUBERNETES_MEMORY_REQUEST: "3Gi"
-  GO_VERSION: 1.26.3
+  GO_VERSION: 1.26.4
   ARCH_LIST: "linux/amd64,linux/arm64"
 
 workflow:

--- a/agent/go/go.mod
+++ b/agent/go/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nodewright/agent
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/onsi/ginkgo/v2 v2.28.1

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -16,7 +16,7 @@ include deps.mk
 
 ## Version of the operator
 VERSION ?= $(GIT_TAG_LAST)
-GO_VERSION ?= 1.26.3
+GO_VERSION ?= 1.26.4
 DEBIAN_VERSION ?= trixie
 DISTROLESS_VERSION ?= 4.0.2
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -90,7 +90,7 @@ Packages can depend on each other, so if you needed `something_important` to be 
 
 ### Prerequisites
 
-- go version v1.26.3+
+- go version v1.26.4+
 - docker version 17.03+ or podman 4.9.4+ (project makefile kind of assumes podman)
 - kubectl version v1.27.3+.
 - Access to a Kubernetes v1.27+ cluster. (We test on 1.32+, could work on older, not regularly tested. Could be api compatibilities issues.)

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/NVIDIA/nodewright/operator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
## Description
chore: update golang from 1.26.3 to 1.26.4

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
