### PR TITLE
fix(api): preserve registry ports in package images

### DIFF
--- a/operator/api/v1alpha1/skyhook_types.go
+++ b/operator/api/v1alpha1/skyhook_types.go
@@ -149,13 +149,28 @@ func (f Packages) Names() {
 func (f Packages) Images() {
 	for k := range f {
 		m := f[k]
-		image, _, found := strings.Cut(m.Image, ":")
+		image, _, found := splitImageTag(m.Image)
 		if found {
 			m.Image = image
 		}
 
 		f[k] = m
 	}
+}
+
+func splitImageTag(image string) (string, string, bool) {
+	imageWithoutDigest := image
+	if index := strings.Index(imageWithoutDigest, "@"); index >= 0 {
+		imageWithoutDigest = imageWithoutDigest[:index]
+	}
+
+	lastSlash := strings.LastIndex(imageWithoutDigest, "/")
+	lastColon := strings.LastIndex(imageWithoutDigest, ":")
+	if lastColon == -1 || lastColon < lastSlash {
+		return image, "", false
+	}
+
+	return imageWithoutDigest[:lastColon], imageWithoutDigest[lastColon+1:], true
 }
 
 func (f *Packages) UnmarshalJSON(data []byte) error {

--- a/operator/api/v1alpha1/skyhook_webhook.go
+++ b/operator/api/v1alpha1/skyhook_webhook.go
@@ -289,7 +289,7 @@ func (r *Skyhook) Validate() error {
 			return fmt.Errorf("error config interrupt for key that doesn't exist: %s doesn't exist as a configmap", pattern)
 		}
 
-		image, version, found := strings.Cut(v.Image, ":")
+		image, version, found := splitImageTag(v.Image)
 		if found && version != v.Version {
 			return fmt.Errorf(
 				"error package %s's image tag was set to '%s' for '%s' and doesn't match the pacakge's version '%s'. Do not explicitly set the image's tag in the package's definition (The package version will be set as the tag)",

--- a/operator/api/v1alpha1/skyhook_webhook_test.go
+++ b/operator/api/v1alpha1/skyhook_webhook_test.go
@@ -195,6 +195,59 @@ var _ = Describe("Skyhook Webhook", func() {
 			Expect(err).ToNot(BeNil())
 		})
 
+		It("Should allow registry ports in package images", func() {
+			skyhook := &Skyhook{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: SkyhookSpec{
+					Packages: Packages{
+						"foo": {
+							PackageRef: PackageRef{
+								Name:    "foo",
+								Version: "1.0.0",
+							},
+							Image: "localhost:5000/org/pkg",
+						},
+					},
+				},
+			}
+
+			_, err := skyhookWebhook.ValidateCreate(ctx, skyhook)
+			Expect(err).To(BeNil())
+		})
+
+		It("Should validate image tags after registry ports", func() {
+			skyhook := &Skyhook{
+				ObjectMeta: metav1.ObjectMeta{Name: "test"},
+				Spec: SkyhookSpec{
+					Packages: Packages{
+						"foo": {
+							PackageRef: PackageRef{
+								Name:    "foo",
+								Version: "1.0.0",
+							},
+							Image: "localhost:5000/org/pkg:1.0.0",
+						},
+					},
+				},
+			}
+
+			_, err := skyhookWebhook.ValidateCreate(ctx, skyhook)
+			Expect(err).To(BeNil())
+
+			skyhook.Spec.Packages["foo"] = Package{
+				PackageRef: PackageRef{
+					Name:    "foo",
+					Version: "1.0.0",
+				},
+				Image: "localhost:5000/org/pkg:2.0.0",
+			}
+
+			_, err = skyhookWebhook.ValidateCreate(ctx, skyhook)
+			Expect(err).ToNot(BeNil())
+			Expect(err.Error()).To(ContainSubstring("2.0.0"))
+			Expect(err.Error()).To(ContainSubstring("localhost:5000/org/pkg"))
+		})
+
 		It("should validate that the configInterrupts are for valid configMaps", func() {
 			skyhook := &Skyhook{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
@@ -523,6 +576,28 @@ var _ = Describe("Skyhook Webhook", func() {
 
 		Expect(ret["foo"].Name).To(Equal("foo"))
 		Expect(ret["foo"].Image).To(Equal("bar"))
+	})
+
+	It("packages should preserve registry ports when stripping image tags", func() {
+		digest := "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+		js := `{
+				"foo": {"version":"1.2.2", "image":"localhost:5000/org/pkg:1.2.2"},
+				"bar": {"version":"1.2.2", "image":"localhost:5000/org/pkg"},
+				"baz": {"version":"1.2.2", "image":"localhost:5000/org/pkg@` + digest + `"},
+				"qux": {"version":"1.2.2", "image":"localhost:5000/org/pkg:1.2.2@` + digest + `"}
+			}`
+
+		var ret Packages
+		Expect(json.Unmarshal([]byte(js), &ret)).Should(Succeed())
+
+		Expect(ret["foo"].Name).To(Equal("foo"))
+		Expect(ret["foo"].Image).To(Equal("localhost:5000/org/pkg"))
+		Expect(ret["bar"].Name).To(Equal("bar"))
+		Expect(ret["bar"].Image).To(Equal("localhost:5000/org/pkg"))
+		Expect(ret["baz"].Name).To(Equal("baz"))
+		Expect(ret["baz"].Image).To(Equal("localhost:5000/org/pkg@" + digest))
+		Expect(ret["qux"].Name).To(Equal("qux"))
+		Expect(ret["qux"].Image).To(Equal("localhost:5000/org/pkg"))
 	})
 
 	It("should validate the package name is a valid RFC 1123 name", func() {


### PR DESCRIPTION
## Summary
- Parse package image tags only when the tag separator appears after the final slash.
- Preserve registry ports such as `localhost:5000/org/pkg` during package image defaulting.
- Keep validating explicit tags, including tags on images from registries with ports.

## Why
Package image handling split on the first colon, so a registry port was mistaken for a tag. That truncated valid package images like `localhost:5000/org/pkg` to `localhost` and made validation treat `5000/org/pkg` as the image tag.

## Validation
- `go test ./api/v1alpha1`
- `go test ./...`
