### PR TITLE
chore(release): bump chart to v0.17.0 on release/v0.17.x (cherry-pick #278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Install NodeWright quickly using Helm without downloading the repository:
 # The chart is distributed as an OCI artifact on GitHub Container Registry.
 # Helm 3.8+ supports OCI natively — no `helm repo add` needed.
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.16.1 \
+  --version v0.17.0 \
   --namespace skyhook \
   --create-namespace
 ```

--- a/chart/CHANGELOG.md
+++ b/chart/CHANGELOG.md
@@ -5,11 +5,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [chart/v0.17.0] - 2026-06-12
 
 ### Bug Fixes
 
 - *(chart)* Agent container path pointing to skyhook not nodewright
+
+### New Features
+
+- *(changelog)* Tag-range generator, split CHANGELOG/RELEASE_NOTES, release-tag helper 
 
 ### Other Tasks
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 # This is the chart version. This version number must be incremented each time you make changes to the helm chart. OR
 # it the agent version is updated, or operator version is updated.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: v0.16.1
+version: v0.17.0
 # This is the version number operator container being deployed.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-appVersion: v0.16.1
+appVersion: v0.17.0
 # this is the minimum version of kubernetes that the operator supports/tested against.
 kubeVersion: ">=1.27.0-0"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -84,8 +84,8 @@ controllerManager:
       pauseImage: registry.k8s.io/pause:3.10
     image:
       repository: ghcr.io/nvidia/nodewright/operator
-      tag: "v0.16.1" ## if both tag and digest are omitted, defaults to the chart appVersion
-      digest: "sha256:e406cf0f51766c873ef6e2c103e0dedd43680ef57d608104edfc6aa378698b3c" # manifest list digest (multi-arch) on ghcr.io/nvidia/nodewright/operator:v0.16.1
+      tag: "v0.17.0" ## if both tag and digest are omitted, defaults to the chart appVersion
+      digest: "sha256:1511449bf51f2844b6bb3a03bde3d5590caf2ca283e3e39c0745a8016af2132f" # manifest list digest (multi-arch) on ghcr.io/nvidia/nodewright/operator:v0.17.0
     ## agentImage: is the image used for the agent container. This image is the default for this install, but can be overridden in the CR at package level.
     agent:
       repository: ghcr.io/nvidia/nodewright/agent


### PR DESCRIPTION
## What

Cherry-picks the chart v0.17.0 version bump from #278 (merged to `main`) onto `release/v0.17.x`.

- `chart/Chart.yaml`: `version` and `appVersion` `v0.16.1` -> `v0.17.0`
- `chart/values.yaml`: operator image `tag` -> `v0.17.0`, pinned to the multi-arch digest of `ghcr.io/nvidia/nodewright/operator:v0.17.0`
- `README.md`: install `--version` -> `v0.17.0`

## Why

Per the release-branch strategy in `docs/release-process.md`, the chart is cut at the final release with the operator image pinned by digest. This carries the v0.17.0 chart bump onto `release/v0.17.x` so `chart/v0.17.0` can be tagged from the branch.

## Diff

`chart/Chart.yaml`, `chart/values.yaml`, `chart/CHANGELOG.md`, `README.md`.
