### PR TITLE
fix(operator): promote skipped interrupt packages from the reconcile loop (closes #270)

### DIFF
--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -528,8 +528,7 @@ func (ns *NodeState) IsComplete(packages Packages, interrupt map[string][]*Inter
 	if len(activePackages) <= len(ns.GetComplete(activePackages, interrupt, config)) {
 		// If a current spec package is still in the uninstall cycle the node isn't complete.
 		for _, pkg := range activePackages {
-			if status, ok := (*ns)[pkg.GetUniqueName()]; ok &&
-				(status.Stage == StageUninstall || status.Stage == StageUninstallInterrupt) {
+			if ns.IsUninstallCycleInProgress(pkg.GetUniqueName()) {
 				return false
 			}
 		}
@@ -722,6 +721,34 @@ func (left *PackageStatus) Equal(right *PackageStatus) bool {
 		left.Stage == right.Stage &&
 		left.State == right.State &&
 		left.Restarts == right.Restarts
+}
+
+// IsInterruptStage reports whether the package is in one of the two interrupt-phase
+// Stages (interrupt or uninstall-interrupt). Nil-safe so it preserves the existing
+// `status != nil &&` guards at call sites: a nil/absent status is in no Stage.
+func (s *PackageStatus) IsInterruptStage() bool {
+	if s == nil {
+		return false
+	}
+	return s.Stage == StageInterrupt || s.Stage == StageUninstallInterrupt
+}
+
+// IsActive reports whether the package's execution State is still live (in-progress or
+// erroring), i.e. started but not yet terminal. Nil-safe.
+func (s *PackageStatus) IsActive() bool {
+	if s == nil {
+		return false
+	}
+	return s.State == StateInProgress || s.State == StateErroring
+}
+
+// IsSkipped reports whether the package's execution State is skipped (a higher-priority
+// interrupt won the node's single interrupt slot). Nil-safe.
+func (s *PackageStatus) IsSkipped() bool {
+	if s == nil {
+		return false
+	}
+	return s.State == StateSkipped
 }
 
 type Stage string

--- a/operator/api/v1alpha1/skyhook_types_test.go
+++ b/operator/api/v1alpha1/skyhook_types_test.go
@@ -656,6 +656,36 @@ var _ = Describe("Skyhook Types", func() {
 		Expect(nilState.IsUninstallCycleInProgress("pkg|1.0.0")).To(BeFalse())
 	})
 
+	It("Should detect IsInterruptStage from the package's stage", func() {
+		Expect((&PackageStatus{Stage: StageInterrupt}).IsInterruptStage()).To(BeTrue())
+		Expect((&PackageStatus{Stage: StageUninstallInterrupt}).IsInterruptStage()).To(BeTrue())
+		Expect((&PackageStatus{Stage: StageConfig}).IsInterruptStage()).To(BeFalse())
+		Expect((&PackageStatus{Stage: StagePostInterrupt}).IsInterruptStage()).To(BeFalse())
+
+		var nilStatus *PackageStatus
+		Expect(nilStatus.IsInterruptStage()).To(BeFalse())
+	})
+
+	It("Should detect IsActive when the package state is in-progress or erroring", func() {
+		Expect((&PackageStatus{State: StateInProgress}).IsActive()).To(BeTrue())
+		Expect((&PackageStatus{State: StateErroring}).IsActive()).To(BeTrue())
+		Expect((&PackageStatus{State: StateComplete}).IsActive()).To(BeFalse())
+		Expect((&PackageStatus{State: StateSkipped}).IsActive()).To(BeFalse())
+		Expect((&PackageStatus{State: StateUnknown}).IsActive()).To(BeFalse())
+
+		var nilStatus *PackageStatus
+		Expect(nilStatus.IsActive()).To(BeFalse())
+	})
+
+	It("Should detect IsSkipped when the package state is skipped", func() {
+		Expect((&PackageStatus{State: StateSkipped}).IsSkipped()).To(BeTrue())
+		Expect((&PackageStatus{State: StateComplete}).IsSkipped()).To(BeFalse())
+		Expect((&PackageStatus{State: StateInProgress}).IsSkipped()).To(BeFalse())
+
+		var nilStatus *PackageStatus
+		Expect(nilStatus.IsSkipped()).To(BeFalse())
+	})
+
 	It("Should detect IsUninstalled from node state", func() {
 		ns := NodeState{
 			"pkg|1.0.0": PackageStatus{

--- a/operator/internal/controller/mock/SkyhookNodes.go
+++ b/operator/internal/controller/mock/SkyhookNodes.go
@@ -593,6 +593,59 @@ func (_c *MockSkyhookNodes_GetSkyhook_Call) RunAndReturn(run func() *wrapper.Sky
 	return _c
 }
 
+// HasUninstallWork provides a mock function for the type MockSkyhookNodes
+func (_mock *MockSkyhookNodes) HasUninstallWork() (bool, error) {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasUninstallWork")
+	}
+
+	var r0 bool
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func() (bool, error)); ok {
+		return returnFunc()
+	}
+	if returnFunc, ok := ret.Get(0).(func() bool); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+	if returnFunc, ok := ret.Get(1).(func() error); ok {
+		r1 = returnFunc()
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockSkyhookNodes_HasUninstallWork_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasUninstallWork'
+type MockSkyhookNodes_HasUninstallWork_Call struct {
+	*mock.Call
+}
+
+// HasUninstallWork is a helper method to define mock.On call
+func (_e *MockSkyhookNodes_Expecter) HasUninstallWork() *MockSkyhookNodes_HasUninstallWork_Call {
+	return &MockSkyhookNodes_HasUninstallWork_Call{Call: _e.mock.On("HasUninstallWork")}
+}
+
+func (_c *MockSkyhookNodes_HasUninstallWork_Call) Run(run func()) *MockSkyhookNodes_HasUninstallWork_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSkyhookNodes_HasUninstallWork_Call) Return(b bool, err error) *MockSkyhookNodes_HasUninstallWork_Call {
+	_c.Call.Return(b, err)
+	return _c
+}
+
+func (_c *MockSkyhookNodes_HasUninstallWork_Call) RunAndReturn(run func() (bool, error)) *MockSkyhookNodes_HasUninstallWork_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // IsComplete provides a mock function for the type MockSkyhookNodes
 func (_mock *MockSkyhookNodes) IsComplete() bool {
 	ret := _mock.Called()
@@ -937,6 +990,50 @@ func (_c *MockSkyhookNodes_Status_Call) RunAndReturn(run func() v1alpha1.Status)
 	return _c
 }
 
+// UpdateBlockedCondition provides a mock function for the type MockSkyhookNodes
+func (_mock *MockSkyhookNodes) UpdateBlockedCondition() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateBlockedCondition")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockSkyhookNodes_UpdateBlockedCondition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBlockedCondition'
+type MockSkyhookNodes_UpdateBlockedCondition_Call struct {
+	*mock.Call
+}
+
+// UpdateBlockedCondition is a helper method to define mock.On call
+func (_e *MockSkyhookNodes_Expecter) UpdateBlockedCondition() *MockSkyhookNodes_UpdateBlockedCondition_Call {
+	return &MockSkyhookNodes_UpdateBlockedCondition_Call{Call: _e.mock.On("UpdateBlockedCondition")}
+}
+
+func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) Run(run func()) *MockSkyhookNodes_UpdateBlockedCondition_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) Return(err error) *MockSkyhookNodes_UpdateBlockedCondition_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) RunAndReturn(run func() error) *MockSkyhookNodes_UpdateBlockedCondition_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateCondition provides a mock function for the type MockSkyhookNodes
 func (_mock *MockSkyhookNodes) UpdateCondition(logger logr.Logger) bool {
 	ret := _mock.Called(logger)
@@ -988,100 +1085,36 @@ func (_c *MockSkyhookNodes_UpdateCondition_Call) RunAndReturn(run func(logger lo
 	return _c
 }
 
-// HasUninstallWork provides a mock function for the type MockSkyhookNodes
-func (_mock *MockSkyhookNodes) HasUninstallWork() (bool, error) {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for HasUninstallWork")
-	}
-
-	var r0 bool
-	var r1 error
-	if returnFunc, ok := ret.Get(0).(func() (bool, error)); ok {
-		return returnFunc()
-	}
-	if returnFunc, ok := ret.Get(0).(func() bool); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-	if returnFunc, ok := ret.Get(1).(func() error); ok {
-		r1 = returnFunc()
-	} else {
-		r1 = ret.Error(1)
-	}
-	return r0, r1
+// UpdateNodeStateMalformedCondition provides a mock function for the type MockSkyhookNodes
+func (_mock *MockSkyhookNodes) UpdateNodeStateMalformedCondition() {
+	_mock.Called()
+	return
 }
 
-// MockSkyhookNodes_HasUninstallWork_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'HasUninstallWork'
-type MockSkyhookNodes_HasUninstallWork_Call struct {
+// MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateNodeStateMalformedCondition'
+type MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call struct {
 	*mock.Call
 }
 
-// HasUninstallWork is a helper method to define mock.On call
-func (_e *MockSkyhookNodes_Expecter) HasUninstallWork() *MockSkyhookNodes_HasUninstallWork_Call {
-	return &MockSkyhookNodes_HasUninstallWork_Call{Call: _e.mock.On("HasUninstallWork")}
+// UpdateNodeStateMalformedCondition is a helper method to define mock.On call
+func (_e *MockSkyhookNodes_Expecter) UpdateNodeStateMalformedCondition() *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
+	return &MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call{Call: _e.mock.On("UpdateNodeStateMalformedCondition")}
 }
 
-func (_c *MockSkyhookNodes_HasUninstallWork_Call) Run(run func()) *MockSkyhookNodes_HasUninstallWork_Call {
+func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) Run(run func()) *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		run()
 	})
 	return _c
 }
 
-func (_c *MockSkyhookNodes_HasUninstallWork_Call) Return(b bool, err error) *MockSkyhookNodes_HasUninstallWork_Call {
-	_c.Call.Return(b, err)
+func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) Return() *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
+	_c.Call.Return()
 	return _c
 }
 
-func (_c *MockSkyhookNodes_HasUninstallWork_Call) RunAndReturn(run func() (bool, error)) *MockSkyhookNodes_HasUninstallWork_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateBlockedCondition provides a mock function for the type MockSkyhookNodes
-func (_mock *MockSkyhookNodes) UpdateBlockedCondition() error {
-	ret := _mock.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for UpdateBlockedCondition")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func() error); ok {
-		r0 = returnFunc()
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockSkyhookNodes_UpdateBlockedCondition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateBlockedCondition'
-type MockSkyhookNodes_UpdateBlockedCondition_Call struct {
-	*mock.Call
-}
-
-// UpdateBlockedCondition is a helper method to define mock.On call
-func (_e *MockSkyhookNodes_Expecter) UpdateBlockedCondition() *MockSkyhookNodes_UpdateBlockedCondition_Call {
-	return &MockSkyhookNodes_UpdateBlockedCondition_Call{Call: _e.mock.On("UpdateBlockedCondition")}
-}
-
-func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) Run(run func()) *MockSkyhookNodes_UpdateBlockedCondition_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) Return(err error) *MockSkyhookNodes_UpdateBlockedCondition_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockSkyhookNodes_UpdateBlockedCondition_Call) RunAndReturn(run func() error) *MockSkyhookNodes_UpdateBlockedCondition_Call {
-	_c.Call.Return(run)
+func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) RunAndReturn(run func()) *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
+	_c.Run(run)
 	return _c
 }
 
@@ -1126,38 +1159,5 @@ func (_c *MockSkyhookNodes_UpdateUninstallConditions_Call) Return(err error) *Mo
 
 func (_c *MockSkyhookNodes_UpdateUninstallConditions_Call) RunAndReturn(run func() error) *MockSkyhookNodes_UpdateUninstallConditions_Call {
 	_c.Call.Return(run)
-	return _c
-}
-
-// UpdateNodeStateMalformedCondition provides a mock function for the type MockSkyhookNodes
-func (_mock *MockSkyhookNodes) UpdateNodeStateMalformedCondition() {
-	_mock.Called()
-	return
-}
-
-// MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'UpdateNodeStateMalformedCondition'
-type MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call struct {
-	*mock.Call
-}
-
-// UpdateNodeStateMalformedCondition is a helper method to define mock.On call
-func (_e *MockSkyhookNodes_Expecter) UpdateNodeStateMalformedCondition() *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
-	return &MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call{Call: _e.mock.On("UpdateNodeStateMalformedCondition")}
-}
-
-func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) Run(run func()) *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) Return() *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
-	_c.Call.Return()
-	return _c
-}
-
-func (_c *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call) RunAndReturn(run func()) *MockSkyhookNodes_UpdateNodeStateMalformedCondition_Call {
-	_c.Run(run)
 	return _c
 }

--- a/operator/internal/controller/pod_controller.go
+++ b/operator/internal/controller/pod_controller.go
@@ -206,7 +206,9 @@ func (r *SkyhookReconciler) HandleCompletePod(ctx context.Context, skyhookNode w
 		}
 
 		// progress forward any skipped packages that this interrupt completed
-		upgraded.ProgressSkipped()
+		if err := upgraded.ProgressSkipped(); err != nil {
+			return false, fmt.Errorf("error progressing skipped packages: %w", err)
+		}
 	} else if packagePtr.Stage == v1alpha1.StageUpgrade {
 		nodeState, err := skyhookNode.State()
 		if err != nil {

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -1003,7 +1003,7 @@ func HandleCancelledUninstalls(skyhook SkyhookNodes) error {
 				continue // finalizer-driven uninstall — do not cancel
 			}
 			// Package is at StageUninstall but apply is false → cancelled
-			if status.State == v1alpha1.StateInProgress || status.State == v1alpha1.StateErroring {
+			if status.IsActive() {
 				// Reset to re-enter install pipeline
 				err := node.Upsert(pkg.PackageRef, pkg.Image,
 					v1alpha1.StateInProgress, v1alpha1.StageApply, 0, pkg.ContainerSHA)
@@ -2613,14 +2613,28 @@ func (r *SkyhookReconciler) ProcessInterrupt(ctx context.Context, skyhookNode wr
 
 	// wait tell this is done if its happening
 	status, found := skyhookNode.PackageStatus(_package.GetUniqueName())
-	if found && status.State == v1alpha1.StateSkipped {
+	if found && status.IsSkipped() {
+		// Level-triggered backstop. This package was skipped because a higher-priority
+		// interrupt won the node's single interrupt slot (e.g. a reboot that also satisfies
+		// it). The pod controller promotes skipped packages when that interrupt pod completes,
+		// but a skipped package has no pod of its own, so if that edge is missed (the pod is
+		// already GC'd, or the skip was written after it completed) nothing else ever promotes
+		// it and the node never finishes. runInterrupt is true only once this is the highest-
+		// priority interrupt left to run, meaning the preempting interrupt has completed and
+		// left the runnable set: promote then, so the reconcile converges on its own rather
+		// than depending on a pod event that may never arrive. While a higher-priority
+		// interrupt is still pending (runInterrupt false) the package keeps waiting.
+		if runInterrupt {
+			if err := skyhookNode.ProgressSkipped(); err != nil {
+				return false, fmt.Errorf("error progressing skipped package [%s]: %w", _package.GetUniqueName(), err)
+			}
+		}
 		return false, nil
 	}
 
 	// Theres is a race condition when a node reboots and api cleans up the interrupt pod
 	// so we need to check if the pod exists and if it does, we need to recreate it
-	if status != nil && (status.State == v1alpha1.StateInProgress || status.State == v1alpha1.StateErroring) &&
-		(status.Stage == v1alpha1.StageInterrupt || status.Stage == v1alpha1.StageUninstallInterrupt) {
+	if status != nil && status.IsActive() && status.IsInterruptStage() {
 		// call interrupt to recreate the pod if missing
 		err := r.Interrupt(ctx, skyhookNode, _package, interrupt, status.Stage)
 		if err != nil {
@@ -2671,9 +2685,7 @@ func (r *SkyhookReconciler) ProcessInterrupt(ctx context.Context, skyhookNode wr
 	}
 
 	// wait tell this is done if its happening
-	if status != nil &&
-		(status.Stage == v1alpha1.StageInterrupt || status.Stage == v1alpha1.StageUninstallInterrupt) &&
-		status.State != v1alpha1.StateComplete {
+	if status != nil && status.IsInterruptStage() && status.State != v1alpha1.StateComplete {
 		return false, nil
 	}
 
@@ -2757,7 +2769,7 @@ func (r *SkyhookReconciler) ApplyPackage(ctx context.Context, logger logr.Logger
 	// wait tell this is done if its happening
 	status, found := skyhookNode.PackageStatus(_package.GetUniqueName())
 
-	if found && status.State == v1alpha1.StateSkipped { // skipped, so nothing to do
+	if found && status.IsSkipped() { // skipped, so nothing to do
 		return nil
 	}
 

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -3666,3 +3666,61 @@ var _ = Describe("TrackReboots reapply-on-reboot on a busy node", func() {
 		Expect(sh.Status.NodeBootIds[nodeName]).To(Equal(newBootID))
 	})
 })
+
+// ProcessInterrupt skipped-package promotion guards the level-triggered backstop for packages
+// parked at (interrupt, skipped). Such a package lost the node's single interrupt slot to a
+// higher-priority interrupt (e.g. a reboot). The pod controller promotes it when that interrupt
+// pod completes, but a skipped package has no pod of its own, so if that edge is missed the main
+// reconcile must still converge. Once the preempting interrupt has finished and left the runnable
+// set, the skipped package becomes the chosen interrupt winner (runInterrupt=true), which is the
+// signal that it is safe to promote it to complete from the reconcile loop itself.
+var _ = Describe("ProcessInterrupt skipped-package promotion", func() {
+
+	newSkippedNode := func() wrapper.SkyhookNode {
+		pkg := v1alpha1.Package{
+			PackageRef: v1alpha1.PackageRef{Name: "baxter", Version: "3.2.1"},
+			Image:      "baxter-image",
+			Interrupt:  &v1alpha1.Interrupt{Type: v1alpha1.SERVICE, Services: []string{"cron"}},
+		}
+		skyhook := &v1alpha1.Skyhook{
+			ObjectMeta: metav1.ObjectMeta{Name: "config-skyhook"},
+			Spec:       v1alpha1.SkyhookSpec{Packages: v1alpha1.Packages{"baxter": pkg}},
+		}
+		node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "kind-worker"}}
+		sn, err := wrapper.NewSkyhookNode(node, skyhook)
+		Expect(err).NotTo(HaveOccurred())
+		// Park baxter at interrupt/skipped (Upsert persists it to the annotation).
+		Expect(sn.Upsert(pkg.PackageRef, pkg.Image, v1alpha1.StateSkipped, v1alpha1.StageInterrupt, 0, "")).To(Succeed())
+		return sn
+	}
+
+	It("promotes a skipped package once it is the interrupt winner (runInterrupt=true)", func() {
+		sn := newSkippedNode()
+		pkg := sn.GetSkyhook().Spec.Packages["baxter"]
+
+		r := &SkyhookReconciler{}
+		proceed, err := r.ProcessInterrupt(context.Background(), sn, &pkg, pkg.Interrupt, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(proceed).To(BeFalse())
+
+		status, found := sn.PackageStatus("baxter|3.2.1")
+		Expect(found).To(BeTrue())
+		Expect(status.State).To(Equal(v1alpha1.StateComplete),
+			"a skipped package that is now the interrupt winner must be promoted by the reconcile, not left for a pod event that never comes")
+	})
+
+	It("does NOT promote a skipped package while a higher-priority interrupt is still pending (runInterrupt=false)", func() {
+		sn := newSkippedNode()
+		pkg := sn.GetSkyhook().Spec.Packages["baxter"]
+
+		r := &SkyhookReconciler{}
+		proceed, err := r.ProcessInterrupt(context.Background(), sn, &pkg, pkg.Interrupt, false)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(proceed).To(BeFalse())
+
+		status, found := sn.PackageStatus("baxter|3.2.1")
+		Expect(found).To(BeTrue())
+		Expect(status.State).To(Equal(v1alpha1.StateSkipped),
+			"a skipped package must keep waiting while the preempting interrupt is still pending")
+	})
+})

--- a/operator/internal/wrapper/mock/SkyhookNode.go
+++ b/operator/internal/wrapper/mock/SkyhookNode.go
@@ -706,9 +706,20 @@ func (_c *MockSkyhookNode_PackageStatus_Call) RunAndReturn(run func(name string)
 }
 
 // ProgressSkipped provides a mock function for the type MockSkyhookNode
-func (_mock *MockSkyhookNode) ProgressSkipped() {
-	_mock.Called()
-	return
+func (_mock *MockSkyhookNode) ProgressSkipped() error {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ProgressSkipped")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func() error); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }
 
 // MockSkyhookNode_ProgressSkipped_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ProgressSkipped'
@@ -728,13 +739,13 @@ func (_c *MockSkyhookNode_ProgressSkipped_Call) Run(run func()) *MockSkyhookNode
 	return _c
 }
 
-func (_c *MockSkyhookNode_ProgressSkipped_Call) Return() *MockSkyhookNode_ProgressSkipped_Call {
-	_c.Call.Return()
+func (_c *MockSkyhookNode_ProgressSkipped_Call) Return(err error) *MockSkyhookNode_ProgressSkipped_Call {
+	_c.Call.Return(err)
 	return _c
 }
 
-func (_c *MockSkyhookNode_ProgressSkipped_Call) RunAndReturn(run func()) *MockSkyhookNode_ProgressSkipped_Call {
-	_c.Run(run)
+func (_c *MockSkyhookNode_ProgressSkipped_Call) RunAndReturn(run func() error) *MockSkyhookNode_ProgressSkipped_Call {
+	_c.Call.Return(run)
 	return _c
 }
 

--- a/operator/internal/wrapper/node.go
+++ b/operator/internal/wrapper/node.go
@@ -48,8 +48,8 @@ type SkyhookNode interface {
 	SetStatus(status v1alpha1.Status)
 	// IsComplete reports whether all packages for this Skyhook are complete on this node.
 	IsComplete() bool
-	// ProgressSkipped marks progress as skipped for sequencing (e.g. when dependencies are not run).
-	ProgressSkipped()
+	// ProgressSkipped promotes any package skipped during interrupt sequencing to complete and persists it.
+	ProgressSkipped() error
 	// IsPackageComplete reports whether the given package is complete on this node (considering interrupts and updates).
 	IsPackageComplete(_package v1alpha1.Package) bool
 	// RunNext returns the next package(s) that should run according to the dependency graph and current completion.
@@ -363,12 +363,18 @@ func (node *skyhookNode) GetComplete() []string {
 	return node.nodeState.GetComplete(node.skyhook.Spec.Packages, node.skyhook.GetConfigInterrupts(), node.skyhook.GetConfigUpdates())
 }
 
-// ProgressSkipped marks progress as skipped for sequencing (e.g. when dependencies are not run).
-func (node *skyhookNode) ProgressSkipped() {
+// ProgressSkipped promotes any package that was skipped during interrupt sequencing
+// to complete and persists the result.
+func (node *skyhookNode) ProgressSkipped() error {
 	if node.nodeState.ProgressSkipped(node.skyhook.Spec.Packages, node.skyhook.GetConfigInterrupts(), node.skyhook.GetConfigUpdates()) {
 		node.skyhook.Updated = true
-		node.updated = true
+		// Persist the promotion to the nodeState annotation, exactly as Upsert/RemoveState do.
+		// Without SetState the promoted state lives only in node.nodeState; it never reaches
+		// the annotation the Node patch diffs against, so the promotion is silently dropped
+		// unless another package's Upsert happens to re-serialize the whole map.
+		return node.SetState(node.nodeState)
 	}
+	return nil
 }
 
 // RunNext returns the next package(s) that should run according to the dependency graph and current completion.

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -280,4 +280,41 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(node.Status.Conditions).To(BeEmpty())
 		})
 	})
+
+	Context("ProgressSkipped", func() {
+		It("persists the skipped->complete promotion to the nodeState annotation", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+			}
+			skyhook := v1alpha1.Skyhook{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-skyhook"},
+				Spec: v1alpha1.SkyhookSpec{
+					Packages: map[string]v1alpha1.Package{
+						"baxter": {
+							PackageRef: v1alpha1.PackageRef{Name: "baxter", Version: "3.2.1"},
+							Image:      "baxter-image",
+						},
+					},
+				},
+			}
+
+			sn, err := NewSkyhookNode(node, &skyhook)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Park baxter at interrupt/skipped. Upsert persists this to the annotation.
+			Expect(sn.Upsert(v1alpha1.PackageRef{Name: "baxter", Version: "3.2.1"}, "baxter-image",
+				v1alpha1.StateSkipped, v1alpha1.StageInterrupt, 0, "")).To(Succeed())
+
+			Expect(sn.ProgressSkipped()).To(Succeed())
+
+			// The promotion must be persisted to the nodeState annotation, not just the
+			// in-memory map: the reconcile is level-triggered and reloads state from the
+			// annotation each pass. A fresh wrapper over the same Node models that reload.
+			reloaded, err := NewSkyhookNode(node, &skyhook)
+			Expect(err).NotTo(HaveOccurred())
+			status, found := reloaded.PackageStatus("baxter|3.2.1")
+			Expect(found).To(BeTrue())
+			Expect(status.State).To(Equal(v1alpha1.StateComplete))
+		})
+	})
 })


### PR DESCRIPTION
## Description

Fixes #270: a package parked at `(interrupt, skipped)` could be orphaned forever, leaving the node cordoned and the Skyhook `in_progress`. This surfaced as the flaky `config-skyhook` "update while running" e2e step.

A package is marked `skipped` when a higher-priority interrupt wins the node's single interrupt slot (for example a reboot that also satisfies it). The only path that promoted such a package to `complete` was **edge-triggered**: `wrapper.ProgressSkipped` ran solely on an interrupt-pod completion in the pod controller, and it never re-serialized the `nodeState` annotation. If that edge was missed (the interrupt pod was already garbage-collected, or the package was skipped after the pod completed), nothing else ever promoted it and the main reconcile only waited. The main reconcile loop had no level-triggered backstop.

### Fix

- `wrapper.ProgressSkipped` now persists via `SetState` (like `Upsert`/`RemoveState`), so a promotion actually reaches the `nodeState` annotation that the Node patch diffs against. As written it mutated only the in-memory map, so the promotion was dropped unless another package's `Upsert` happened to re-serialize the map.
- `ProcessInterrupt` promotes a skipped package once it is the interrupt winner (`promoteSkippedWinner`). `runInterrupt` is true only after the preempting interrupt has completed and left the runnable set, which is exactly when it is safe to promote without a pod event. While a higher-priority interrupt is still pending the package keeps waiting, so there is no premature promotion.

This is a level-triggered, idempotent convergence: the pod-completion path remains a fast path, and the reconcile loop is now the backstop.

### Readability refactor (same area)

Extracts three nil-safe predicate helpers on `*PackageStatus` (`IsInterruptStage`, `IsActive`, `IsSkipped`) matching the existing `Is*`/`Has*` convention on these types, and dedups the inlined uninstall-cycle check in `IsComplete` onto the existing `NodeState.IsUninstallCycleInProgress`. This collapses `ProcessInterrupt`'s dense compound conditionals, e.g. `status != nil && status.IsActive() && status.IsInterruptStage()`. Each helper carries exactly one of the State/Stage concepts (no Status/State/Stage conflation), and every substitution is behavior-preserving.

### Tests

New unit specs drive the real reconcile path rather than calling `NodeState.ProgressSkipped` directly (the gap that let this slip past the existing #242 tests):

- `wrapper`: `ProgressSkipped` must persist the promotion to the annotation (a reloaded wrapper sees `complete`).
- `controller`: `ProcessInterrupt` promotes a skipped package once it is the interrupt winner, and does NOT promote while a higher-priority interrupt is still pending.
- `api/v1alpha1`: truth-table coverage for the three new predicates, including nil receivers.

`make unit-tests` (10 suites, envtest), `make fmt`, `make vet`, and `make lint` are all green.

### Docs

No `docs/` change: this restores intended behavior and changes no CRD field, CLI command, annotation, metric, or documented lifecycle semantic. The `skipped` State definition in `docs/operator-status-definitions.md` is unchanged.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
