### PR TITLE
feat(agent): complete Go agent orchestration and entrypoint

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -36,8 +36,39 @@ are paths inside the agent container, resolved through the mounted host root.
 Each Go interrupt owns its command construction and execution. The `Interrupt`
 contract exposes `Type` for the wire identity, `Run` for execution using an
 `execution.Config`, and `Serialize` for the operator-facing representation.
-Retry state and completion flags remain orchestration concerns outside the
-interrupt implementations.
+The orchestration layer uses the legacy agent's indexed completion-marker names
+for each interrupt command and resource ID, so an agent upgrade resumes after
+the last completed command. Node restarts use an indexed pending marker
+containing the host boot ID: a changed boot ID promotes the marker to complete,
+while an unchanged boot ID retries the restart. This keeps reboot completion
+independent of the signal used to terminate the agent or its child process.
+
+Successful steps write both the legacy-compatible completion marker and the
+Go-native fingerprint marker. Either marker prevents a step from running again,
+which preserves idempotence when moving between agent implementations.
+
+The Go entrypoint accepts the current operator forms:
+
+```text
+agent MODE ROOT_MOUNT COPY_DIR
+agent interrupt ROOT_MOUNT COPY_DIR INTERRUPT_DATA
+```
+
+It also accepts the legacy forms, which default `ROOT_MOUNT` to `/root`:
+
+```text
+agent MODE COPY_DIR
+agent interrupt COPY_DIR INTERRUPT_DATA
+```
+
+SIGTERM cancels the active step or interrupt and prevents later steps from
+starting. A failed operation or runtime error exits with status 1; malformed
+arguments exit with status 2.
+
+The entrypoint preserves the legacy agent's dashed startup banner because
+operator diagnostics and end-to-end tests consume that output.
+Before each step that runs, it also prints the legacy-compatible execution
+header: `MODE PATH ARGUMENTS RETURNCODES IDEMPOTENCE ON_HOST`.
 
 ### Container Image Build
 
@@ -48,14 +79,26 @@ interrupt implementations.
 
 ## Environment variables
 
-There are a number of environment variables that can be used to control how the controller works
+There are a number of environment variables that can be used to control how the agent works.
 
 1. `COPY_RESOLV` if set to `"false"` it will NOT copy the container's `/etc/resolv.conf` to the host.
-1. `OVERLAY_ALWAYS_RUN_STEP` if set to `"true"` it will ignore any step flags and always run every step. A warning will be printed to stdout if it sees a flag file.
-1. `SKYHOOK_AGENT_BUFFER_LIMIT` defaults to 8KB. This is how much of the log of each step it will read before syncing the data to stdout/stderr and the log file. It is recommended to keep this somewhat low to avoid excessive delay between a step emitting some information and seeing it in the docker logs or in the log file.
+1. `OVERLAY_ALWAYS_RUN_STEP` if set to `"true"` it will ignore any step flags and always run every step. A warning is logged if it sees a flag file.
+1. `SKYHOOK_AGENT_WRITE_LOGS` defaults to `"true"`. Step and interrupt output is streamed directly to stdout/stderr and also written under `SKYHOOK_LOG_DIR`. Set it to `"false"` to stream without retaining host log files.
 
-The following are enviroment variables expected to be set by either the build system or skyhook-operator. It is not recommended they be changed manually.
+`SKYHOOK_AGENT_BUFFER_LIMIT` applies only to the legacy agent. The Go agent
+streams command output directly and does not buffer it.
 
-1. `OVERLAY_FRAMEWORK_VERSION` this the version of the current overlay. It is expected that this gets set by the docker build system. It is required to be able to manage the history file. It must be in the format of `{package name}-{version}`
-1. `SKYHOOK_RESOURCE_ID` this is used to determine if an interrupt should be rerun. Interrupts are only run once per `SKYHOOK_RESOURCE_ID`. Skyhook operator should make this unique per conifguration of the package.
-1. `SKYHOOK_NODE_ORDER` zero-indexed monotonic position of this node in the rollout. The first batch's nodes get `0, 1, 2, ...` and subsequent batches continue from where the previous batch left off. Useful for kubeadm upgrade workflows where the first node (`SKYHOOK_NODE_ORDER=0`) runs a different command than subsequent nodes. See [Node Order Within a Rollout](../docs/architecture/ordering.md#node-order-within-a-rollout) for details.
+The following environment variables are required and are expected to be set by either the build system or skyhook-operator. It is not recommended that they be changed manually.
+
+1. `OVERLAY_FRAMEWORK_VERSION` is the version of the current overlay. It is expected that this gets set by the docker build system. It is required to be able to manage the history file. It must be in the format of `{package name}-{version}`.
+1. `SKYHOOK_RESOURCE_ID` is used to determine if an interrupt should be rerun. Interrupts are only run once per `SKYHOOK_RESOURCE_ID`. Skyhook operator should make this unique per configuration of the package.
+
+The following environment variables are optional and use the documented defaults when unset:
+
+1. `SKYHOOK_DATA_DIR` is the package data source used by legacy invocations when the operator has not already populated `COPY_DIR`. It defaults to `/skyhook-package`.
+1. `SKYHOOK_ROOT_DIR` is the host state root for flags, interrupt markers, and history. It defaults to `/etc/skyhook`.
+1. `SKYHOOK_LOG_DIR` is the host log root. It defaults to `/var/log/skyhook`.
+
+The following environment variable is optional:
+
+1. `SKYHOOK_NODE_ORDER` is a zero-indexed monotonic position of this node in the rollout. The first batch's nodes get `0, 1, 2, ...` and subsequent batches continue from where the previous batch left off. Useful for kubeadm upgrade workflows where the first node (`SKYHOOK_NODE_ORDER=0`) runs a different command than subsequent nodes. See [Node Order Within a Rollout](../docs/architecture/ordering.md#node-order-within-a-rollout) for details.

--- a/agent/README.md
+++ b/agent/README.md
@@ -85,13 +85,14 @@ There are a number of environment variables that can be used to control how the 
 1. `OVERLAY_ALWAYS_RUN_STEP` if set to `"true"` it will ignore any step flags and always run every step. A warning is logged if it sees a flag file.
 1. `SKYHOOK_AGENT_WRITE_LOGS` defaults to `"true"`. Step and interrupt output is streamed directly to stdout/stderr and also written under `SKYHOOK_LOG_DIR`. Set it to `"false"` to stream without retaining host log files.
 
-`SKYHOOK_AGENT_BUFFER_LIMIT` applies only to the legacy agent. The Go agent
-streams command output directly and does not buffer it.
+`SKYHOOK_AGENT_BUFFER_LIMIT` is printed in the startup banner for legacy output
+compatibility, but it has no effect in the Go agent. The Go agent streams
+command output directly and does not buffer it.
 
-The following environment variables are required and are expected to be set by either the build system or skyhook-operator. It is not recommended that they be changed manually.
+The following environment variable is required and is expected to be set by
+the NodeWright operator. It is not recommended that it be changed manually.
 
-1. `OVERLAY_FRAMEWORK_VERSION` is the version of the current overlay. It is expected that this gets set by the docker build system. It is required to be able to manage the history file. It must be in the format of `{package name}-{version}`.
-1. `SKYHOOK_RESOURCE_ID` is used to determine if an interrupt should be rerun. Interrupts are only run once per `SKYHOOK_RESOURCE_ID`. Skyhook operator should make this unique per configuration of the package.
+1. `SKYHOOK_RESOURCE_ID` is used to determine if an interrupt should be rerun. Interrupts are only run once per `SKYHOOK_RESOURCE_ID`. The NodeWright operator makes this unique per package configuration.
 
 The following environment variables are optional and use the documented defaults when unset:
 

--- a/agent/go/cmd/agent/main.go
+++ b/agent/go/cmd/agent/main.go
@@ -19,17 +19,20 @@
 package main
 
 import (
-	"fmt"
-	"log/slog"
+	"context"
 	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/NVIDIA/nodewright/agent/internal/agent"
 )
 
 func main() {
-	// Establish the agent's structured-logging seam. Packages (e.g.
-	// config.Loader.Load) log through *slog.Logger and fall back to
-	// slog.Default() when passed nil, so wiring it here once keeps that
-	// default sane for the whole process.
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
+	defer stop()
 
-	fmt.Println("Hello, World!")
+	nodewrightAgent := agent.New()
+	exitCode := nodewrightAgent.Run(ctx, os.Args[1:], os.Stdout, os.Stderr)
+
+	os.Exit(int(exitCode))
 }

--- a/agent/go/cmd/agent/main.go
+++ b/agent/go/cmd/agent/main.go
@@ -29,10 +29,10 @@ import (
 
 func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM)
-	defer stop()
 
 	nodewrightAgent := agent.New()
 	exitCode := nodewrightAgent.Run(ctx, os.Args[1:], os.Stdout, os.Stderr)
 
+	stop()
 	os.Exit(int(exitCode))
 }

--- a/agent/go/internal/agent/agent.go
+++ b/agent/go/internal/agent/agent.go
@@ -1,0 +1,435 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package agent coordinates package preparation, lifecycle steps, interrupts,
+// completion flags, history, and logs for one agent invocation.
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/history"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+)
+
+const (
+	usage            = "usage: agent MODE [ROOT_MOUNT] COPY_DIR [INTERRUPT_DATA]"
+	defaultRootMount = "/root"
+	defaultDataDir   = "/skyhook-package"
+
+	copyResolverEnv    = "COPY_RESOLV"
+	alwaysRunEnv       = "OVERLAY_ALWAYS_RUN_STEP"
+	resourceIDEnv      = "SKYHOOK_RESOURCE_ID"
+	dataDirEnv         = "SKYHOOK_DATA_DIR"
+	stateRootEnv       = "SKYHOOK_ROOT_DIR"
+	logRootEnv         = "SKYHOOK_LOG_DIR"
+	bufferLimitEnv     = "SKYHOOK_AGENT_BUFFER_LIMIT"
+	writeLogsEnv       = "SKYHOOK_AGENT_WRITE_LOGS"
+	defaultBufferLimit = "8192"
+)
+
+// ExitCode is the process result returned by Agent.Run.
+type ExitCode int
+
+const (
+	ExitSuccess ExitCode = iota
+	ExitFailure
+	ExitUsage
+)
+
+type request struct {
+	stage         stage.Stage
+	rootMount     string
+	copyDir       string
+	interruptData string
+}
+
+type runtimeConfig struct {
+	dataDir       string
+	stateRoot     string
+	logRoot       string
+	bufferLimit   string
+	resourceID    string
+	alwaysRunStep bool
+	writeLogs     bool
+	copyResolver  bool
+	stdout        io.Writer
+	stderr        io.Writer
+	logger        *slog.Logger
+}
+
+type unsupportedStageError struct {
+	stage string
+}
+
+func (err *unsupportedStageError) Error() string {
+	return fmt.Sprintf("unsupported stage %q", err.stage)
+}
+
+// Agent executes one operator invocation.
+type Agent interface {
+	Run(context.Context, []string, io.Writer, io.Writer) ExitCode
+}
+
+type orchestrator struct{}
+
+var _ Agent = orchestrator{}
+
+// New constructs the agent orchestrator.
+func New() Agent {
+	return orchestrator{}
+}
+
+// Run executes one operator invocation and returns its process exit code.
+func (agent orchestrator) Run(
+	ctx context.Context,
+	arguments []string,
+	stdout, stderr io.Writer,
+) ExitCode {
+	if stdout == nil {
+		stdout = os.Stdout
+	}
+	if stderr == nil {
+		stderr = os.Stderr
+	}
+	logger := slog.New(slog.NewTextHandler(stderr, nil))
+
+	req, err := parseRequest(arguments)
+	if err != nil {
+		var unsupportedStage *unsupportedStageError
+		if errors.As(err, &unsupportedStage) {
+			logger.Warn(
+				"this agent version does not support the requested stage; treating it as a no-op",
+				"stage", unsupportedStage.stage,
+			)
+			return ExitSuccess
+		}
+		_, _ = fmt.Fprintln(stderr, err)
+		_, _ = fmt.Fprintln(stderr, usage)
+		return ExitUsage
+	}
+
+	runtime := runtimeFromEnvironment(stdout, stderr, logger)
+	if err := printStartupBanner(stdout, req, runtime); err != nil {
+		logger.Error("preparing agent startup banner", "error", err)
+		return ExitFailure
+	}
+
+	status, err := agent.runRequest(ctx, req, runtime)
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			logger.Info("agent stopped after receiving a termination signal", "error", err)
+		} else {
+			logger.Error("agent execution failed", "error", err)
+		}
+		return ExitFailure
+	}
+
+	if status == execution.StatusFailed {
+		return ExitFailure
+	}
+
+	return ExitSuccess
+}
+
+func parseRequest(arguments []string) (request, error) {
+	var (
+		mode          string
+		rootMount     string
+		copyDir       string
+		interruptData string
+	)
+	switch len(arguments) {
+	case 2:
+		mode = arguments[0]
+		rootMount = defaultRootMount
+		copyDir = arguments[1]
+	case 3:
+		mode = arguments[0]
+		if mode == string(stage.Interrupt) {
+			rootMount = defaultRootMount
+			copyDir = arguments[1]
+			interruptData = arguments[2]
+		} else {
+			rootMount = arguments[1]
+			copyDir = arguments[2]
+		}
+	case 4:
+		mode = arguments[0]
+		rootMount = arguments[1]
+		copyDir = arguments[2]
+		interruptData = arguments[3]
+	default:
+		return request{}, fmt.Errorf(
+			"expected 2, 3, or 4 arguments; received %d",
+			len(arguments),
+		)
+	}
+
+	currentStage, err := stage.ParseStage(mode)
+	if err != nil {
+		return request{}, &unsupportedStageError{stage: mode}
+	}
+	parsed := request{
+		stage:         currentStage,
+		rootMount:     rootMount,
+		copyDir:       copyDir,
+		interruptData: interruptData,
+	}
+	if err := validateRequest(parsed); err != nil {
+		return request{}, err
+	}
+	return parsed, nil
+}
+
+func runtimeFromEnvironment(stdout, stderr io.Writer, logger *slog.Logger) runtimeConfig {
+	runtime := normalizeRuntime(runtimeConfig{
+		dataDir:     envOrDefault(dataDirEnv, defaultDataDir),
+		stateRoot:   envOrDefault(stateRootEnv, flags.DefaultStateRoot),
+		logRoot:     envOrDefault(logRootEnv, flags.DefaultLogRoot),
+		bufferLimit: envOrDefault(bufferLimitEnv, defaultBufferLimit),
+		resourceID:  os.Getenv(resourceIDEnv),
+		stdout:      stdout,
+		stderr:      stderr,
+		logger:      logger,
+	})
+	runtime.alwaysRunStep = envBool(alwaysRunEnv, false, runtime.logger)
+	runtime.writeLogs = envBool(writeLogsEnv, true, runtime.logger)
+	runtime.copyResolver = envBool(copyResolverEnv, true, runtime.logger)
+	return runtime
+}
+
+// The dashed startup banner is consumed by operator diagnostics and existing
+// end-to-end tests, so its field order and legacy value formatting are a
+// compatibility contract.
+func printStartupBanner(output io.Writer, req request, runtime runtimeConfig) error {
+	cfg, err := configFromResourceID(runtime.resourceID)
+	if err != nil {
+		return fmt.Errorf("resolving package identity: %w", err)
+	}
+	interruptData := req.interruptData
+	if interruptData == "" {
+		interruptData = "None"
+	}
+	lines := []string{
+		"--------------------",
+		"--CLI CONFIGURATION-",
+		"mode: " + string(req.stage),
+		"root_mount: " + req.rootMount,
+		"copy_dir: " + req.copyDir,
+		"interrupt_data: " + interruptData,
+		"always_run_step: " + formatLegacyBool(runtime.alwaysRunStep),
+		"--ENV CONFIGURATION-",
+		"COPY_RESOLV: " + formatLegacyBool(runtime.copyResolver),
+		"OVERLAY_ALWAYS_RUN_STEP: " + formatLegacyBool(runtime.alwaysRunStep),
+		"SKYHOOK_RESOURCE_ID: " + runtime.resourceID,
+		"SKYHOOK_DATA_DIR: " + runtime.dataDir,
+		"SKYHOOK_ROOT_DIR: " + runtime.stateRoot,
+		"SKYHOOK_LOG_DIR: " + runtime.logRoot,
+		"SKYHOOK_AGENT_BUFFER_LIMIT: " + runtime.bufferLimit,
+		"SKYHOOK_AGENT_WRITE_LOGS: " + formatLegacyBool(runtime.writeLogs),
+		"Directory CONFIGURATION",
+		"flag_dir: " + filepath.Join(runtime.stateRoot, "flags", cfg.PackageName, cfg.PackageVersion),
+		"log_dir: " + filepath.Join(runtime.logRoot, cfg.PackageName, cfg.PackageVersion),
+		"history_file: " + filepath.Join(runtime.stateRoot, "history", cfg.PackageName+".json"),
+		"--------------------",
+	}
+	if _, err := fmt.Fprintln(output, strings.Join(lines, "\n")); err != nil {
+		return fmt.Errorf("writing startup banner: %w", err)
+	}
+	return nil
+}
+
+func formatLegacyBool(value bool) string {
+	if value {
+		return "True"
+	}
+	return "False"
+}
+
+func envOrDefault(name, fallback string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func envBool(name string, fallback bool, logger *slog.Logger) bool {
+	value, exists := os.LookupEnv(name)
+	if !exists {
+		return fallback
+	}
+	if strings.EqualFold(value, "true") {
+		return true
+	}
+	if !strings.EqualFold(value, "false") {
+		logger.Warn(
+			"invalid boolean environment variable; treating it as false",
+			"name", name,
+			"value", value,
+		)
+	}
+	return false
+}
+
+func normalizeRuntime(runtime runtimeConfig) runtimeConfig {
+	if runtime.dataDir == "" {
+		runtime.dataDir = defaultDataDir
+	}
+	if runtime.stateRoot == "" {
+		runtime.stateRoot = flags.DefaultStateRoot
+	}
+	if runtime.logRoot == "" {
+		runtime.logRoot = flags.DefaultLogRoot
+	}
+	if runtime.bufferLimit == "" {
+		runtime.bufferLimit = defaultBufferLimit
+	}
+	if runtime.stdout == nil {
+		runtime.stdout = os.Stdout
+	}
+	if runtime.stderr == nil {
+		runtime.stderr = os.Stderr
+	}
+	if runtime.logger == nil {
+		runtime.logger = slog.New(slog.NewTextHandler(runtime.stderr, nil))
+	}
+	return runtime
+}
+
+func validateRun(ctx context.Context, req request, runtime runtimeConfig) error {
+	if ctx == nil {
+		return errors.New("running agent: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return fmt.Errorf("running agent: %w", err)
+	}
+	if err := validateRequest(req); err != nil {
+		return fmt.Errorf("running agent: %w", err)
+	}
+	if !filepath.IsAbs(runtime.dataDir) {
+		return fmt.Errorf("running agent: data directory %q is not absolute", runtime.dataDir)
+	}
+	if req.stage == stage.Interrupt {
+		if err := validatePathComponent("resource ID", runtime.resourceID); err != nil {
+			return fmt.Errorf("running agent: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateRequest(req request) error {
+	if _, err := stage.ParseStage(string(req.stage)); err != nil {
+		return err
+	}
+	if !filepath.IsAbs(req.rootMount) {
+		return fmt.Errorf("root mount %q is not absolute", req.rootMount)
+	}
+	if !filepath.IsAbs(req.copyDir) {
+		return fmt.Errorf("copy directory %q is not absolute", req.copyDir)
+	}
+	if req.stage == stage.Interrupt {
+		if req.interruptData == "" {
+			return errors.New("interrupt data must not be empty")
+		}
+	} else if req.interruptData != "" {
+		return fmt.Errorf("stage %q does not accept interrupt data", req.stage)
+	}
+	return nil
+}
+
+func validatePathComponent(name, value string) error {
+	if value == "" || value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
+		return fmt.Errorf("%s %q must be a single path component", name, value)
+	}
+	return nil
+}
+
+func (orchestrator) runRequest(
+	ctx context.Context,
+	req request,
+	runtime runtimeConfig,
+) (execution.Status, error) {
+	runtime = normalizeRuntime(runtime)
+	if err := validateRun(ctx, req, runtime); err != nil {
+		return execution.StatusFailed, err
+	}
+
+	if runtime.copyResolver {
+		if err := copyResolverConfig(req.rootMount); err != nil {
+			return execution.StatusFailed, fmt.Errorf("copying resolver configuration: %w", err)
+		}
+	}
+
+	copyRoot, err := hostfs.HostPathToMounted(req.rootMount, req.copyDir)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("resolving package copy directory: %w", err)
+	}
+	if err := ensurePackageData(
+		req.rootMount,
+		copyRoot,
+		packageDataSources{
+			dataDir:            runtime.dataDir,
+			legacyNodeFilesDir: legacyNodeFilesDir,
+		},
+	); err != nil {
+		return execution.StatusFailed, fmt.Errorf("preparing package data: %w", err)
+	}
+
+	layout, err := flags.NewLayout(req.rootMount, runtime.stateRoot, runtime.logRoot)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("preparing agent filesystem layout: %w", err)
+	}
+	if req.stage == stage.Interrupt {
+		return runDecodedInterrupt(ctx, req, runtime, layout)
+	}
+
+	cfg, err := loadConfig(copyRoot, runtime.logger)
+	if err != nil {
+		return execution.StatusFailed, err
+	}
+
+	if req.stage != stage.Uninstall && req.stage != stage.UninstallCheck {
+		if err := prepareHost(req.rootMount, copyRoot, *cfg); err != nil {
+			return execution.StatusFailed, err
+		}
+	}
+
+	flagStore, err := flags.NewStore(layout, *cfg)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("constructing flag store: %w", err)
+	}
+
+	historyStore, err := history.NewStore(layout, *cfg, runtime.logger)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("constructing history store: %w", err)
+	}
+
+	return runSteps(ctx, req, runtime, layout, *cfg, flagStore, historyStore)
+}

--- a/agent/go/internal/agent/agent.go
+++ b/agent/go/internal/agent/agent.go
@@ -42,15 +42,15 @@ const (
 	defaultRootMount = "/root"
 	defaultDataDir   = "/skyhook-package"
 
-	copyResolverEnv    = "COPY_RESOLV"
-	alwaysRunEnv       = "OVERLAY_ALWAYS_RUN_STEP"
-	resourceIDEnv      = "SKYHOOK_RESOURCE_ID"
-	dataDirEnv         = "SKYHOOK_DATA_DIR"
-	stateRootEnv       = "SKYHOOK_ROOT_DIR"
-	logRootEnv         = "SKYHOOK_LOG_DIR"
-	bufferLimitEnv     = "SKYHOOK_AGENT_BUFFER_LIMIT"
-	writeLogsEnv       = "SKYHOOK_AGENT_WRITE_LOGS"
-	defaultBufferLimit = "8192"
+	copyResolverEnv          = "COPY_RESOLV"
+	alwaysRunEnv             = "OVERLAY_ALWAYS_RUN_STEP"
+	resourceIDEnv            = "SKYHOOK_RESOURCE_ID"
+	dataDirEnv               = "SKYHOOK_DATA_DIR"
+	stateRootEnv             = "SKYHOOK_ROOT_DIR"
+	logRootEnv               = "SKYHOOK_LOG_DIR"
+	legacyBufferLimitEnv     = "SKYHOOK_AGENT_BUFFER_LIMIT"
+	writeLogsEnv             = "SKYHOOK_AGENT_WRITE_LOGS"
+	defaultLegacyBufferLimit = "8192"
 )
 
 // ExitCode is the process result returned by Agent.Run.
@@ -73,7 +73,6 @@ type runtimeConfig struct {
 	dataDir       string
 	stateRoot     string
 	logRoot       string
-	bufferLimit   string
 	resourceID    string
 	alwaysRunStep bool
 	writeLogs     bool
@@ -209,14 +208,13 @@ func parseRequest(arguments []string) (request, error) {
 
 func runtimeFromEnvironment(stdout, stderr io.Writer, logger *slog.Logger) runtimeConfig {
 	runtime := normalizeRuntime(runtimeConfig{
-		dataDir:     envOrDefault(dataDirEnv, defaultDataDir),
-		stateRoot:   envOrDefault(stateRootEnv, flags.DefaultStateRoot),
-		logRoot:     envOrDefault(logRootEnv, flags.DefaultLogRoot),
-		bufferLimit: envOrDefault(bufferLimitEnv, defaultBufferLimit),
-		resourceID:  os.Getenv(resourceIDEnv),
-		stdout:      stdout,
-		stderr:      stderr,
-		logger:      logger,
+		dataDir:    envOrDefault(dataDirEnv, defaultDataDir),
+		stateRoot:  envOrDefault(stateRootEnv, flags.DefaultStateRoot),
+		logRoot:    envOrDefault(logRootEnv, flags.DefaultLogRoot),
+		resourceID: os.Getenv(resourceIDEnv),
+		stdout:     stdout,
+		stderr:     stderr,
+		logger:     logger,
 	})
 	runtime.alwaysRunStep = envBool(alwaysRunEnv, false, runtime.logger)
 	runtime.writeLogs = envBool(writeLogsEnv, true, runtime.logger)
@@ -251,7 +249,7 @@ func printStartupBanner(output io.Writer, req request, runtime runtimeConfig) er
 		"SKYHOOK_DATA_DIR: " + runtime.dataDir,
 		"SKYHOOK_ROOT_DIR: " + runtime.stateRoot,
 		"SKYHOOK_LOG_DIR: " + runtime.logRoot,
-		"SKYHOOK_AGENT_BUFFER_LIMIT: " + runtime.bufferLimit,
+		"SKYHOOK_AGENT_BUFFER_LIMIT: " + envOrDefault(legacyBufferLimitEnv, defaultLegacyBufferLimit),
 		"SKYHOOK_AGENT_WRITE_LOGS: " + formatLegacyBool(runtime.writeLogs),
 		"Directory CONFIGURATION",
 		"flag_dir: " + filepath.Join(runtime.stateRoot, "flags", cfg.PackageName, cfg.PackageVersion),
@@ -308,9 +306,6 @@ func normalizeRuntime(runtime runtimeConfig) runtimeConfig {
 	if runtime.logRoot == "" {
 		runtime.logRoot = flags.DefaultLogRoot
 	}
-	if runtime.bufferLimit == "" {
-		runtime.bufferLimit = defaultBufferLimit
-	}
 	if runtime.stdout == nil {
 		runtime.stdout = os.Stdout
 	}
@@ -337,7 +332,7 @@ func validateRun(ctx context.Context, req request, runtime runtimeConfig) error 
 		return fmt.Errorf("running agent: data directory %q is not absolute", runtime.dataDir)
 	}
 	if req.stage == stage.Interrupt {
-		if err := validatePathComponent("resource ID", runtime.resourceID); err != nil {
+		if err := hostfs.ValidatePathComponent("resource ID", runtime.resourceID); err != nil {
 			return fmt.Errorf("running agent: %w", err)
 		}
 	}
@@ -360,13 +355,6 @@ func validateRequest(req request) error {
 		}
 	} else if req.interruptData != "" {
 		return fmt.Errorf("stage %q does not accept interrupt data", req.stage)
-	}
-	return nil
-}
-
-func validatePathComponent(name, value string) error {
-	if value == "" || value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
-		return fmt.Errorf("%s %q must be a single path component", name, value)
 	}
 	return nil
 }

--- a/agent/go/internal/agent/agent_test.go
+++ b/agent/go/internal/agent/agent_test.go
@@ -120,7 +120,7 @@ var _ = Describe("runtime environment", func() {
 			dataDirEnv,
 			stateRootEnv,
 			logRootEnv,
-			bufferLimitEnv,
+			legacyBufferLimitEnv,
 			writeLogsEnv,
 		} {
 			unsetEnvironment(name)
@@ -131,7 +131,6 @@ var _ = Describe("runtime environment", func() {
 		Expect(runtime.dataDir).To(Equal(defaultDataDir))
 		Expect(runtime.stateRoot).To(Equal(flags.DefaultStateRoot))
 		Expect(runtime.logRoot).To(Equal(flags.DefaultLogRoot))
-		Expect(runtime.bufferLimit).To(Equal(defaultBufferLimit))
 		Expect(runtime.resourceID).To(BeEmpty())
 		Expect(runtime.alwaysRunStep).To(BeFalse())
 		Expect(runtime.writeLogs).To(BeTrue())
@@ -148,7 +147,6 @@ var _ = Describe("runtime environment", func() {
 		GinkgoT().Setenv(dataDirEnv, "/data")
 		GinkgoT().Setenv(stateRootEnv, "/state")
 		GinkgoT().Setenv(logRootEnv, "/logs")
-		GinkgoT().Setenv(bufferLimitEnv, "4096")
 		GinkgoT().Setenv(writeLogsEnv, "false")
 		stdout := &bytes.Buffer{}
 		stderr := &bytes.Buffer{}
@@ -159,7 +157,6 @@ var _ = Describe("runtime environment", func() {
 		Expect(runtime.dataDir).To(Equal("/data"))
 		Expect(runtime.stateRoot).To(Equal("/state"))
 		Expect(runtime.logRoot).To(Equal("/logs"))
-		Expect(runtime.bufferLimit).To(Equal("4096"))
 		Expect(runtime.resourceID).To(Equal("resource"))
 		Expect(runtime.alwaysRunStep).To(BeTrue())
 		Expect(runtime.writeLogs).To(BeFalse())
@@ -199,6 +196,7 @@ var _ = Describe("Agent.Run", func() {
 		GinkgoT().Setenv(stateRootEnv, "/state")
 		GinkgoT().Setenv(logRootEnv, "/logs")
 		GinkgoT().Setenv(writeLogsEnv, "false")
+		GinkgoT().Setenv(legacyBufferLimitEnv, "4096")
 	})
 
 	It("defines process exit codes", func() {
@@ -240,7 +238,7 @@ var _ = Describe("Agent.Run", func() {
 				"SKYHOOK_DATA_DIR: %s\n"+
 				"SKYHOOK_ROOT_DIR: /state\n"+
 				"SKYHOOK_LOG_DIR: /logs\n"+
-				"SKYHOOK_AGENT_BUFFER_LIMIT: 8192\n"+
+				"SKYHOOK_AGENT_BUFFER_LIMIT: 4096\n"+
 				"SKYHOOK_AGENT_WRITE_LOGS: False\n"+
 				"Directory CONFIGURATION\n"+
 				"flag_dir: /state/flags/package/1.0.0\n"+

--- a/agent/go/internal/agent/agent_test.go
+++ b/agent/go/internal/agent/agent_test.go
@@ -1,0 +1,542 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/interrupts"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAgent(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Agent Suite")
+}
+
+var _ = Describe("request parsing", func() {
+	DescribeTable(
+		"supports current and legacy operator forms",
+		func(arguments []string, expected request) {
+			actual, err := parseRequest(arguments)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(expected))
+		},
+		Entry(
+			"legacy stage",
+			[]string{"apply", "/packages/value"},
+			request{stage: stage.Apply, rootMount: "/root", copyDir: "/packages/value"},
+		),
+		Entry(
+			"legacy interrupt",
+			[]string{"interrupt", "/packages/value", "payload"},
+			request{
+				stage: stage.Interrupt, rootMount: "/root",
+				copyDir: "/packages/value", interruptData: "payload",
+			},
+		),
+		Entry(
+			"current stage",
+			[]string{"apply", "/host", "/packages/value"},
+			request{stage: stage.Apply, rootMount: "/host", copyDir: "/packages/value"},
+		),
+		Entry(
+			"current interrupt",
+			[]string{"interrupt", "/host", "/packages/value", "payload"},
+			request{
+				stage: stage.Interrupt, rootMount: "/host",
+				copyDir: "/packages/value", interruptData: "payload",
+			},
+		),
+	)
+
+	It("identifies stages unknown to this agent version", func() {
+		_, err := parseRequest([]string{"future-stage", "/host", "/package"})
+
+		Expect(err).To(MatchError(`unsupported stage "future-stage"`))
+		var unsupported *unsupportedStageError
+		Expect(errors.As(err, &unsupported)).To(BeTrue())
+		Expect(unsupported.stage).To(Equal("future-stage"))
+	})
+
+	DescribeTable(
+		"rejects malformed requests",
+		func(arguments []string, expected string) {
+			_, err := parseRequest(arguments)
+			Expect(err).To(MatchError(ContainSubstring(expected)))
+		},
+		Entry("argument count", []string{"apply"}, "expected 2, 3, or 4 arguments"),
+		Entry("relative root", []string{"apply", "host", "/package"}, "root mount"),
+		Entry("relative copy directory", []string{"apply", "/host", "package"}, "copy directory"),
+		Entry(
+			"empty interrupt data",
+			[]string{"interrupt", "/host", "/package", ""},
+			"interrupt data must not be empty",
+		),
+		Entry(
+			"interrupt data on a normal stage",
+			[]string{"apply", "/host", "/package", "payload"},
+			`stage "apply" does not accept interrupt data`,
+		),
+	)
+})
+
+var _ = Describe("runtime environment", func() {
+	It("uses documented defaults when environment values are absent", func() {
+		for _, name := range []string{
+			copyResolverEnv,
+			alwaysRunEnv,
+			resourceIDEnv,
+			dataDirEnv,
+			stateRootEnv,
+			logRootEnv,
+			bufferLimitEnv,
+			writeLogsEnv,
+		} {
+			unsetEnvironment(name)
+		}
+
+		runtime := runtimeFromEnvironment(nil, nil, nil)
+
+		Expect(runtime.dataDir).To(Equal(defaultDataDir))
+		Expect(runtime.stateRoot).To(Equal(flags.DefaultStateRoot))
+		Expect(runtime.logRoot).To(Equal(flags.DefaultLogRoot))
+		Expect(runtime.bufferLimit).To(Equal(defaultBufferLimit))
+		Expect(runtime.resourceID).To(BeEmpty())
+		Expect(runtime.alwaysRunStep).To(BeFalse())
+		Expect(runtime.writeLogs).To(BeTrue())
+		Expect(runtime.copyResolver).To(BeTrue())
+		Expect(runtime.stdout).To(Equal(io.Writer(os.Stdout)))
+		Expect(runtime.stderr).To(Equal(io.Writer(os.Stderr)))
+		Expect(runtime.logger).NotTo(BeNil())
+	})
+
+	It("loads configured values and output composition", func() {
+		GinkgoT().Setenv(copyResolverEnv, "false")
+		GinkgoT().Setenv(alwaysRunEnv, "TRUE")
+		GinkgoT().Setenv(resourceIDEnv, "resource")
+		GinkgoT().Setenv(dataDirEnv, "/data")
+		GinkgoT().Setenv(stateRootEnv, "/state")
+		GinkgoT().Setenv(logRootEnv, "/logs")
+		GinkgoT().Setenv(bufferLimitEnv, "4096")
+		GinkgoT().Setenv(writeLogsEnv, "false")
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+		runtime := runtimeFromEnvironment(stdout, stderr, logger)
+
+		Expect(runtime.dataDir).To(Equal("/data"))
+		Expect(runtime.stateRoot).To(Equal("/state"))
+		Expect(runtime.logRoot).To(Equal("/logs"))
+		Expect(runtime.bufferLimit).To(Equal("4096"))
+		Expect(runtime.resourceID).To(Equal("resource"))
+		Expect(runtime.alwaysRunStep).To(BeTrue())
+		Expect(runtime.writeLogs).To(BeFalse())
+		Expect(runtime.copyResolver).To(BeFalse())
+		Expect(runtime.stdout).To(BeIdenticalTo(stdout))
+		Expect(runtime.stderr).To(BeIdenticalTo(stderr))
+		Expect(runtime.logger).To(BeIdenticalTo(logger))
+	})
+
+	It("treats an invalid configured boolean as false and warns", func() {
+		GinkgoT().Setenv(copyResolverEnv, " true ")
+		logOutput := &bytes.Buffer{}
+		logger := slog.New(slog.NewTextHandler(logOutput, nil))
+
+		runtime := runtimeFromEnvironment(io.Discard, io.Discard, logger)
+
+		Expect(runtime.copyResolver).To(BeFalse())
+		Expect(logOutput.String()).To(ContainSubstring(
+			"invalid boolean environment variable; treating it as false",
+		))
+		Expect(logOutput.String()).To(ContainSubstring(copyResolverEnv))
+	})
+
+	It("normalizes empty state and log roots", func() {
+		runtime := normalizeRuntime(runtimeConfig{})
+
+		Expect(runtime.stateRoot).To(Equal(flags.DefaultStateRoot))
+		Expect(runtime.logRoot).To(Equal(flags.DefaultLogRoot))
+	})
+})
+
+var _ = Describe("Agent.Run", func() {
+	BeforeEach(func() {
+		GinkgoT().Setenv(copyResolverEnv, "false")
+		GinkgoT().Setenv(alwaysRunEnv, "false")
+		GinkgoT().Setenv(resourceIDEnv, "resource_package_1.0.0")
+		GinkgoT().Setenv(stateRootEnv, "/state")
+		GinkgoT().Setenv(logRootEnv, "/logs")
+		GinkgoT().Setenv(writeLogsEnv, "false")
+	})
+
+	It("defines process exit codes", func() {
+		Expect(ExitSuccess).To(Equal(ExitCode(0)))
+		Expect(ExitFailure).To(Equal(ExitCode(1)))
+		Expect(ExitUsage).To(Equal(ExitCode(2)))
+	})
+
+	It("runs a valid operator invocation", func() {
+		root := GinkgoT().TempDir()
+		dataDir := GinkgoT().TempDir()
+		writePackageFixture(dataDir, "[]", true)
+		GinkgoT().Setenv(dataDirEnv, dataDir)
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+
+		exitCode := New().Run(
+			context.Background(),
+			[]string{"config", root, "/package"},
+			stdout,
+			stderr,
+		)
+
+		Expect(exitCode).To(Equal(ExitSuccess))
+		Expect(filepath.Join(root, "package", configFileName)).To(BeAnExistingFile())
+		Expect(stderr.String()).NotTo(ContainSubstring("starting agent"))
+		Expect(stdout.String()).To(Equal(fmt.Sprintf(
+			"--------------------\n"+
+				"--CLI CONFIGURATION-\n"+
+				"mode: config\n"+
+				"root_mount: %s\n"+
+				"copy_dir: /package\n"+
+				"interrupt_data: None\n"+
+				"always_run_step: False\n"+
+				"--ENV CONFIGURATION-\n"+
+				"COPY_RESOLV: False\n"+
+				"OVERLAY_ALWAYS_RUN_STEP: False\n"+
+				"SKYHOOK_RESOURCE_ID: resource_package_1.0.0\n"+
+				"SKYHOOK_DATA_DIR: %s\n"+
+				"SKYHOOK_ROOT_DIR: /state\n"+
+				"SKYHOOK_LOG_DIR: /logs\n"+
+				"SKYHOOK_AGENT_BUFFER_LIMIT: 8192\n"+
+				"SKYHOOK_AGENT_WRITE_LOGS: False\n"+
+				"Directory CONFIGURATION\n"+
+				"flag_dir: /state/flags/package/1.0.0\n"+
+				"log_dir: /logs/package/1.0.0\n"+
+				"history_file: /state/history/package.json\n"+
+				"--------------------\n",
+			root,
+			dataDir,
+		)))
+	})
+
+	It("treats an unsupported stage as a successful no-op", func() {
+		stderr := &bytes.Buffer{}
+
+		exitCode := New().Run(
+			context.Background(),
+			[]string{"future-stage", "/host", "/package"},
+			io.Discard,
+			stderr,
+		)
+
+		Expect(exitCode).To(Equal(ExitSuccess))
+		Expect(stderr.String()).To(ContainSubstring("does not support the requested stage"))
+	})
+
+	It("returns a usage exit code for an invalid invocation", func() {
+		stderr := &bytes.Buffer{}
+
+		exitCode := New().Run(context.Background(), []string{"apply"}, io.Discard, stderr)
+
+		Expect(exitCode).To(Equal(ExitUsage))
+		Expect(stderr.String()).To(ContainSubstring("expected 2, 3, or 4 arguments"))
+		Expect(stderr.String()).To(ContainSubstring(usage))
+	})
+
+	It("returns a failure exit code when execution fails", func() {
+		root := GinkgoT().TempDir()
+		GinkgoT().Setenv(dataDirEnv, filepath.Join(root, "missing"))
+		stderr := &bytes.Buffer{}
+
+		exitCode := New().Run(
+			context.Background(),
+			[]string{"apply", root, "/package"},
+			io.Discard,
+			stderr,
+		)
+
+		Expect(exitCode).To(Equal(ExitFailure))
+		Expect(stderr.String()).To(ContainSubstring("agent execution failed"))
+	})
+
+	It("returns a failure exit code when execution is canceled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		stderr := &bytes.Buffer{}
+
+		exitCode := New().Run(
+			ctx,
+			[]string{"apply", GinkgoT().TempDir(), "/package"},
+			io.Discard,
+			stderr,
+		)
+
+		Expect(exitCode).To(Equal(ExitFailure))
+		Expect(stderr.String()).To(ContainSubstring("agent stopped after receiving a termination signal"))
+	})
+
+	It("cancels an active step and does not start the next step", func() {
+		root := GinkgoT().TempDir()
+		dataDir := GinkgoT().TempDir()
+		writeCancellationPackageFixture(dataDir)
+		GinkgoT().Setenv(dataDirEnv, dataDir)
+		GinkgoT().Setenv("NODEWRIGHT_AGENT_TEST_MARKER_DIR", filepath.Join(root, "package"))
+		stderr := &bytes.Buffer{}
+		ctx, cancel := context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+		exitCodes := make(chan ExitCode, 1)
+		var earlyExit error
+
+		go func() {
+			exitCodes <- New().Run(
+				ctx,
+				[]string{"apply", root, "/package"},
+				io.Discard,
+				stderr,
+			)
+		}()
+
+		firstStarted := filepath.Join(root, "package", "first-started")
+		Eventually(func() error {
+			if _, err := os.Stat(firstStarted); err == nil {
+				return nil
+			} else if !errors.Is(err, os.ErrNotExist) {
+				return err
+			}
+			if earlyExit == nil {
+				select {
+				case exitCode := <-exitCodes:
+					earlyExit = fmt.Errorf(
+						"agent exited with code %d before the first step started: %s",
+						exitCode,
+						stderr,
+					)
+				default:
+				}
+			}
+			if earlyExit != nil {
+				return earlyExit
+			}
+			return errors.New("first step has not started")
+		}).WithTimeout(5 * time.Second).Should(Succeed())
+		cancel()
+
+		var exitCode ExitCode
+		Eventually(exitCodes).WithTimeout(5 * time.Second).Should(Receive(&exitCode))
+		Expect(exitCode).To(Equal(ExitFailure))
+		Expect(filepath.Join(root, "package", "first-finished")).NotTo(BeAnExistingFile())
+		Expect(filepath.Join(root, "package", "second-started")).NotTo(BeAnExistingFile())
+		Expect(stderr.String()).To(ContainSubstring("agent stopped after receiving a termination signal"))
+	})
+})
+
+var _ = Describe("request orchestration", func() {
+	It("copies legacy package data before running a stage", func() {
+		root := GinkgoT().TempDir()
+		dataDir := GinkgoT().TempDir()
+		writePackageFixture(dataDir, "[]", true)
+		_, resolverErr := os.Stat("/etc/resolv.conf")
+		copyResolver := resolverErr == nil
+		if resolverErr != nil && !errors.Is(resolverErr, os.ErrNotExist) {
+			Expect(resolverErr).NotTo(HaveOccurred())
+		}
+		runtime := runtimeConfig{
+			dataDir:      dataDir,
+			stateRoot:    "/state",
+			logRoot:      "/logs",
+			copyResolver: copyResolver,
+			writeLogs:    false,
+			stdout:       io.Discard,
+			stderr:       io.Discard,
+			logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		status, err := orchestrator{}.runRequest(context.Background(), request{
+			stage:     stage.Config,
+			rootMount: root,
+			copyDir:   "/package",
+		}, runtime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(root, "package", configFileName)).To(BeAnExistingFile())
+		if copyResolver {
+			Expect(filepath.Join(root, "etc", "resolv.conf")).To(BeAnExistingFile())
+		}
+		Expect(filepath.Join(root, "state", "flags", startFlagName)).To(BeAnExistingFile())
+	})
+
+	It("does not apply host preparation requirements during uninstall", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		writePackageFixture(copyRoot, `["missing"]`, true)
+		Expect(os.Mkdir(filepath.Join(copyRoot, rootOverlayDirName), 0o755)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(copyRoot, rootOverlayDirName, "should-not-copy"),
+			[]byte("value"),
+			0o600,
+		)).To(Succeed())
+		runtime := runtimeConfig{
+			stateRoot: "/state",
+			logRoot:   "/logs",
+			writeLogs: false,
+			stdout:    io.Discard,
+			stderr:    io.Discard,
+			logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		status, err := orchestrator{}.runRequest(context.Background(), request{
+			stage:     stage.Uninstall,
+			rootMount: root,
+			copyDir:   "/package",
+		}, runtime)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(root, "should-not-copy")).NotTo(BeAnExistingFile())
+	})
+
+	It("runs an encoded interrupt through the Agent interface", func() {
+		root := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(root, "package"), 0o755)).To(Succeed())
+		encoded, err := interrupts.Encode(interrupts.NoOp{})
+		Expect(err).NotTo(HaveOccurred())
+
+		status, err := orchestrator{}.runRequest(
+			context.Background(),
+			request{
+				stage:         stage.Interrupt,
+				rootMount:     root,
+				copyDir:       "/package",
+				interruptData: encoded,
+			},
+			runtimeConfig{
+				stateRoot:  "/state",
+				logRoot:    "/logs",
+				resourceID: "resource_package_1.0.0",
+				stdout:     io.Discard,
+				stderr:     io.Discard,
+				logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+			},
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(
+			root,
+			"state",
+			interruptsDirName,
+			interruptFlagsDirName,
+			"resource_package_1.0.0",
+			"no_op.complete",
+		)).To(BeAnExistingFile())
+	})
+})
+
+func writePackageFixture(directory, expectedConfigFiles string, onHost bool) {
+	Expect(os.MkdirAll(filepath.Join(directory, "skyhook_dir"), 0o755)).To(Succeed())
+	for _, name := range []string{"apply", "second", "apply-check"} {
+		Expect(os.WriteFile(filepath.Join(directory, "skyhook_dir", name), nil, 0o700)).To(Succeed())
+	}
+	data := fmt.Sprintf(`{
+		"schema_version": "v1",
+		"root_dir": "/",
+		"expected_config_files": %s,
+		"package_name": "package",
+		"package_version": "1.0.0",
+		"modes": {
+			"apply": [
+				{
+					"name": "apply",
+					"path": "apply",
+					"arguments": [],
+					"returncodes": [0],
+					"on_host": %t,
+					"idempotence": false,
+					"upgrade_step": false
+				},
+				{
+					"name": "second",
+					"path": "second",
+					"arguments": [],
+					"returncodes": [0],
+					"on_host": %t,
+					"idempotence": false,
+					"upgrade_step": false
+				}
+			],
+			"apply-check": [
+				{
+					"name": "apply-check",
+					"path": "apply-check",
+					"arguments": [],
+					"returncodes": [0],
+					"on_host": %t,
+					"idempotence": false,
+					"upgrade_step": false
+				}
+			]
+		}
+	}`, expectedConfigFiles, onHost, onHost, onHost)
+	Expect(os.WriteFile(filepath.Join(directory, configFileName), []byte(data), 0o600)).To(Succeed())
+}
+
+func writeCancellationPackageFixture(directory string) {
+	writePackageFixture(directory, "[]", false)
+	stepsDir := filepath.Join(directory, "skyhook_dir")
+	Expect(os.WriteFile(
+		filepath.Join(stepsDir, "apply"),
+		[]byte("#!/bin/sh\n: > \"$NODEWRIGHT_AGENT_TEST_MARKER_DIR/first-started\"\nsleep 3600\n: > \"$NODEWRIGHT_AGENT_TEST_MARKER_DIR/first-finished\"\n"),
+		0o700,
+	)).To(Succeed())
+	Expect(os.WriteFile(
+		filepath.Join(stepsDir, "second"),
+		[]byte("#!/bin/sh\n: > \"$NODEWRIGHT_AGENT_TEST_MARKER_DIR/second-started\"\n"),
+		0o700,
+	)).To(Succeed())
+}
+
+func unsetEnvironment(name string) {
+	value, exists := os.LookupEnv(name)
+	Expect(os.Unsetenv(name)).To(Succeed())
+	DeferCleanup(func() {
+		if exists {
+			Expect(os.Setenv(name, value)).To(Succeed())
+			return
+		}
+		Expect(os.Unsetenv(name)).To(Succeed())
+	})
+}

--- a/agent/go/internal/agent/interrupt.go
+++ b/agent/go/internal/agent/interrupt.go
@@ -1,0 +1,374 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
+	"github.com/NVIDIA/nodewright/agent/internal/interrupts"
+)
+
+const (
+	interruptsDirName     = "interrupts"
+	interruptFlagsDirName = "flags"
+	markerFileMode        = 0o600
+	hostBootIDPath        = "/proc/sys/kernel/random/boot_id"
+	restartMarkerPrefix   = "boot-id:"
+)
+
+func runDecodedInterrupt(
+	ctx context.Context,
+	req request,
+	runtime runtimeConfig,
+	layout flags.Layout,
+) (execution.Status, error) {
+	value, err := interrupts.Decode(req.interruptData)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("decoding interrupt: %w", err)
+	}
+	return runInterrupt(ctx, req, runtime, layout, value)
+}
+
+func runInterrupt(
+	ctx context.Context,
+	req request,
+	runtime runtimeConfig,
+	layout flags.Layout,
+	value interrupts.Interrupt,
+) (status execution.Status, retErr error) {
+	interruptType := value.Type()
+	completeMarkers := interruptCompletionMarkers(layout, runtime.resourceID, value)
+	completedOperations, err := completedInterruptOperations(req.rootMount, completeMarkers)
+	if err != nil {
+		return execution.StatusFailed, err
+	}
+	if len(completedOperations) > 0 && allOperationsComplete(completedOperations) {
+		runtime.logger.Info(
+			"skipping completed interrupt",
+			"interrupt", interruptType,
+			"resourceID", runtime.resourceID,
+		)
+		return execution.StatusSuccess, nil
+	}
+
+	pendingMarker := ""
+	retainPendingMarker := false
+	if interruptType == interrupts.NodeRestartType {
+		var completed bool
+		pendingMarker, completed, err = prepareNodeRestartMarker(req, runtime, completeMarkers[0])
+		if err != nil {
+			return execution.StatusFailed, err
+		}
+		if completed {
+			runtime.logger.Info(
+				"skipping completed interrupt after host reboot",
+				"interrupt", interruptType,
+				"resourceID", runtime.resourceID,
+			)
+			return execution.StatusSuccess, nil
+		}
+	}
+
+	defer func() {
+		if pendingMarker == "" || retainPendingMarker {
+			return
+		}
+		if err := hostfs.RemoveFile(req.rootMount, pendingMarker); err != nil {
+			status = execution.StatusFailed
+			retErr = errors.Join(
+				retErr,
+				fmt.Errorf("removing failed node restart marker: %w", err),
+			)
+		}
+	}()
+
+	stdout, stderr := runtime.stdout, runtime.stderr
+	closeLog := func() error { return nil }
+	closeLogErr := func() error {
+		if err := closeLog(); err != nil {
+			return fmt.Errorf("closing interrupt log: %w", err)
+		}
+		return nil
+	}
+	var logFiles flags.LogFiles
+	if runtime.writeLogs {
+		logConfig, err := configFromResourceID(runtime.resourceID)
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf("resolving interrupt log identity: %w", err)
+		}
+		logName := filepath.Join(interruptsDirName, string(interruptType))
+		_, file, err := layout.CreateLogFile(logConfig, logName, time.Now(), logFileMode)
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf("preparing log for interrupt %q: %w", interruptType, err)
+		}
+		stdout = io.MultiWriter(stdout, file)
+		stderr = io.MultiWriter(stderr, file)
+		closeLog = file.Close
+		logFiles, err = layout.LogFilePattern(logConfig, logName)
+		if err != nil {
+			return execution.StatusFailed, errors.Join(
+				fmt.Errorf("resolving log retention for interrupt %q: %w", interruptType, err),
+				closeLogErr(),
+			)
+		}
+	}
+
+	runConfig, err := execution.NewConfig(
+		execution.WithRootMount(req.rootMount),
+		execution.WithStepRoot(flags.StepsDir(req.copyDir)),
+		execution.WithSkyhookDir(req.copyDir),
+		execution.WithRunOutput(stdout, stderr),
+	)
+	if err != nil {
+		return execution.StatusFailed, errors.Join(
+			fmt.Errorf("configuring interrupt %q execution: %w", interruptType, err),
+			closeLogErr(),
+		)
+	}
+	if interruptType == interrupts.NodeRestartType {
+		// A successful reboot can terminate the agent by several signal paths.
+		// Keep the pending marker once execution begins and decide completion by
+		// comparing host boot IDs on the next invocation.
+		retainPendingMarker = true
+	}
+	status, runErr := executeInterrupt(
+		ctx,
+		req.rootMount,
+		value,
+		runConfig,
+		completedOperations,
+		completeMarkers,
+	)
+	closeErr := closeLogErr()
+	var cleanupErr error
+	if runtime.writeLogs {
+		cleanupErr = flags.CleanupOldLogs(logFiles, flags.DefaultLogRetention)
+	}
+	if runErr != nil || closeErr != nil || cleanupErr != nil {
+		if runErr != nil {
+			runErr = fmt.Errorf("running interrupt %q: %w", interruptType, runErr)
+		}
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("cleaning old interrupt logs: %w", cleanupErr)
+		}
+		return execution.StatusFailed, errors.Join(
+			runErr,
+			closeErr,
+			cleanupErr,
+		)
+	}
+	if status != execution.StatusSuccess {
+		return execution.StatusFailed, nil
+	}
+
+	return execution.StatusSuccess, nil
+}
+
+func executeInterrupt(
+	ctx context.Context,
+	rootMount string,
+	value interrupts.Interrupt,
+	runConfig execution.Config,
+	completedOperations []bool,
+	completeMarkers []string,
+) (execution.Status, error) {
+	if resumable, ok := value.(interrupts.ResumableInterrupt); ok {
+		return resumable.RunPending(
+			ctx,
+			runConfig,
+			completedOperations,
+			func(index int) error {
+				if index < 0 || index >= len(completeMarkers) {
+					return fmt.Errorf("interrupt operation index %d is out of range", index)
+				}
+				return markInterruptComplete(rootMount, completeMarkers[index])
+			},
+		)
+	}
+
+	status, err := value.Run(ctx, runConfig)
+	if err != nil || status != execution.StatusSuccess ||
+		value.Type() == interrupts.NodeRestartType || len(completeMarkers) == 0 {
+		return status, err
+	}
+	for index, completed := range completedOperations {
+		if completed {
+			continue
+		}
+		if err := markInterruptComplete(rootMount, completeMarkers[index]); err != nil {
+			return status, fmt.Errorf("marking interrupt %q complete: %w", value.Type(), err)
+		}
+	}
+	return status, nil
+}
+
+func interruptCompletionMarkers(
+	layout flags.Layout,
+	resourceID string,
+	value interrupts.Interrupt,
+) []string {
+	interruptType := value.Type()
+	baseDirectory := filepath.Join(
+		layout.StateDir(),
+		interruptsDirName,
+		interruptFlagsDirName,
+		resourceID,
+	)
+	if interruptType == interrupts.ScriptInterruptType {
+		return nil
+	}
+	if interruptType == interrupts.NoOpType {
+		return []string{filepath.Join(baseDirectory, string(interruptType)+".complete")}
+	}
+	operationCount := 1
+	if resumable, ok := value.(interrupts.ResumableInterrupt); ok {
+		operationCount = resumable.OperationCount()
+	}
+	markers := make([]string, operationCount)
+	for index := range operationCount {
+		markers[index] = filepath.Join(
+			baseDirectory,
+			fmt.Sprintf("%s_%d.complete", interruptType, index),
+		)
+	}
+	return markers
+}
+
+func completedInterruptOperations(rootMount string, markers []string) ([]bool, error) {
+	completed := make([]bool, len(markers))
+	for index, marker := range markers {
+		exists, err := hostfs.RegularFileExists(rootMount, marker)
+		if err != nil {
+			return nil, fmt.Errorf("checking interrupt completion marker %q: %w", marker, err)
+		}
+		completed[index] = exists
+	}
+	return completed, nil
+}
+
+func allOperationsComplete(completed []bool) bool {
+	for _, value := range completed {
+		if !value {
+			return false
+		}
+	}
+	return true
+}
+
+func markInterruptComplete(rootMount, marker string) error {
+	return hostfs.CreateFile(
+		rootMount,
+		marker,
+		[]byte(time.Now().UTC().Format(time.RFC3339Nano)),
+		markerFileMode,
+	)
+}
+
+func prepareNodeRestartMarker(
+	req request,
+	runtime runtimeConfig,
+	completeMarker string,
+) (string, bool, error) {
+	bootID, err := hostBootID(req.rootMount)
+	if err != nil {
+		return "", false, fmt.Errorf("reading host boot ID: %w", err)
+	}
+	pendingMarker := strings.TrimSuffix(completeMarker, ".complete") + ".pending"
+	pending, err := hostfs.RegularFileExists(req.rootMount, pendingMarker)
+	if err != nil {
+		return "", false, fmt.Errorf("checking pending node restart: %w", err)
+	}
+	if pending {
+		data, err := hostfs.ReadFile(req.rootMount, pendingMarker)
+		if err != nil {
+			return "", false, fmt.Errorf("reading pending node restart: %w", err)
+		}
+		previousBootID, valid := strings.CutPrefix(strings.TrimSpace(string(data)), restartMarkerPrefix)
+		if valid && previousBootID != "" && previousBootID != bootID {
+			if err := hostfs.RenameFile(req.rootMount, pendingMarker, completeMarker); err != nil {
+				return "", false, fmt.Errorf("completing node restart marker: %w", err)
+			}
+			return pendingMarker, true, nil
+		}
+		if !valid || previousBootID == "" {
+			runtime.logger.Warn(
+				"discarding malformed pending node restart marker",
+				"resourceID", runtime.resourceID,
+			)
+		}
+		if err := hostfs.RemoveFile(req.rootMount, pendingMarker); err != nil {
+			return "", false, fmt.Errorf("removing stale node restart marker: %w", err)
+		}
+	}
+	if err := hostfs.CreateFile(
+		req.rootMount,
+		pendingMarker,
+		[]byte(restartMarkerPrefix+bootID+"\n"),
+		markerFileMode,
+	); err != nil {
+		return "", false, fmt.Errorf("marking node restart pending: %w", err)
+	}
+	return pendingMarker, false, nil
+}
+
+func hostBootID(rootMount string) (string, error) {
+	path, err := hostfs.HostPathToMounted(rootMount, hostBootIDPath)
+	if err != nil {
+		return "", err
+	}
+	data, err := hostfs.ReadFile(rootMount, path)
+	if err != nil {
+		return "", err
+	}
+	bootID := strings.TrimSpace(string(data))
+	if bootID == "" {
+		return "", errors.New("host boot ID is empty")
+	}
+	return bootID, nil
+}
+
+func configFromResourceID(resourceID string) (config.Config, error) {
+	versionSeparator := strings.LastIndex(resourceID, "_")
+	if versionSeparator <= 0 || versionSeparator == len(resourceID)-1 {
+		return config.Config{}, fmt.Errorf("resource ID %q must end in _PACKAGE_VERSION", resourceID)
+	}
+	packageSeparator := strings.Index(resourceID[:versionSeparator], "_")
+	if packageSeparator <= 0 || packageSeparator == versionSeparator-1 {
+		return config.Config{}, fmt.Errorf("resource ID %q must end in _PACKAGE_VERSION", resourceID)
+	}
+	packageName := resourceID[packageSeparator+1 : versionSeparator]
+	packageVersion := resourceID[versionSeparator+1:]
+	if err := validatePathComponent("package name", packageName); err != nil {
+		return config.Config{}, err
+	}
+	if err := validatePathComponent("package version", packageVersion); err != nil {
+		return config.Config{}, err
+	}
+	return config.Config{PackageName: packageName, PackageVersion: packageVersion}, nil
+}

--- a/agent/go/internal/agent/interrupt.go
+++ b/agent/go/internal/agent/interrupt.go
@@ -22,7 +22,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
 	"path/filepath"
 	"strings"
 	"time"
@@ -108,47 +107,35 @@ func runInterrupt(
 		}
 	}()
 
-	stdout, stderr := runtime.stdout, runtime.stderr
-	closeLog := func() error { return nil }
-	closeLogErr := func() error {
-		if err := closeLog(); err != nil {
-			return fmt.Errorf("closing interrupt log: %w", err)
-		}
-		return nil
-	}
-	var logFiles flags.LogFiles
+	logConfig := config.Config{}
 	if runtime.writeLogs {
-		logConfig, err := configFromResourceID(runtime.resourceID)
+		logConfig, err = configFromResourceID(runtime.resourceID)
 		if err != nil {
 			return execution.StatusFailed, fmt.Errorf("resolving interrupt log identity: %w", err)
 		}
-		logName := filepath.Join(interruptsDirName, string(interruptType))
-		_, file, err := layout.CreateLogFile(logConfig, logName, time.Now(), logFileMode)
-		if err != nil {
-			return execution.StatusFailed, fmt.Errorf("preparing log for interrupt %q: %w", interruptType, err)
-		}
-		stdout = io.MultiWriter(stdout, file)
-		stderr = io.MultiWriter(stderr, file)
-		closeLog = file.Close
-		logFiles, err = layout.LogFilePattern(logConfig, logName)
-		if err != nil {
-			return execution.StatusFailed, errors.Join(
-				fmt.Errorf("resolving log retention for interrupt %q: %w", interruptType, err),
-				closeLogErr(),
-			)
-		}
+	}
+	logName := filepath.Join(interruptsDirName, string(interruptType))
+	operationLog, err := prepareOperationLog(
+		runtime,
+		layout,
+		logConfig,
+		logName,
+		fmt.Sprintf("interrupt %q", interruptType),
+	)
+	if err != nil {
+		return execution.StatusFailed, err
 	}
 
 	runConfig, err := execution.NewConfig(
 		execution.WithRootMount(req.rootMount),
 		execution.WithStepRoot(flags.StepsDir(req.copyDir)),
 		execution.WithSkyhookDir(req.copyDir),
-		execution.WithRunOutput(stdout, stderr),
+		execution.WithRunOutput(operationLog.stdout, operationLog.stderr),
 	)
 	if err != nil {
 		return execution.StatusFailed, errors.Join(
 			fmt.Errorf("configuring interrupt %q execution: %w", interruptType, err),
-			closeLogErr(),
+			operationLog.finalize(),
 		)
 	}
 	if interruptType == interrupts.NodeRestartType {
@@ -165,22 +152,14 @@ func runInterrupt(
 		completedOperations,
 		completeMarkers,
 	)
-	closeErr := closeLogErr()
-	var cleanupErr error
-	if runtime.writeLogs {
-		cleanupErr = flags.CleanupOldLogs(logFiles, flags.DefaultLogRetention)
-	}
-	if runErr != nil || closeErr != nil || cleanupErr != nil {
+	finalizeErr := operationLog.finalize()
+	if runErr != nil || finalizeErr != nil {
 		if runErr != nil {
 			runErr = fmt.Errorf("running interrupt %q: %w", interruptType, runErr)
 		}
-		if cleanupErr != nil {
-			cleanupErr = fmt.Errorf("cleaning old interrupt logs: %w", cleanupErr)
-		}
 		return execution.StatusFailed, errors.Join(
 			runErr,
-			closeErr,
-			cleanupErr,
+			finalizeErr,
 		)
 	}
 	if status != execution.StatusSuccess {
@@ -364,10 +343,10 @@ func configFromResourceID(resourceID string) (config.Config, error) {
 	}
 	packageName := resourceID[packageSeparator+1 : versionSeparator]
 	packageVersion := resourceID[versionSeparator+1:]
-	if err := validatePathComponent("package name", packageName); err != nil {
+	if err := hostfs.ValidatePathComponent("package name", packageName); err != nil {
 		return config.Config{}, err
 	}
-	if err := validatePathComponent("package version", packageVersion); err != nil {
+	if err := hostfs.ValidatePathComponent("package version", packageVersion); err != nil {
 		return config.Config{}, err
 	}
 	return config.Config{PackageName: packageName, PackageVersion: packageVersion}, nil

--- a/agent/go/internal/agent/interrupt_test.go
+++ b/agent/go/internal/agent/interrupt_test.go
@@ -1,0 +1,347 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/interrupts"
+	interruptsmock "github.com/NVIDIA/nodewright/agent/internal/interrupts/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+)
+
+type resumableTestInterrupt struct {
+	operationCount int
+	runPending     func([]bool, func(int) error) (execution.Status, error)
+}
+
+func (r *resumableTestInterrupt) Type() interrupts.InterruptType {
+	return interrupts.ServiceRestartType
+}
+
+func (r *resumableTestInterrupt) Run(
+	context.Context,
+	execution.Config,
+) (execution.Status, error) {
+	return execution.StatusFailed, errors.New("unexpected non-resumable interrupt execution")
+}
+
+func (r *resumableTestInterrupt) Serialize() ([]byte, error) { return nil, nil }
+
+func (r *resumableTestInterrupt) OperationCount() int { return r.operationCount }
+
+func (r *resumableTestInterrupt) RunPending(
+	_ context.Context,
+	_ execution.Config,
+	completed []bool,
+	markCompleted func(int) error,
+) (execution.Status, error) {
+	return r.runPending(completed, markCompleted)
+}
+
+func newMockInterrupt(
+	interruptType interrupts.InterruptType,
+	status execution.Status,
+) *interruptsmock.MockInterrupt {
+	value := interruptsmock.NewMockInterrupt(GinkgoT())
+	value.EXPECT().Type().Return(interruptType).Maybe()
+	value.EXPECT().
+		Run(mock.Anything, mock.Anything).
+		Return(status, nil).
+		Once()
+	return value
+}
+
+var _ = Describe("interrupt orchestration", func() {
+	It("preserves underscores in package names parsed from resource IDs", func() {
+		cfg, err := configFromResourceID("nodewright-uid-1_package_with_underscores_1.2.3")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg).To(Equal(config.Config{
+			PackageName:    "package_with_underscores",
+			PackageVersion: "1.2.3",
+		}))
+	})
+
+	It("marks a successful interrupt and skips it on the next invocation", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			writeLogs:  true,
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		value := newMockInterrupt(interrupts.NoOpType, execution.StatusSuccess)
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		status, err = runInterrupt(context.Background(), req, runtime, layout, value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "no_op.complete",
+		)).To(BeAnExistingFile())
+		logEntries, err := os.ReadDir(filepath.Join(
+			layout.LogDir(), "package", "1.0.0", interruptsDirName,
+		))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(logEntries).To(HaveLen(1))
+	})
+
+	It("does not expose an ordinary interrupt as complete while it is running", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		marker := filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "service_restart_0.complete",
+		)
+		value := interruptsmock.NewMockInterrupt(GinkgoT())
+		value.EXPECT().Type().Return(interrupts.ServiceRestartType).Maybe()
+		value.EXPECT().Run(mock.Anything, mock.Anything).
+			Run(func(context.Context, execution.Config) {
+				Expect(marker).NotTo(BeAnExistingFile())
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(marker).To(BeAnExistingFile())
+	})
+
+	It("does not mark a failed ordinary interrupt complete", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		value := newMockInterrupt(interrupts.ServiceRestartType, execution.StatusFailed)
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "service_restart_0.complete",
+		)).NotTo(BeAnExistingFile())
+	})
+
+	It("recognizes legacy interrupt completion markers", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		marker := filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "service_restart_0.complete",
+		)
+		Expect(os.MkdirAll(filepath.Dir(marker), 0o755)).To(Succeed())
+		Expect(os.WriteFile(marker, nil, 0o600)).To(Succeed())
+		value := interruptsmock.NewMockInterrupt(GinkgoT())
+		value.EXPECT().Type().Return(interrupts.ServiceRestartType).Maybe()
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+
+	It("resumes multi-command interrupts from indexed legacy markers", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		markerDirectory := filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName, runtime.resourceID,
+		)
+		Expect(os.MkdirAll(markerDirectory, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(markerDirectory, "service_restart_0.complete"), nil, 0o600)).To(Succeed())
+		value := &resumableTestInterrupt{operationCount: 3}
+		value.runPending = func(completed []bool, markCompleted func(int) error) (execution.Status, error) {
+			Expect(completed).To(Equal([]bool{true, false, false}))
+			Expect(markCompleted(1)).To(Succeed())
+			return execution.StatusFailed, nil
+		}
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(filepath.Join(markerDirectory, "service_restart_1.complete")).To(BeAnExistingFile())
+		Expect(filepath.Join(markerDirectory, "service_restart_2.complete")).NotTo(BeAnExistingFile())
+
+		value.runPending = func(completed []bool, markCompleted func(int) error) (execution.Status, error) {
+			Expect(completed).To(Equal([]bool{true, true, false}))
+			Expect(markCompleted(2)).To(Succeed())
+			return execution.StatusSuccess, nil
+		}
+		status, err = runInterrupt(context.Background(), req, runtime, layout, value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(markerDirectory, "service_restart_2.complete")).To(BeAnExistingFile())
+	})
+
+	It("retains interrupt completion when log cleanup fails", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			writeLogs:  true,
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		logDirectory := filepath.Join(layout.LogDir(), "package", "1.0.0", interruptsDirName)
+		savedLogDirectory := logDirectory + "-saved"
+		outside := GinkgoT().TempDir()
+		value := interruptsmock.NewMockInterrupt(GinkgoT())
+		value.EXPECT().Type().Return(interrupts.ServiceRestartType).Maybe()
+		value.EXPECT().Run(mock.Anything, mock.Anything).
+			Run(func(context.Context, execution.Config) {
+				Expect(os.Rename(logDirectory, savedLogDirectory)).To(Succeed())
+				Expect(os.Symlink(outside, logDirectory)).To(Succeed())
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
+
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(err).To(MatchError(ContainSubstring("cleaning old interrupt logs")))
+		marker := filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "service_restart_0.complete",
+		)
+		Expect(marker).To(BeAnExistingFile())
+		status, err = runInterrupt(context.Background(), req, runtime, layout, value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+
+	It("retries a canceled node restart until the host boot ID changes", func() {
+		root := GinkgoT().TempDir()
+		bootIDPath := filepath.Join(root, "proc", "sys", "kernel", "random", "boot_id")
+		Expect(os.MkdirAll(filepath.Dir(bootIDPath), 0o755)).To(Succeed())
+		Expect(os.WriteFile(bootIDPath, []byte("boot-a\n"), 0o600)).To(Succeed())
+		layout := flags.DefaultLayout(root)
+		req := request{rootMount: root, copyDir: "/package"}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		markerBase := filepath.Join(
+			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
+			runtime.resourceID, "node_restart_0",
+		)
+		pendingMarker := markerBase + ".pending"
+		completeMarker := markerBase + ".complete"
+		canceled := interruptsmock.NewMockInterrupt(GinkgoT())
+		canceled.EXPECT().Type().Return(interrupts.NodeRestartType).Maybe()
+		canceled.EXPECT().Run(mock.Anything, mock.Anything).
+			Return(execution.StatusFailed, context.Canceled).
+			Once()
+
+		status, err := runInterrupt(context.Background(), req, runtime, layout, canceled)
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+		Expect(pendingMarker).To(BeAnExistingFile())
+		Expect(completeMarker).NotTo(BeAnExistingFile())
+
+		retried := newMockInterrupt(interrupts.NodeRestartType, execution.StatusSuccess)
+		status, err = runInterrupt(context.Background(), req, runtime, layout, retried)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(pendingMarker).To(BeAnExistingFile())
+		Expect(completeMarker).NotTo(BeAnExistingFile())
+
+		Expect(os.WriteFile(bootIDPath, []byte("boot-b\n"), 0o600)).To(Succeed())
+		completed := interruptsmock.NewMockInterrupt(GinkgoT())
+		completed.EXPECT().Type().Return(interrupts.NodeRestartType).Maybe()
+		status, err = runInterrupt(context.Background(), req, runtime, layout, completed)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(pendingMarker).NotTo(BeAnExistingFile())
+		Expect(completeMarker).To(BeAnExistingFile())
+	})
+
+	It("decodes the operator wire payload before running an interrupt", func() {
+		root := GinkgoT().TempDir()
+		layout := flags.DefaultLayout(root)
+		encoded, err := interrupts.Encode(interrupts.NoOp{})
+		Expect(err).NotTo(HaveOccurred())
+		req := request{
+			rootMount:     root,
+			copyDir:       "/package",
+			interruptData: encoded,
+		}
+		runtime := runtimeConfig{
+			resourceID: "resource_package_1.0.0",
+			stdout:     io.Discard,
+			stderr:     io.Discard,
+			logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+
+		status, err := runDecodedInterrupt(context.Background(), req, runtime, layout)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+})

--- a/agent/go/internal/agent/interrupt_test.go
+++ b/agent/go/internal/agent/interrupt_test.go
@@ -263,7 +263,7 @@ var _ = Describe("interrupt orchestration", func() {
 		status, err := runInterrupt(context.Background(), req, runtime, layout, value)
 
 		Expect(status).To(Equal(execution.StatusFailed))
-		Expect(err).To(MatchError(ContainSubstring("cleaning old interrupt logs")))
+		Expect(err).To(MatchError(ContainSubstring("cleaning old logs for interrupt")))
 		marker := filepath.Join(
 			layout.StateDir(), interruptsDirName, interruptFlagsDirName,
 			runtime.resourceID, "service_restart_0.complete",

--- a/agent/go/internal/agent/log.go
+++ b/agent/go/internal/agent/log.go
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+)
+
+const logFileMode = 0o600
+
+type operationLog struct {
+	stdout    io.Writer
+	stderr    io.Writer
+	close     func() error
+	files     flags.LogFiles
+	operation string
+	retained  bool
+}
+
+func prepareOperationLog(
+	runtime runtimeConfig,
+	layout flags.Layout,
+	cfg config.Config,
+	logPath string,
+	operation string,
+) (operationLog, error) {
+	prepared := operationLog{
+		stdout:    runtime.stdout,
+		stderr:    runtime.stderr,
+		close:     func() error { return nil },
+		operation: operation,
+		retained:  runtime.writeLogs,
+	}
+	if !runtime.writeLogs {
+		return prepared, nil
+	}
+
+	_, file, err := layout.CreateLogFile(cfg, logPath, time.Now(), logFileMode)
+	if err != nil {
+		return operationLog{}, fmt.Errorf("preparing log for %s: %w", operation, err)
+	}
+	prepared.stdout = io.MultiWriter(runtime.stdout, file)
+	prepared.stderr = io.MultiWriter(runtime.stderr, file)
+	prepared.close = file.Close
+	prepared.files, err = layout.LogFilePattern(cfg, logPath)
+	if err != nil {
+		return operationLog{}, errors.Join(
+			fmt.Errorf("resolving log retention for %s: %w", operation, err),
+			prepared.closeLog(),
+		)
+	}
+	return prepared, nil
+}
+
+func (log operationLog) finalize() error {
+	closeErr := log.closeLog()
+	var cleanupErr error
+	if log.retained {
+		cleanupErr = flags.CleanupOldLogs(log.files, flags.DefaultLogRetention)
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("cleaning old logs for %s: %w", log.operation, cleanupErr)
+		}
+	}
+	return errors.Join(closeErr, cleanupErr)
+}
+
+func (log operationLog) closeLog() error {
+	if err := log.close(); err != nil {
+		return fmt.Errorf("closing log for %s: %w", log.operation, err)
+	}
+	return nil
+}

--- a/agent/go/internal/agent/log_test.go
+++ b/agent/go/internal/agent/log_test.go
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package agent
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("operation logging", func() {
+	var (
+		root   string
+		layout flags.Layout
+		cfg    config.Config
+	)
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		layout = flags.DefaultLayout(root)
+		cfg = config.Config{PackageName: "package", PackageVersion: "1.2.3"}
+	})
+
+	It("uses the configured streams without creating a retained log when disabled", func() {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		runtime := runtimeConfig{stdout: stdout, stderr: stderr}
+
+		operationLog, err := prepareOperationLog(
+			runtime,
+			layout,
+			cfg,
+			"apply.sh",
+			`step "apply.sh"`,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(operationLog.stdout).To(BeIdenticalTo(stdout))
+		Expect(operationLog.stderr).To(BeIdenticalTo(stderr))
+		_, err = io.WriteString(operationLog.stdout, "stdout")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.WriteString(operationLog.stderr, "stderr")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(operationLog.finalize()).To(Succeed())
+		Expect(stdout.String()).To(Equal("stdout"))
+		Expect(stderr.String()).To(Equal("stderr"))
+		Expect(layout.LogDir()).NotTo(BeAnExistingFile())
+	})
+
+	It("streams output while retaining it in one operation log", func() {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		runtime := runtimeConfig{
+			writeLogs: true,
+			stdout:    stdout,
+			stderr:    stderr,
+		}
+
+		operationLog, err := prepareOperationLog(
+			runtime,
+			layout,
+			cfg,
+			filepath.Join("steps", "apply.sh"),
+			`step "steps/apply.sh"`,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.WriteString(operationLog.stdout, "stdout\n")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = io.WriteString(operationLog.stderr, "stderr\n")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(operationLog.finalize()).To(Succeed())
+
+		Expect(stdout.String()).To(Equal("stdout\n"))
+		Expect(stderr.String()).To(Equal("stderr\n"))
+		logDirectory := filepath.Join(
+			layout.LogDir(),
+			cfg.PackageName,
+			cfg.PackageVersion,
+			"steps",
+		)
+		entries, err := os.ReadDir(logDirectory)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		contents, err := os.ReadFile(filepath.Join(logDirectory, entries[0].Name()))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).To(Equal("stdout\nstderr\n"))
+	})
+
+	It("retains only the configured number of finalized logs", func() {
+		runtime := runtimeConfig{
+			writeLogs: true,
+			stdout:    io.Discard,
+			stderr:    io.Discard,
+		}
+
+		for range flags.DefaultLogRetention + 2 {
+			operationLog, err := prepareOperationLog(
+				runtime,
+				layout,
+				cfg,
+				"apply.sh",
+				`step "apply.sh"`,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(operationLog.finalize()).To(Succeed())
+		}
+
+		entries, err := os.ReadDir(filepath.Join(
+			layout.LogDir(),
+			cfg.PackageName,
+			cfg.PackageVersion,
+		))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(flags.DefaultLogRetention))
+	})
+})

--- a/agent/go/internal/agent/package.go
+++ b/agent/go/internal/agent/package.go
@@ -1,0 +1,125 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
+)
+
+const (
+	legacyNodeFilesDir = "/etc/nvidia-bootstrap/node-files"
+	configFileName     = "config.json"
+	configMapsDirName  = "configmaps"
+	rootOverlayDirName = "root_dir"
+)
+
+type packageDataSources struct {
+	dataDir            string
+	legacyNodeFilesDir string
+}
+
+func ensurePackageData(rootMount, copyRoot string, sources packageDataSources) error {
+	info, err := os.Stat(copyRoot)
+	if err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("package copy path %q is not a directory", copyRoot)
+		}
+		return nil
+	}
+	if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("stating package copy path %q: %w", copyRoot, err)
+	}
+	if err := hostfs.CopyTreeIfExistsFollowingSymlinks(rootMount, sources.dataDir, copyRoot); err != nil {
+		return fmt.Errorf("copying package data from %q: %w", sources.dataDir, err)
+	}
+	if _, err := os.Stat(copyRoot); errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("package data directory %q does not exist", sources.dataDir)
+	} else if err != nil {
+		return fmt.Errorf("stating copied package data %q: %w", copyRoot, err)
+	}
+	if err := hostfs.CopyTreeIfExistsFollowingSymlinks(
+		rootMount,
+		sources.legacyNodeFilesDir,
+		copyRoot,
+	); err != nil {
+		return fmt.Errorf("copying legacy node files from %q: %w", sources.legacyNodeFilesDir, err)
+	}
+	return nil
+}
+
+func loadConfig(copyRoot string, logger *slog.Logger) (*config.Config, error) {
+	configPath := filepath.Join(copyRoot, configFileName)
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("reading package config %q: %w", configPath, err)
+	}
+	cfg, err := config.NewLoader().Load(data, flags.StepsDir(copyRoot), logger)
+	if err != nil {
+		return nil, fmt.Errorf("loading package config %q: %w", configPath, err)
+	}
+	return cfg, nil
+}
+
+func prepareHost(rootMount, copyRoot string, cfg config.Config) error {
+	if err := hostfs.CopyTreeIfExistsFollowingSymlinks(
+		rootMount,
+		filepath.Join(copyRoot, rootOverlayDirName),
+		rootMount,
+	); err != nil {
+		return fmt.Errorf("copying package root overlay: %w", err)
+	}
+	for _, expected := range cfg.ExpectedConfigFiles {
+		if !filepath.IsLocal(expected) {
+			return fmt.Errorf("expected config file %q must be relative to the configmaps directory", expected)
+		}
+		path := filepath.Join(copyRoot, configMapsDirName, expected)
+		info, err := os.Stat(path)
+		if errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("expected config file %q was not found in the configmaps directory", expected)
+		}
+		if err != nil {
+			return fmt.Errorf("stating expected config file %q: %w", expected, err)
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("expected config file %q is not a regular file", expected)
+		}
+	}
+	return nil
+}
+
+func copyResolverConfig(rootMount string) error {
+	source := filepath.Join(string(filepath.Separator), "etc", "resolv.conf")
+	destination, err := hostfs.HostPathToMounted(rootMount, source)
+	if err != nil {
+		return fmt.Errorf("resolving host resolver path: %w", err)
+	}
+	if err := hostfs.CopyFileFollowingSymlinks(rootMount, source, destination); err != nil {
+		return fmt.Errorf("copying resolver configuration: %w", err)
+	}
+	return nil
+}

--- a/agent/go/internal/agent/package_test.go
+++ b/agent/go/internal/agent/package_test.go
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("package preparation", func() {
+	It("copies the container resolver into the mounted root", func() {
+		_, err := os.Stat("/etc/resolv.conf")
+		if errors.Is(err, os.ErrNotExist) {
+			Skip("/etc/resolv.conf is not available")
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		root := GinkgoT().TempDir()
+
+		Expect(copyResolverConfig(root)).To(Succeed())
+
+		expected, err := os.ReadFile("/etc/resolv.conf")
+		Expect(err).NotTo(HaveOccurred())
+		actual, err := os.ReadFile(filepath.Join(root, "etc", "resolv.conf"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+
+	It("copies the container resolver through a relative host symlink", func() {
+		_, err := os.Stat("/etc/resolv.conf")
+		if errors.Is(err, os.ErrNotExist) {
+			Skip("/etc/resolv.conf is not available")
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		root := GinkgoT().TempDir()
+		target := filepath.Join(root, "run", "resolver", "resolv.conf")
+		Expect(os.MkdirAll(filepath.Dir(target), 0o755)).To(Succeed())
+		Expect(os.WriteFile(target, []byte("old"), 0o600)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "etc"), 0o755)).To(Succeed())
+		Expect(os.Symlink("../run/resolver/resolv.conf", filepath.Join(root, "etc", "resolv.conf"))).To(Succeed())
+
+		Expect(copyResolverConfig(root)).To(Succeed())
+
+		expected, err := os.ReadFile("/etc/resolv.conf")
+		Expect(err).NotTo(HaveOccurred())
+		actual, err := os.ReadFile(target)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(actual).To(Equal(expected))
+	})
+
+	It("copies root overlays and validates expected configuration files", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		Expect(os.MkdirAll(filepath.Join(copyRoot, rootOverlayDirName, "etc"), 0o755)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(copyRoot, rootOverlayDirName, "etc", "package.conf"),
+			[]byte("configured"),
+			0o600,
+		)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(copyRoot, configMapsDirName), 0o755)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(copyRoot, configMapsDirName, "input.conf"),
+			[]byte("input"),
+			0o600,
+		)).To(Succeed())
+
+		Expect(prepareHost(root, copyRoot, config.Config{
+			ExpectedConfigFiles: []string{"input.conf"},
+		})).To(Succeed())
+		Expect(filepath.Join(root, "etc", "package.conf")).To(BeAnExistingFile())
+
+		err := prepareHost(root, copyRoot, config.Config{
+			ExpectedConfigFiles: []string{"missing.conf"},
+		})
+		Expect(err).To(MatchError(ContainSubstring(
+			`expected config file "missing.conf" was not found`,
+		)))
+	})
+
+	It("dereferences source links and follows relative host directory links", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		overlay := filepath.Join(copyRoot, rootOverlayDirName)
+		shared := filepath.Join(copyRoot, "shared")
+		Expect(os.MkdirAll(filepath.Join(overlay, "lib", "systemd", "system"), 0o755)).To(Succeed())
+		Expect(os.MkdirAll(shared, 0o755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(shared, "package.service"), []byte("unit"), 0o600)).To(Succeed())
+		Expect(os.Symlink(
+			filepath.Join(shared, "package.service"),
+			filepath.Join(overlay, "lib", "systemd", "system", "package.service"),
+		)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "usr", "lib"), 0o755)).To(Succeed())
+		Expect(os.Symlink("usr/lib", filepath.Join(root, "lib"))).To(Succeed())
+
+		Expect(prepareHost(root, copyRoot, config.Config{})).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(root, "usr", "lib", "systemd", "system", "package.service"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("unit"))
+	})
+
+	It("rejects expected configuration paths that escape the configmaps directory", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		Expect(os.MkdirAll(filepath.Join(copyRoot, configMapsDirName), 0o755)).To(Succeed())
+
+		err := prepareHost(root, copyRoot, config.Config{
+			ExpectedConfigFiles: []string{"../outside.conf"},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("must be relative to the configmaps directory")))
+	})
+
+	It("rejects an expected configuration path that is not a regular file", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		path := filepath.Join(copyRoot, configMapsDirName, "nested")
+		Expect(os.MkdirAll(path, 0o755)).To(Succeed())
+
+		err := prepareHost(root, copyRoot, config.Config{
+			ExpectedConfigFiles: []string{"nested"},
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("is not a regular file")))
+	})
+
+	It("rejects an existing package copy path that is not a directory", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		Expect(os.WriteFile(copyRoot, nil, 0o600)).To(Succeed())
+
+		err := ensurePackageData(root, copyRoot, packageDataSources{
+			dataDir:            GinkgoT().TempDir(),
+			legacyNodeFilesDir: GinkgoT().TempDir(),
+		})
+
+		Expect(err).To(MatchError(ContainSubstring("is not a directory")))
+	})
+
+	It("reports a missing package data directory", func() {
+		root := GinkgoT().TempDir()
+
+		err := ensurePackageData(
+			root,
+			filepath.Join(root, "package"),
+			packageDataSources{
+				dataDir:            filepath.Join(root, "missing"),
+				legacyNodeFilesDir: GinkgoT().TempDir(),
+			},
+		)
+
+		Expect(err).To(MatchError(ContainSubstring("does not exist")))
+	})
+
+	It("merges current package data and legacy node files", func() {
+		root := GinkgoT().TempDir()
+		copyRoot := filepath.Join(root, "package")
+		dataDir := GinkgoT().TempDir()
+		legacyDataDir := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(dataDir, "config.json"), []byte("config"), 0o600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(legacyDataDir, "node.conf"), []byte("node"), 0o600)).To(Succeed())
+
+		Expect(ensurePackageData(root, copyRoot, packageDataSources{
+			dataDir:            dataDir,
+			legacyNodeFilesDir: legacyDataDir,
+		})).To(Succeed())
+
+		Expect(filepath.Join(copyRoot, "config.json")).To(BeARegularFile())
+		Expect(filepath.Join(copyRoot, "node.conf")).To(BeARegularFile())
+	})
+})

--- a/agent/go/internal/agent/steps.go
+++ b/agent/go/internal/agent/steps.go
@@ -39,7 +39,6 @@ import (
 const (
 	startFlagName        = "START"
 	checkResultsFlagName = "check_results"
-	logFileMode          = 0o600
 )
 
 func runSteps(
@@ -124,7 +123,7 @@ func runSteps(
 				continue
 			}
 		}
-		if err := writeStepHeader(runtime.stdout, req.stage, configuredStep); err != nil {
+		if err := writeStepHeader(runtime.stdout, req.stage, runnableStep); err != nil {
 			return execution.StatusFailed, fmt.Errorf(
 				"writing execution header for step %q: %w",
 				configuredStep.Path(),
@@ -132,7 +131,21 @@ func runSteps(
 			)
 		}
 
-		status, err := runStep(ctx, req, runtime, layout, cfg, runnableStep)
+		var markComplete func() error
+		if !isCheck {
+			markComplete = func() error {
+				message := fmt.Sprintf(
+					"last_run: %s\nstep_always_runs: %t",
+					time.Now().UTC().Format(time.RFC3339Nano),
+					configuredStep.Idempotence() == step.Disabled,
+				)
+				if _, err := flagStore.Mark(configuredStep, message); err != nil {
+					return fmt.Errorf("marking step %q complete: %w", configuredStep.Path(), err)
+				}
+				return nil
+			}
+		}
+		status, err := runStep(ctx, req, runtime, layout, cfg, runnableStep, markComplete)
 		if err != nil {
 			return execution.StatusFailed, err
 		}
@@ -145,18 +158,6 @@ func runSteps(
 		}
 		if status != execution.StatusSuccess {
 			return execution.StatusFailed, nil
-		}
-		message := fmt.Sprintf(
-			"last_run: %s\nstep_always_runs: %t",
-			time.Now().UTC().Format(time.RFC3339Nano),
-			configuredStep.Idempotence() == step.Disabled,
-		)
-		if _, err := flagStore.Mark(configuredStep, message); err != nil {
-			return execution.StatusFailed, fmt.Errorf(
-				"marking step %q complete: %w",
-				configuredStep.Path(),
-				err,
-			)
 		}
 	}
 
@@ -216,71 +217,43 @@ func runStep(
 	layout flags.Layout,
 	cfg config.Config,
 	value step.Step,
+	markComplete func() error,
 ) (execution.Status, error) {
-	stdout, stderr := runtime.stdout, runtime.stderr
-	closeLog := func() error { return nil }
-	var logFiles flags.LogFiles
-	if runtime.writeLogs {
-		_, file, err := layout.CreateLogFile(cfg, value.Path(), time.Now(), logFileMode)
-		if err != nil {
-			return execution.StatusFailed, fmt.Errorf("preparing log for step %q: %w", value.Path(), err)
-		}
-		stdout = io.MultiWriter(stdout, file)
-		stderr = io.MultiWriter(stderr, file)
-		closeLog = file.Close
-		logFiles, err = layout.LogFilePattern(cfg, value.Path())
-		if err != nil {
-			return execution.StatusFailed, errors.Join(
-				fmt.Errorf("resolving log retention for step %q: %w", value.Path(), err),
-				finalizeStepLog(false, closeLog, flags.LogFiles{}, value.Path()),
-			)
-		}
+	operation := fmt.Sprintf("step %q", value.Path())
+	operationLog, err := prepareOperationLog(runtime, layout, cfg, value.Path(), operation)
+	if err != nil {
+		return execution.StatusFailed, err
 	}
 
 	runConfig, err := execution.NewConfig(
 		execution.WithRootMount(req.rootMount),
 		execution.WithStepRoot(flags.StepsDir(req.copyDir)),
 		execution.WithSkyhookDir(req.copyDir),
-		execution.WithRunOutput(stdout, stderr),
+		execution.WithRunOutput(operationLog.stdout, operationLog.stderr),
 	)
 	if err != nil {
 		return execution.StatusFailed, errors.Join(
 			fmt.Errorf("configuring step %q execution: %w", value.Path(), err),
-			finalizeStepLog(runtime.writeLogs, closeLog, logFiles, value.Path()),
+			operationLog.finalize(),
 		)
 	}
 	status, runErr := value.Run(ctx, runConfig)
-	finalizeErr := finalizeStepLog(runtime.writeLogs, closeLog, logFiles, value.Path())
-	if runErr != nil || finalizeErr != nil {
+	var markErr error
+	if runErr == nil && status == execution.StatusSuccess && markComplete != nil {
+		markErr = markComplete()
+	}
+	finalizeErr := operationLog.finalize()
+	if runErr != nil || markErr != nil || finalizeErr != nil {
 		if runErr != nil {
 			runErr = fmt.Errorf("running step %q: %w", value.Path(), runErr)
 		}
 		return execution.StatusFailed, errors.Join(
 			runErr,
+			markErr,
 			finalizeErr,
 		)
 	}
 	return status, nil
-}
-
-func finalizeStepLog(
-	writeLogs bool,
-	closeLog func() error,
-	logFiles flags.LogFiles,
-	stepPath string,
-) error {
-	closeErr := closeLog()
-	if closeErr != nil {
-		closeErr = fmt.Errorf("closing log for step %q: %w", stepPath, closeErr)
-	}
-	var cleanupErr error
-	if writeLogs {
-		cleanupErr = flags.CleanupOldLogs(logFiles, flags.DefaultLogRetention)
-		if cleanupErr != nil {
-			cleanupErr = fmt.Errorf("cleaning old logs for step %q: %w", stepPath, cleanupErr)
-		}
-	}
-	return errors.Join(closeErr, cleanupErr)
 }
 
 type checkResult struct {

--- a/agent/go/internal/agent/steps.go
+++ b/agent/go/internal/agent/steps.go
@@ -1,0 +1,351 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/history"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+)
+
+const (
+	startFlagName        = "START"
+	checkResultsFlagName = "check_results"
+	logFileMode          = 0o600
+)
+
+func runSteps(
+	ctx context.Context,
+	req request,
+	runtime runtimeConfig,
+	layout flags.Layout,
+	cfg config.Config,
+	flagStore flags.Store,
+	historyStore history.Store,
+) (execution.Status, error) {
+	if err := flagStore.Write(filepath.Join(layout.FlagDir(), startFlagName), nil); err != nil {
+		return execution.StatusFailed, fmt.Errorf("writing agent start flag: %w", err)
+	}
+
+	configuredSteps := cfg.Modes[req.stage]
+	if len(configuredSteps) == 0 {
+		runtime.logger.Warn("stage has no configured steps; treating it as a no-op", "stage", req.stage)
+	}
+
+	var versions history.Versions
+	if isUpgradeStage(req.stage) {
+		var err error
+		versions, err = historyStore.Read()
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"reading package history for stage %q: %w",
+				req.stage,
+				err,
+			)
+		}
+	}
+
+	_, isCheck := stage.CheckToApply[req.stage]
+	if isCheck && len(configuredSteps) > 0 {
+		completedCheckFlag := filepath.Join(
+			layout.FlagDir(),
+			string(req.stage)+"_ALL_CHECKED",
+		)
+		if err := hostfs.RemoveFile(req.rootMount, completedCheckFlag); err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"clearing completed-check flag for stage %q: %w",
+				req.stage,
+				err,
+			)
+		}
+	}
+	results := make([]checkResult, 0, len(configuredSteps))
+	for _, configuredStep := range configuredSteps {
+		if err := ctx.Err(); err != nil {
+			return execution.StatusFailed, fmt.Errorf("running stage %q: %w", req.stage, err)
+		}
+
+		runnableStep := configuredStep
+		if isUpgradeStage(req.stage) {
+			runnableStep = configuredStep.WithVersions(versions.Previous, versions.Current)
+		}
+
+		if !isCheck {
+			decision, err := flagStore.Check(configuredStep, runtime.alwaysRunStep, req.stage)
+			if err != nil {
+				return execution.StatusFailed, fmt.Errorf(
+					"checking completion for step %q: %w",
+					configuredStep.Path(),
+					err,
+				)
+			}
+			if decision.Reason == flags.ReasonAlwaysRun {
+				runtime.logger.Warn(
+					"running completed step because always-run policy is enabled",
+					"stage", req.stage,
+					"step", configuredStep.Path(),
+				)
+			}
+			if !decision.Run {
+				runtime.logger.Info(
+					"skipping completed step",
+					"stage", req.stage,
+					"step", configuredStep.Path(),
+					"reason", decision.Reason,
+				)
+				continue
+			}
+		}
+		if err := writeStepHeader(runtime.stdout, req.stage, configuredStep); err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"writing execution header for step %q: %w",
+				configuredStep.Path(),
+				err,
+			)
+		}
+
+		status, err := runStep(ctx, req, runtime, layout, cfg, runnableStep)
+		if err != nil {
+			return execution.StatusFailed, err
+		}
+		if isCheck {
+			results = append(results, checkResult{
+				path:   configuredStep.Path(),
+				failed: status != execution.StatusSuccess,
+			})
+			continue
+		}
+		if status != execution.StatusSuccess {
+			return execution.StatusFailed, nil
+		}
+		message := fmt.Sprintf(
+			"last_run: %s\nstep_always_runs: %t",
+			time.Now().UTC().Format(time.RFC3339Nano),
+			configuredStep.Idempotence() == step.Disabled,
+		)
+		if _, err := flagStore.Mark(configuredStep, message); err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"marking step %q complete: %w",
+				configuredStep.Path(),
+				err,
+			)
+		}
+	}
+
+	if isCheck && len(configuredSteps) > 0 {
+		status, err := summarizeChecks(req.stage, results, flagStore, layout)
+		if err != nil || status == execution.StatusFailed {
+			return status, err
+		}
+	}
+	if recordsHistory(req.stage) {
+		if err := historyStore.Record(req.stage, time.Now()); err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"recording package history for stage %q: %w",
+				req.stage,
+				err,
+			)
+		}
+	}
+	if req.stage == stage.UninstallCheck {
+		if err := removeStepFlags(cfg, flagStore); err != nil {
+			return execution.StatusFailed, err
+		}
+	}
+	return execution.StatusSuccess, nil
+}
+
+func writeStepHeader(output io.Writer, currentStage stage.Stage, value step.Step) error {
+	metadata := value.ExecutionMetadata()
+	_, err := fmt.Fprintf(
+		output,
+		"%s %s %s %s %s %s\n",
+		currentStage,
+		value.Path(),
+		step.FormatLegacyArguments(metadata.Arguments),
+		step.FormatLegacyReturnCodes(metadata.ReturnCodes),
+		formatLegacyIdempotence(value.Idempotence()),
+		formatLegacyBool(metadata.OnHost),
+	)
+	return err
+}
+
+func formatLegacyIdempotence(value step.Idempotence) string {
+	switch value {
+	case step.Auto:
+		return "Idempotence.Auto"
+	case step.Disabled:
+		return "Idempotence.Disabled"
+	default:
+		return "Idempotence." + string(value)
+	}
+}
+
+func runStep(
+	ctx context.Context,
+	req request,
+	runtime runtimeConfig,
+	layout flags.Layout,
+	cfg config.Config,
+	value step.Step,
+) (execution.Status, error) {
+	stdout, stderr := runtime.stdout, runtime.stderr
+	closeLog := func() error { return nil }
+	var logFiles flags.LogFiles
+	if runtime.writeLogs {
+		_, file, err := layout.CreateLogFile(cfg, value.Path(), time.Now(), logFileMode)
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf("preparing log for step %q: %w", value.Path(), err)
+		}
+		stdout = io.MultiWriter(stdout, file)
+		stderr = io.MultiWriter(stderr, file)
+		closeLog = file.Close
+		logFiles, err = layout.LogFilePattern(cfg, value.Path())
+		if err != nil {
+			return execution.StatusFailed, errors.Join(
+				fmt.Errorf("resolving log retention for step %q: %w", value.Path(), err),
+				finalizeStepLog(false, closeLog, flags.LogFiles{}, value.Path()),
+			)
+		}
+	}
+
+	runConfig, err := execution.NewConfig(
+		execution.WithRootMount(req.rootMount),
+		execution.WithStepRoot(flags.StepsDir(req.copyDir)),
+		execution.WithSkyhookDir(req.copyDir),
+		execution.WithRunOutput(stdout, stderr),
+	)
+	if err != nil {
+		return execution.StatusFailed, errors.Join(
+			fmt.Errorf("configuring step %q execution: %w", value.Path(), err),
+			finalizeStepLog(runtime.writeLogs, closeLog, logFiles, value.Path()),
+		)
+	}
+	status, runErr := value.Run(ctx, runConfig)
+	finalizeErr := finalizeStepLog(runtime.writeLogs, closeLog, logFiles, value.Path())
+	if runErr != nil || finalizeErr != nil {
+		if runErr != nil {
+			runErr = fmt.Errorf("running step %q: %w", value.Path(), runErr)
+		}
+		return execution.StatusFailed, errors.Join(
+			runErr,
+			finalizeErr,
+		)
+	}
+	return status, nil
+}
+
+func finalizeStepLog(
+	writeLogs bool,
+	closeLog func() error,
+	logFiles flags.LogFiles,
+	stepPath string,
+) error {
+	closeErr := closeLog()
+	if closeErr != nil {
+		closeErr = fmt.Errorf("closing log for step %q: %w", stepPath, closeErr)
+	}
+	var cleanupErr error
+	if writeLogs {
+		cleanupErr = flags.CleanupOldLogs(logFiles, flags.DefaultLogRetention)
+		if cleanupErr != nil {
+			cleanupErr = fmt.Errorf("cleaning old logs for step %q: %w", stepPath, cleanupErr)
+		}
+	}
+	return errors.Join(closeErr, cleanupErr)
+}
+
+type checkResult struct {
+	path   string
+	failed bool
+}
+
+func summarizeChecks(
+	currentStage stage.Stage,
+	results []checkResult,
+	flagStore flags.Store,
+	layout flags.Layout,
+) (execution.Status, error) {
+	lines := make([]string, 0, len(results))
+	failed := false
+	for _, result := range results {
+		value := "False"
+		if result.failed {
+			value = "True"
+			failed = true
+		}
+		lines = append(lines, result.path+" "+value)
+	}
+	if err := flagStore.Write(
+		filepath.Join(layout.FlagDir(), checkResultsFlagName),
+		[]byte(strings.Join(lines, "\n")),
+	); err != nil {
+		return execution.StatusFailed, fmt.Errorf("writing check results for stage %q: %w", currentStage, err)
+	}
+	if failed {
+		return execution.StatusFailed, nil
+	}
+	if err := flagStore.Write(
+		filepath.Join(layout.FlagDir(), string(currentStage)+"_ALL_CHECKED"),
+		nil,
+	); err != nil {
+		return execution.StatusFailed, fmt.Errorf(
+			"writing completed-check flag for stage %q: %w",
+			currentStage,
+			err,
+		)
+	}
+	return execution.StatusSuccess, nil
+}
+
+func isUpgradeStage(currentStage stage.Stage) bool {
+	return currentStage == stage.Upgrade || currentStage == stage.UpgradeCheck
+}
+
+func recordsHistory(currentStage stage.Stage) bool {
+	switch currentStage {
+	case stage.ApplyCheck, stage.UpgradeCheck, stage.UninstallCheck:
+		return true
+	default:
+		return false
+	}
+}
+
+func removeStepFlags(cfg config.Config, flagStore flags.Store) error {
+	for _, currentStage := range stage.All {
+		for _, value := range cfg.Modes[currentStage] {
+			if err := flagStore.Remove(value); err != nil {
+				return fmt.Errorf("removing completion flag for step %q: %w", value.Path(), err)
+			}
+		}
+	}
+	return nil
+}

--- a/agent/go/internal/agent/steps_test.go
+++ b/agent/go/internal/agent/steps_test.go
@@ -146,6 +146,34 @@ var _ = Describe("step orchestration", func() {
 		Expect(status).To(Equal(execution.StatusSuccess))
 	})
 
+	It("prints resolved package versions in an upgrade step header", func() {
+		req.stage = stage.Upgrade
+		versions := history.Versions{Previous: "1.0.0", Current: "1.2.3"}
+		historyStore.EXPECT().Read().Return(versions, nil).Once()
+		value, err := step.NewUpgradeStep("upgrade.sh", step.WithOnHost(false))
+		Expect(err).NotTo(HaveOccurred())
+		cfg.Modes[stage.Upgrade] = []step.Step{value}
+		stepDirectory := filepath.Join(root, "packages", "package", "skyhook_dir")
+		Expect(os.MkdirAll(stepDirectory, 0o755)).To(Succeed())
+		Expect(os.WriteFile(
+			filepath.Join(stepDirectory, value.Path()),
+			[]byte("#!/bin/sh\nexit 0\n"),
+			0o700,
+		)).To(Succeed())
+		output := &bytes.Buffer{}
+		runtime.stdout = output
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(output.String()).To(Equal(
+			"upgrade upgrade.sh ['1.0.0', '1.2.3'] [0] Idempotence.Auto False\n",
+		))
+	})
+
 	It("formats step headers like the legacy agent", func() {
 		value := step.NewRegularStep(
 			"apply.sh",
@@ -332,6 +360,39 @@ var _ = Describe("step orchestration", func() {
 		))
 	})
 
+	It("marks a successful step complete before log cleanup", func() {
+		runtime.writeLogs = true
+		logDirectory := filepath.Join(layout.LogDir(), cfg.PackageName, cfg.PackageVersion)
+		savedLogDirectory := logDirectory + "-saved"
+		outside := GinkgoT().TempDir()
+		value := newMockStep("apply.sh")
+		value.EXPECT().
+			Run(mock.Anything, mock.Anything).
+			Run(func(context.Context, execution.Config) {
+				Expect(os.Rename(logDirectory, savedLogDirectory)).To(Succeed())
+				Expect(os.Symlink(outside, logDirectory)).To(Succeed())
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+		cfg.Modes[stage.Apply] = []step.Step{value}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(err).To(MatchError(ContainSubstring("cleaning old logs for step")))
+		completionFlag, err := flagStore.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(completionFlag).To(BeAnExistingFile())
+
+		status, err = runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+
 	It("cleans old retained logs after repeated runtime errors", func() {
 		runtime.writeLogs = true
 		value := newMockStep("apply.sh")
@@ -341,7 +402,7 @@ var _ = Describe("step orchestration", func() {
 			Times(flags.DefaultLogRetention + 2)
 
 		for range flags.DefaultLogRetention + 2 {
-			status, err := runStep(context.Background(), req, runtime, layout, cfg, value)
+			status, err := runStep(context.Background(), req, runtime, layout, cfg, value, nil)
 			Expect(status).To(Equal(execution.StatusFailed))
 			Expect(err).To(MatchError(ContainSubstring("run failed")))
 		}

--- a/agent/go/internal/agent/steps_test.go
+++ b/agent/go/internal/agent/steps_test.go
@@ -1,0 +1,381 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package agent
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/history"
+	historymock "github.com/NVIDIA/nodewright/agent/internal/history/mock"
+	"github.com/NVIDIA/nodewright/agent/internal/stage"
+	"github.com/NVIDIA/nodewright/agent/internal/step"
+	stepmock "github.com/NVIDIA/nodewright/agent/internal/step/mock"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+)
+
+func newMockStep(path string) *stepmock.MockStep {
+	value := stepmock.NewMockStep(GinkgoT())
+	value.EXPECT().Path().Return(path).Maybe()
+	value.EXPECT().
+		Fingerprint().
+		Return("fingerprint-"+filepath.Base(path), nil).
+		Maybe()
+	value.EXPECT().Idempotence().Return(step.Auto).Maybe()
+	value.EXPECT().
+		ExecutionMetadata().
+		Return(step.ExecutionMetadata{
+			Arguments:   []string{},
+			ReturnCodes: []command.ExitCode{command.SuccessExitCode},
+			OnHost:      true,
+		}).
+		Maybe()
+	return value
+}
+
+func newRunnableMockStep(path string, status execution.Status) *stepmock.MockStep {
+	value := newMockStep(path)
+	value.EXPECT().
+		Run(mock.Anything, mock.Anything).
+		Return(status, nil).
+		Once()
+	return value
+}
+
+var _ = Describe("step orchestration", func() {
+	var (
+		root         string
+		layout       flags.Layout
+		cfg          config.Config
+		runtime      runtimeConfig
+		req          request
+		flagStore    flags.Store
+		historyStore *historymock.MockStore
+	)
+
+	BeforeEach(func() {
+		root = GinkgoT().TempDir()
+		layout = flags.DefaultLayout(root)
+		cfg = config.Config{
+			PackageName:    "package",
+			PackageVersion: "1.2.3",
+			Modes:          map[stage.Stage][]step.Step{},
+		}
+		runtime = runtimeConfig{
+			stdout: io.Discard,
+			stderr: io.Discard,
+			logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		}
+		req = request{
+			stage:     stage.Apply,
+			rootMount: root,
+			copyDir:   "/packages/package",
+		}
+		var err error
+		flagStore, err = flags.NewStore(layout, cfg)
+		Expect(err).NotTo(HaveOccurred())
+		historyStore = historymock.NewMockStore(GinkgoT())
+	})
+
+	It("writes START and completion flags around successful steps", func() {
+		first := newRunnableMockStep("first.sh", execution.StatusSuccess)
+		second := newRunnableMockStep("second.sh", execution.StatusSuccess)
+		cfg.Modes[stage.Apply] = []step.Step{first, second}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(layout.FlagDir(), startFlagName)).To(BeAnExistingFile())
+		firstFlag, err := flagStore.Path(first)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(firstFlag).To(BeAnExistingFile())
+	})
+
+	It("writes the step header after START and before execution", func() {
+		output := &bytes.Buffer{}
+		runtime.stdout = output
+		value := newMockStep("apply.sh")
+		value.EXPECT().
+			Run(mock.Anything, mock.Anything).
+			Run(func(context.Context, execution.Config) {
+				Expect(filepath.Join(layout.FlagDir(), startFlagName)).To(BeAnExistingFile())
+				Expect(output.String()).To(Equal(
+					"apply apply.sh [] [0] Idempotence.Auto True\n",
+				))
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+		cfg.Modes[stage.Apply] = []step.Step{value}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+
+	It("formats step headers like the legacy agent", func() {
+		value := step.NewRegularStep(
+			"apply.sh",
+			step.WithArguments([]string{"plain", "it's"}),
+			step.WithReturncodes([]command.ExitCode{command.SuccessExitCode, 2}),
+			step.WithIdempotence(step.Disabled),
+			step.WithOnHost(false),
+		)
+		output := &bytes.Buffer{}
+
+		Expect(writeStepHeader(output, stage.Apply, value)).To(Succeed())
+
+		Expect(output.String()).To(Equal(
+			"apply apply.sh ['plain', \"it's\"] [0, 2] Idempotence.Disabled False\n",
+		))
+	})
+
+	It("skips an idempotent step that is already complete", func() {
+		value := newMockStep("apply.sh")
+		cfg.Modes[stage.Apply] = []step.Step{value}
+		_, err := flagStore.Mark(value, "complete")
+		Expect(err).NotTo(HaveOccurred())
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+
+	It("runs a completed step when the always-run policy is enabled", func() {
+		value := newRunnableMockStep("apply.sh", execution.StatusSuccess)
+		cfg.Modes[stage.Apply] = []step.Step{value}
+		runtime.alwaysRunStep = true
+		logOutput := &bytes.Buffer{}
+		runtime.logger = slog.New(slog.NewTextHandler(logOutput, nil))
+		_, err := flagStore.Mark(value, "complete")
+		Expect(err).NotTo(HaveOccurred())
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(logOutput.String()).To(ContainSubstring(
+			"running completed step because always-run policy is enabled",
+		))
+	})
+
+	It("stops a normal stage after the first failed step", func() {
+		first := newRunnableMockStep("first.sh", execution.StatusFailed)
+		second := newMockStep("second.sh")
+		cfg.Modes[stage.Apply] = []step.Step{first, second}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusFailed))
+	})
+
+	It("runs every check and persists mixed results", func() {
+		req.stage = stage.ApplyCheck
+		first := newRunnableMockStep("first.sh", execution.StatusSuccess)
+		second := newRunnableMockStep("second.sh", execution.StatusFailed)
+		cfg.Modes[stage.ApplyCheck] = []step.Step{first, second}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusFailed))
+		data, err := os.ReadFile(filepath.Join(layout.FlagDir(), checkResultsFlagName))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("first.sh False\nsecond.sh True"))
+		Expect(filepath.Join(layout.FlagDir(), "apply-check_ALL_CHECKED")).NotTo(BeAnExistingFile())
+	})
+
+	It("marks successful checks and records package history", func() {
+		req.stage = stage.UpgradeCheck
+		value := newRunnableMockStep("check.sh", execution.StatusSuccess)
+		cfg.Modes[stage.UpgradeCheck] = []step.Step{value}
+		versions := history.Versions{Previous: "1.0.0", Current: "1.2.3"}
+		historyStore.EXPECT().Read().Return(versions, nil).Once()
+		historyStore.EXPECT().
+			Record(stage.UpgradeCheck, mock.Anything).
+			Return(nil).
+			Once()
+		value.EXPECT().
+			WithVersions(versions.Previous, versions.Current).
+			Return(value).
+			Once()
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(filepath.Join(layout.FlagDir(), "upgrade-check_ALL_CHECKED")).To(BeAnExistingFile())
+	})
+
+	It("removes every step completion flag after uninstall-check", func() {
+		req.stage = stage.UninstallCheck
+		apply := newMockStep("apply.sh")
+		uninstallCheck := newRunnableMockStep("uninstall-check.sh", execution.StatusSuccess)
+		historyStore.EXPECT().
+			Record(stage.UninstallCheck, mock.Anything).
+			Return(nil).
+			Once()
+		cfg.Modes[stage.Apply] = []step.Step{apply}
+		cfg.Modes[stage.UninstallCheck] = []step.Step{uninstallCheck}
+		for _, value := range []step.Step{apply, uninstallCheck} {
+			_, err := flagStore.Mark(value, "complete")
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		for _, value := range []step.Step{apply, uninstallCheck} {
+			path, err := flagStore.Path(value)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(path).NotTo(BeAnExistingFile())
+		}
+	})
+
+	It("propagates cancellation and does not start another step", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		first := newMockStep("first.sh")
+		first.EXPECT().
+			Run(mock.Anything, mock.Anything).
+			Run(func(context.Context, execution.Config) {
+				cancel()
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+		second := newMockStep("second.sh")
+		cfg.Modes[stage.Apply] = []step.Step{first, second}
+
+		status, err := runSteps(ctx, req, runtime, layout, cfg, flagStore, historyStore)
+
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
+	})
+
+	It("composes command output with a retained log file", func() {
+		runtime.writeLogs = true
+		streamed := &bytes.Buffer{}
+		runtime.stdout = streamed
+		output := "step output\n"
+		value := newMockStep("apply.sh")
+		value.EXPECT().
+			Run(mock.Anything, mock.Anything).
+			Run(func(_ context.Context, cfg execution.Config) {
+				_, err := io.WriteString(cfg.Stdout(), output)
+				Expect(err).NotTo(HaveOccurred())
+			}).
+			Return(execution.StatusSuccess, nil).
+			Once()
+		cfg.Modes[stage.Apply] = []step.Step{value}
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		entries, err := os.ReadDir(filepath.Join(layout.LogDir(), cfg.PackageName, cfg.PackageVersion))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		data, err := os.ReadFile(filepath.Join(layout.LogDir(), cfg.PackageName, cfg.PackageVersion, entries[0].Name()))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal(output))
+		Expect(streamed.String()).To(Equal(
+			"apply apply.sh [] [0] Idempotence.Auto True\n" + output,
+		))
+	})
+
+	It("cleans old retained logs after repeated runtime errors", func() {
+		runtime.writeLogs = true
+		value := newMockStep("apply.sh")
+		value.EXPECT().
+			Run(mock.Anything, mock.Anything).
+			Return(execution.StatusFailed, errors.New("run failed")).
+			Times(flags.DefaultLogRetention + 2)
+
+		for range flags.DefaultLogRetention + 2 {
+			status, err := runStep(context.Background(), req, runtime, layout, cfg, value)
+			Expect(status).To(Equal(execution.StatusFailed))
+			Expect(err).To(MatchError(ContainSubstring("run failed")))
+		}
+
+		entries, err := os.ReadDir(filepath.Join(layout.LogDir(), cfg.PackageName, cfg.PackageVersion))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(flags.DefaultLogRetention))
+	})
+
+	It("clears stale all-checked state before a failing check run", func() {
+		req.stage = stage.ApplyCheck
+		success := newRunnableMockStep("check.sh", execution.StatusSuccess)
+		cfg.Modes[stage.ApplyCheck] = []step.Step{success}
+		historyStore.EXPECT().
+			Record(stage.ApplyCheck, mock.Anything).
+			Return(nil).
+			Once()
+
+		status, err := runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		marker := filepath.Join(layout.FlagDir(), "apply-check_ALL_CHECKED")
+		Expect(marker).To(BeAnExistingFile())
+
+		failed := newRunnableMockStep("check.sh", execution.StatusFailed)
+		cfg.Modes[stage.ApplyCheck] = []step.Step{failed}
+		status, err = runSteps(
+			context.Background(), req, runtime, layout, cfg, flagStore, historyStore,
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(marker).NotTo(BeAnExistingFile())
+	})
+})

--- a/agent/go/internal/command/chroot_command_runner.go
+++ b/agent/go/internal/command/chroot_command_runner.go
@@ -51,7 +51,7 @@ func (runner *chrootCommandRunner) Run(
 			err = errors.Join(err, closeErr)
 		}
 	}()
-	if command.Permissions != 0 {
+	if command.Permissions != 0 || command.RequiredPermissions != 0 {
 		relative := strings.TrimPrefix(filepath.Clean(command.Executable), string(filepath.Separator))
 		executableFile, openErr := setup.root.Open(relative)
 		if openErr != nil {

--- a/agent/go/internal/command/command.go
+++ b/agent/go/internal/command/command.go
@@ -78,6 +78,11 @@ type Command struct {
 	// starting it. Zero leaves its permissions unchanged. Executable must be
 	// absolute when Permissions is nonzero.
 	Permissions fs.FileMode
+
+	// RequiredPermissions are added to the resolved executable's existing
+	// permission bits before starting it. Executable must be absolute when this
+	// field is nonzero.
+	RequiredPermissions fs.FileMode
 }
 
 // CommandOption configures a Command created by NewCommand.
@@ -89,13 +94,14 @@ type CommandOption func(*Command)
 // directory as "/" instead of the caller's current working directory.
 func NewCommand(executable string, options ...CommandOption) Command {
 	command := Command{
-		Executable:       executable,
-		Arguments:        []string{},
-		WorkingDirectory: "",
-		Environment:      map[string]string{},
-		Stdout:           io.Discard,
-		Stderr:           io.Discard,
-		Permissions:      0,
+		Executable:          executable,
+		Arguments:           []string{},
+		WorkingDirectory:    "",
+		Environment:         map[string]string{},
+		Stdout:              io.Discard,
+		Stderr:              io.Discard,
+		Permissions:         0,
+		RequiredPermissions: 0,
 	}
 	for _, option := range options {
 		option(&command)
@@ -147,6 +153,14 @@ func WithPermissions(permissions fs.FileMode) CommandOption {
 	}
 }
 
+// WithRequiredPermissions adds permission bits without clearing the
+// executable's existing permissions.
+func WithRequiredPermissions(permissions fs.FileMode) CommandOption {
+	return func(command *Command) {
+		command.RequiredPermissions = permissions
+	}
+}
+
 func (command Command) validate() error {
 	if command.Executable == "" {
 		return errors.New("command executable is empty")
@@ -154,7 +168,13 @@ func (command Command) validate() error {
 	if command.Permissions != command.Permissions.Perm() {
 		return errors.New("command permissions contain non-permission mode bits")
 	}
-	if command.Permissions != 0 && !filepath.IsAbs(command.Executable) {
+	if command.RequiredPermissions != command.RequiredPermissions.Perm() {
+		return errors.New("command required permissions contain non-permission mode bits")
+	}
+	if command.Permissions != 0 && command.RequiredPermissions != 0 {
+		return errors.New("command permissions and required permissions are mutually exclusive")
+	}
+	if command.Permissions|command.RequiredPermissions != 0 && !filepath.IsAbs(command.Executable) {
 		return errors.New("command permissions require an absolute executable path")
 	}
 	if strings.ContainsRune(command.Executable, 0) {

--- a/agent/go/internal/command/command_runner.go
+++ b/agent/go/internal/command/command_runner.go
@@ -33,7 +33,7 @@ func (*commandRunner) Run(ctx context.Context, command Command) (Result, error) 
 	if err := validateRun(ctx, command); err != nil {
 		return Result{}, fmt.Errorf("validating command execution: %w", err)
 	}
-	if command.Permissions != 0 {
+	if command.Permissions != 0 || command.RequiredPermissions != 0 {
 		executableFile, err := os.Open(command.Executable)
 		if err != nil {
 			return Result{}, fmt.Errorf(

--- a/agent/go/internal/command/command_runner_test.go
+++ b/agent/go/internal/command/command_runner_test.go
@@ -78,4 +78,24 @@ var _ = Describe("commandRunner", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o700)))
 	})
+
+	It("adds required executable permissions without clearing existing bits", func() {
+		executable := filepath.Join(GinkgoT().TempDir(), "helper")
+		data, err := os.ReadFile(commandTestExecutable())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(executable, data, 0o640)).To(Succeed())
+
+		cmd := NewCommand(
+			executable,
+			WithArguments("-test.run=^TestCommand$", "--", "exit", "0"),
+			WithRequiredPermissions(0o111),
+		)
+		result, err := NewRunner().Run(context.Background(), cmd)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+		info, err := os.Stat(executable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o751)))
+	})
 })

--- a/agent/go/internal/command/command_runner_test.go
+++ b/agent/go/internal/command/command_runner_test.go
@@ -98,4 +98,31 @@ var _ = Describe("commandRunner", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o751)))
 	})
+
+	It("strips privilege bits when adding executable permissions", func() {
+		executable := filepath.Join(GinkgoT().TempDir(), "helper")
+		data, err := os.ReadFile(commandTestExecutable())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.WriteFile(executable, data, 0o640)).To(Succeed())
+		Expect(os.Chmod(executable, 0o640|os.ModeSetuid)).To(Succeed())
+		before, err := os.Stat(executable)
+		Expect(err).NotTo(HaveOccurred())
+		if before.Mode()&os.ModeSetuid == 0 {
+			Skip("test filesystem does not preserve setuid mode bits")
+		}
+
+		cmd := NewCommand(
+			executable,
+			WithArguments("-test.run=^TestCommand$", "--", "exit", "0"),
+			WithRequiredPermissions(0o111),
+		)
+		result, err := NewRunner().Run(context.Background(), cmd)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.ExitCode).To(Equal(SuccessExitCode))
+		after, err := os.Stat(executable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after.Mode() & os.ModeSetuid).To(BeZero())
+		Expect(after.Mode().Perm()).To(Equal(os.FileMode(0o751)))
+	})
 })

--- a/agent/go/internal/command/command_test.go
+++ b/agent/go/internal/command/command_test.go
@@ -43,13 +43,14 @@ var _ = Describe("Command constructor", func() {
 		command := NewCommand("test")
 
 		Expect(command).To(Equal(Command{
-			Executable:       "test",
-			Arguments:        []string{},
-			WorkingDirectory: "",
-			Environment:      map[string]string{},
-			Stdout:           io.Discard,
-			Stderr:           io.Discard,
-			Permissions:      0,
+			Executable:          "test",
+			Arguments:           []string{},
+			WorkingDirectory:    "",
+			Environment:         map[string]string{},
+			Stdout:              io.Discard,
+			Stderr:              io.Discard,
+			Permissions:         0,
+			RequiredPermissions: 0,
 		}))
 	})
 
@@ -79,6 +80,9 @@ var _ = Describe("Command constructor", func() {
 		Expect(command.Stdout).To(BeIdenticalTo(stdout))
 		Expect(command.Stderr).To(BeIdenticalTo(stderr))
 		Expect(command.Permissions).To(Equal(fs.FileMode(0o700)))
+		Expect(NewCommand("/test", WithRequiredPermissions(0o111)).RequiredPermissions).To(
+			Equal(fs.FileMode(0o111)),
+		)
 
 		second := NewCommand("test", argumentOption, environmentOption)
 		command.Arguments[0] = "mutated"
@@ -98,6 +102,16 @@ var _ = Describe("Command validation", func() {
 			"non-permission mode bits",
 			Command{Executable: "/test", Permissions: fs.ModeDir | 0o755},
 			"permissions contain non-permission mode bits",
+		),
+		Entry(
+			"non-permission required mode bits",
+			Command{Executable: "/test", RequiredPermissions: fs.ModeDir | 0o111},
+			"required permissions contain non-permission mode bits",
+		),
+		Entry(
+			"conflicting permission policies",
+			Command{Executable: "/test", Permissions: 0o700, RequiredPermissions: 0o111},
+			"mutually exclusive",
 		),
 		Entry(
 			"relative executable with permissions",

--- a/agent/go/internal/command/process.go
+++ b/agent/go/internal/command/process.go
@@ -58,13 +58,17 @@ func applyExecutablePermissions(
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("command executable %q is not a regular file: %w", command.Executable, fs.ErrPermission)
 	}
-	if info.Mode().Perm() == command.Permissions {
+	permissions := command.Permissions
+	if command.RequiredPermissions != 0 {
+		permissions = info.Mode().Perm() | command.RequiredPermissions
+	}
+	if info.Mode().Perm() == permissions {
 		return nil
 	}
 	if err := ctx.Err(); err != nil {
 		return fmt.Errorf("running command %q: %w", command.Executable, err)
 	}
-	if err := file.Chmod(command.Permissions); err != nil {
+	if err := file.Chmod(permissions); err != nil {
 		return fmt.Errorf("setting permissions on %q: %w", command.Executable, err)
 	}
 	return nil

--- a/agent/go/internal/command/process.go
+++ b/agent/go/internal/command/process.go
@@ -60,6 +60,8 @@ func applyExecutablePermissions(
 	}
 	permissions := command.Permissions
 	if command.RequiredPermissions != 0 {
+		// When chmod is needed, preserve ordinary access bits only rather than
+		// carrying set-ID or sticky privileges from a package-provided step file.
 		permissions = info.Mode().Perm() | command.RequiredPermissions
 	}
 	if info.Mode().Perm() == permissions {

--- a/agent/go/internal/config/validate.go
+++ b/agent/go/internal/config/validate.go
@@ -44,7 +44,7 @@ import (
 // step can enforce on its own.
 
 // schemaFS holds the authoritative JSON Schemas the agent validates package
-// configs against. They are copied byte-for-byte from the Python agent's
+// configs against. They are copied byte-for-byte from the legacy agent's
 // schemas/ tree and embedded so the binary stays a single static artifact.
 //
 //go:embed schemas/v1/*.json

--- a/agent/go/internal/config/validate_test.go
+++ b/agent/go/internal/config/validate_test.go
@@ -169,15 +169,16 @@ var _ = Describe("validateModes", func() {
 
 var _ = Describe("Loader schema-validation seam", func() {
 	It("surfaces the injected validator's error without parsing the document", func() {
+		input := []byte(`{"schema_version":"v1"}`)
 		sentinel := errors.New("boom from fake validator")
 		validator := configmock.NewMockSchemaValidator(GinkgoT())
 		validator.EXPECT().
-			Validate([]byte(validConfigJSON), schema.V1).
+			Validate(input, schema.V1).
 			Return(sentinel).
 			Once()
 		loader := &Loader{validator: validator}
 
-		_, err := loader.Load([]byte(validConfigJSON), GinkgoT().TempDir(), nil)
+		_, err := loader.Load(input, GinkgoT().TempDir(), nil)
 		Expect(err).To(MatchError(sentinel))
 	})
 })

--- a/agent/go/internal/flags/flags.go
+++ b/agent/go/internal/flags/flags.go
@@ -19,6 +19,7 @@
 package flags
 
 import (
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -127,8 +128,40 @@ func (s *fileStore) Mark(value step.Step, message string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("marking step: resolving flag path: %w", err)
 	}
-	if err := s.Write(path, []byte(message)); err != nil {
-		return "", fmt.Errorf("marking step %q: %w", value.Path(), err)
+	legacyPath, hasLegacyPath := s.legacyPath(value)
+	paths := []string{path}
+	if hasLegacyPath {
+		paths = append([]string{legacyPath}, paths...)
+	}
+	existed := make([]bool, len(paths))
+	for index, markerPath := range paths {
+		if err := s.validatePath(markerPath); err != nil {
+			return "", fmt.Errorf("marking step %q: validating flag path: %w", value.Path(), err)
+		}
+		existed[index], err = hostfs.RegularFileExists(s.rootMount, markerPath)
+		if err != nil {
+			return "", fmt.Errorf("marking step %q: inspecting flag path %q: %w", value.Path(), markerPath, err)
+		}
+	}
+	for index, markerPath := range paths {
+		if err := s.Write(markerPath, []byte(message)); err != nil {
+			var rollbackErr error
+			for rollbackIndex, writtenPath := range paths[:index+1] {
+				if existed[rollbackIndex] {
+					continue
+				}
+				if removeErr := hostfs.RemoveFile(s.rootMount, writtenPath); removeErr != nil {
+					rollbackErr = errors.Join(
+						rollbackErr,
+						fmt.Errorf("removing incomplete flag %q: %w", writtenPath, removeErr),
+					)
+				}
+			}
+			return "", errors.Join(
+				fmt.Errorf("marking step %q: %w", value.Path(), err),
+				rollbackErr,
+			)
+		}
 	}
 	return path, nil
 }
@@ -140,13 +173,28 @@ func (s *fileStore) Remove(value step.Step) error {
 	if err != nil {
 		return fmt.Errorf("removing step flag: resolving flag path: %w", err)
 	}
-	if err := s.validatePath(path); err != nil {
-		return fmt.Errorf("removing step flag: validating store path: %w", err)
+	legacyPath, hasLegacyPath := s.legacyPath(value)
+	paths := []string{path}
+	if hasLegacyPath {
+		paths = append(paths, legacyPath)
 	}
-	if err := hostfs.RemoveFile(s.rootMount, path); err != nil {
-		return fmt.Errorf("removing step flag %q: %w", path, err)
+	var removeErr error
+	for _, flagPath := range paths {
+		if err := s.validatePath(flagPath); err != nil {
+			removeErr = errors.Join(
+				removeErr,
+				fmt.Errorf("removing step flag: validating store path: %w", err),
+			)
+			continue
+		}
+		if err := hostfs.RemoveFile(s.rootMount, flagPath); err != nil {
+			removeErr = errors.Join(
+				removeErr,
+				fmt.Errorf("removing step flag %q: %w", flagPath, err),
+			)
+		}
 	}
-	return nil
+	return removeErr
 }
 
 // Write creates or replaces a flag file owned by this store. In addition to
@@ -191,9 +239,35 @@ func (s *fileStore) Check(value step.Step, alwaysRun bool, currentStage stage.St
 		return Decision{}, fmt.Errorf("checking flag for step %q: inspecting store path: %w", value.Path(), err)
 	}
 	if !exists {
-		return Decide(false, alwaysRun, currentStage, value.Idempotence()), nil
+		legacyPath, hasLegacyPath := s.legacyPath(value)
+		if hasLegacyPath {
+			exists, err = hostfs.RegularFileExists(s.rootMount, legacyPath)
+			if err != nil {
+				return Decision{}, fmt.Errorf("checking flag for step %q: inspecting legacy store path: %w", value.Path(), err)
+			}
+		}
+		if !exists {
+			return Decide(false, alwaysRun, currentStage, value.Idempotence()), nil
+		}
 	}
 	return Decide(true, alwaysRun, currentStage, value.Idempotence()), nil
+}
+
+func (s *fileStore) legacyPath(value step.Step) (string, bool) {
+	if value == nil || !filepath.IsLocal(value.Path()) {
+		return "", false
+	}
+	metadata := value.ExecutionMetadata()
+	payload := step.FormatLegacyArguments(metadata.Arguments) + "_" +
+		step.FormatLegacyReturnCodes(metadata.ReturnCodes)
+	marker := base64.StdEncoding.EncodeToString([]byte(payload))
+	return filepath.Join(
+		s.rootMount,
+		s.dir,
+		s.packageName,
+		s.packageVersion,
+		value.Path()+"_"+marker,
+	), true
 }
 
 // Decide applies flag policy without filesystem access.

--- a/agent/go/internal/flags/flags_test.go
+++ b/agent/go/internal/flags/flags_test.go
@@ -127,12 +127,71 @@ var _ = Describe("flag store", func() {
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 	})
 
+	It("writes the legacy completion marker alongside the Go-native marker", func() {
+		path, err := store.Mark(value, "complete")
+		Expect(err).NotTo(HaveOccurred())
+		legacyPath := filepath.Join(
+			root,
+			"etc", "skyhook", "flags", "driver", "1.2.3",
+			"scripts", "apply.sh_WyctLW1vZGUnLCAnZmFzdCddX1swLCAyXQ==",
+		)
+
+		Expect(path).To(BeAnExistingFile())
+		Expect(legacyPath).To(BeAnExistingFile())
+		data, err := os.ReadFile(legacyPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("complete"))
+	})
+
+	It("does not publish either completion marker when preflight fails", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		legacyPath, supported := store.legacyPath(value)
+		Expect(supported).To(BeTrue())
+		Expect(os.MkdirAll(path, 0o755)).To(Succeed())
+
+		_, err = store.Mark(value, "complete")
+
+		Expect(err).To(MatchError(ContainSubstring("is not a regular file")))
+		Expect(legacyPath).NotTo(BeAnExistingFile())
+		Expect(path).To(BeADirectory())
+	})
+
+	It("recognizes and removes a legacy completion marker", func() {
+		legacyPath, supported := store.legacyPath(value)
+		Expect(supported).To(BeTrue())
+		Expect(store.Write(legacyPath, []byte("complete"))).To(Succeed())
+
+		decision, err := store.Check(value, false, stage.Apply)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decision).To(Equal(Decision{Run: false, Reason: ReasonAlreadyCompleted}))
+
+		Expect(store.Remove(value)).To(Succeed())
+		Expect(legacyPath).NotTo(BeAnExistingFile())
+	})
+
+	It("matches legacy string representations in completion fingerprints", func() {
+		value := step.NewRegularStep(
+			"apply.sh",
+			step.WithArguments([]string{"single'quote", "both'\"quotes", "line\nbreak"}),
+		)
+
+		legacyPath, supported := store.legacyPath(value)
+		Expect(supported).To(BeTrue())
+		Expect(filepath.Base(legacyPath)).To(Equal(
+			"apply.sh_WyJzaW5nbGUncXVvdGUiLCAnYm90aFwnInF1b3RlcycsICdsaW5lXG5icmVhayddX1swXQ==",
+		))
+	})
+
 	It("removes a completion flag idempotently", func() {
 		path, err := store.Mark(value, "complete")
 		Expect(err).NotTo(HaveOccurred())
+		legacyPath, supported := store.legacyPath(value)
+		Expect(supported).To(BeTrue())
 
 		Expect(store.Remove(value)).To(Succeed())
 		Expect(path).NotTo(BeAnExistingFile())
+		Expect(legacyPath).NotTo(BeAnExistingFile())
 		Expect(store.Remove(value)).To(Succeed())
 	})
 

--- a/agent/go/internal/flags/layout.go
+++ b/agent/go/internal/flags/layout.go
@@ -217,18 +217,11 @@ func (l Layout) packageLogDir(cfg config.Config, stepPath string) (string, error
 }
 
 func validatePackagePath(cfg config.Config) error {
-	if err := validatePathComponent("package name", cfg.PackageName); err != nil {
+	if err := hostfs.ValidatePathComponent("package name", cfg.PackageName); err != nil {
 		return err
 	}
-	if err := validatePathComponent("package version", cfg.PackageVersion); err != nil {
+	if err := hostfs.ValidatePathComponent("package version", cfg.PackageVersion); err != nil {
 		return err
-	}
-	return nil
-}
-
-func validatePathComponent(name, value string) error {
-	if value == "" || value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
-		return fmt.Errorf("%s %q must be a single path component", name, value)
 	}
 	return nil
 }

--- a/agent/go/internal/flags/layout_test.go
+++ b/agent/go/internal/flags/layout_test.go
@@ -62,11 +62,6 @@ var _ = Describe("Layout", func() {
 	It("resolves the copied step directory", func() {
 		Expect(StepsDir("/copy/package")).To(Equal("/copy/package/skyhook_dir"))
 	})
-
-	It("rejects dot package path components", func() {
-		Expect(validatePathComponent("package name", ".")).To(MatchError(`package name "." must be a single path component`))
-		Expect(validatePathComponent("package version", ".")).To(MatchError(`package version "." must be a single path component`))
-	})
 })
 
 var _ = Describe("log paths", func() {

--- a/agent/go/internal/history/history.go
+++ b/agent/go/internal/history/history.go
@@ -93,8 +93,8 @@ var _ Store = (*fileStore)(nil)
 // an unusable version.
 func newFileStore(layout flags.Layout, cfg config.Config, logger *slog.Logger) (*fileStore, error) {
 	name := cfg.PackageName
-	if name == "" || !filepath.IsLocal(name) || filepath.Base(name) != name {
-		return nil, fmt.Errorf("package name %q must be a single path component", name)
+	if err := hostfs.ValidatePathComponent("package name", name); err != nil {
+		return nil, err
 	}
 	if cfg.PackageVersion == "" {
 		return nil, errors.New("package version must not be empty")

--- a/agent/go/internal/hostfs/copy.go
+++ b/agent/go/internal/hostfs/copy.go
@@ -89,6 +89,95 @@ func CopyTree(rootMount, source, destination string) error {
 	})
 }
 
+// CopyTreeIfExistsFollowingSymlinks recursively copies source into a
+// destination beneath rootMount. Source links are dereferenced and destination
+// links are followed only when they remain inside rootMount. A missing source
+// is treated as an empty tree.
+func CopyTreeIfExistsFollowingSymlinks(rootMount, source, destination string) error {
+	info, err := os.Stat(source)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copy source %q is not a directory", source)
+	}
+	return CopyTreeFollowingSymlinks(rootMount, source, destination)
+}
+
+// CopyTreeFollowingSymlinks recursively copies source into a destination
+// beneath rootMount while dereferencing source links. Relative destination
+// links are followed by os.Root and cannot escape rootMount.
+func CopyTreeFollowingSymlinks(rootMount, source, destination string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copy source %q is not a directory", source)
+	}
+	return copyTreeEntryFollowingSymlinks(
+		rootMount,
+		source,
+		destination,
+		map[string]struct{}{},
+	)
+}
+
+func copyTreeEntryFollowingSymlinks(
+	rootMount, source, destination string,
+	ancestors map[string]struct{},
+) error {
+	resolved, err := filepath.EvalSymlinks(source)
+	if err != nil {
+		return fmt.Errorf("resolving copy source %q: %w", source, err)
+	}
+	info, err := os.Stat(resolved)
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if info.IsDir() {
+		if _, exists := ancestors[resolved]; exists {
+			return fmt.Errorf("copy source %q contains a symbolic-link cycle", source)
+		}
+		ancestors[resolved] = struct{}{}
+		defer delete(ancestors, resolved)
+
+		if err := makeDirectoryFollowingSymlinks(rootMount, destination, info.Mode().Perm()); err != nil {
+			return fmt.Errorf("creating copy destination directory %q: %w", destination, err)
+		}
+		entries, err := os.ReadDir(resolved)
+		if err != nil {
+			return fmt.Errorf("reading copy source directory %q: %w", source, err)
+		}
+		for _, entry := range entries {
+			if err := copyTreeEntryFollowingSymlinks(
+				rootMount,
+				filepath.Join(resolved, entry.Name()),
+				filepath.Join(destination, entry.Name()),
+				ancestors,
+			); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("copy source %q is not a regular file", source)
+	}
+	if err := copyRegularFileFollowingSymlinks(
+		rootMount,
+		resolved,
+		destination,
+		info.Mode().Perm(),
+	); err != nil {
+		return err
+	}
+	return nil
+}
+
 // CopyFile copies a regular file and its permissions to a destination beneath
 // rootMount. Source symbolic links are followed, while symbolic links in the
 // destination path are rejected.
@@ -101,6 +190,20 @@ func CopyFile(rootMount, source, destination string) error {
 		return fmt.Errorf("copy source %q is not a regular file", source)
 	}
 	return copyRegularFile(rootMount, source, destination, info.Mode().Perm())
+}
+
+// CopyFileFollowingSymlinks copies a regular source file to a destination
+// beneath rootMount. Source links are dereferenced and relative destination
+// links are followed only when they remain inside rootMount.
+func CopyFileFollowingSymlinks(rootMount, source, destination string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("copy source %q is not a regular file", source)
+	}
+	return copyRegularFileFollowingSymlinks(rootMount, source, destination, info.Mode().Perm())
 }
 
 func makeDirectory(rootMount, path string, mode fs.FileMode) (retErr error) {
@@ -174,6 +277,105 @@ func copyRegularFile(
 		return nil
 	}); err != nil {
 		return fmt.Errorf("writing copy destination %q: %w", destination, err)
+	}
+	return nil
+}
+
+func makeDirectoryFollowingSymlinks(rootMount, path string, mode fs.FileMode) (retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	if relative == "." {
+		return nil
+	}
+	if err := root.MkdirAll(filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("preparing parent directory for %q: %w", path, err)
+	}
+	info, err := root.Stat(relative)
+	if errors.Is(err, fs.ErrNotExist) {
+		if err := root.Mkdir(relative, mode); err != nil {
+			return fmt.Errorf("creating directory %q: %w", path, err)
+		}
+		info, err = root.Stat(relative)
+	}
+	if err != nil {
+		return fmt.Errorf("inspecting directory %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copy destination %q is not a directory", path)
+	}
+	if err := root.Chmod(relative, mode); err != nil {
+		return fmt.Errorf("setting permissions on directory %q: %w", path, err)
+	}
+	return nil
+}
+
+func copyRegularFileFollowingSymlinks(
+	rootMount, source, destination string,
+	mode fs.FileMode,
+) (retErr error) {
+	root, relative, err := openRoot(rootMount, destination)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("opening copy source %q: %w", source, err)
+	}
+	defer func() {
+		if err := sourceFile.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing copy source %q: %w", source, err)
+		}
+	}()
+
+	if err := root.MkdirAll(filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("creating copy destination directory %q: %w", filepath.Dir(destination), err)
+	}
+	info, err := root.Stat(relative)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("validating copy destination %q: %w", destination, err)
+	}
+	if err == nil {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("copy destination %q is not a regular file", destination)
+		}
+		sourceInfo, err := sourceFile.Stat()
+		if err != nil {
+			return fmt.Errorf("stating open copy source %q: %w", source, err)
+		}
+		if os.SameFile(sourceInfo, info) {
+			return nil
+		}
+	}
+
+	destinationFile, err := root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("opening copy destination %q: %w", destination, err)
+	}
+	defer func() {
+		if err := destinationFile.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
+			retErr = fmt.Errorf("closing copy destination %q: %w", destination, err)
+		}
+	}()
+	if _, err := io.Copy(destinationFile, sourceFile); err != nil {
+		return fmt.Errorf("copying %q to %q: %w", source, destination, err)
+	}
+	if err := root.Chmod(relative, mode); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", destination, err)
+	}
+	if err := destinationFile.Sync(); err != nil {
+		return fmt.Errorf("syncing %q: %w", destination, err)
+	}
+	if err := destinationFile.Close(); err != nil {
+		return fmt.Errorf("closing copy destination %q: %w", destination, err)
+	}
+	if err := syncRootedDirectory(root, filepath.Dir(relative)); err != nil {
+		return fmt.Errorf("syncing parent directory for %q: %w", destination, err)
 	}
 	return nil
 }

--- a/agent/go/internal/hostfs/copy_test.go
+++ b/agent/go/internal/hostfs/copy_test.go
@@ -148,6 +148,51 @@ var _ = Describe("filesystem copying", func() {
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o640)))
 	})
 
+	It("dereferences symbolic links in compatibility copy trees", func() {
+		root := GinkgoT().TempDir()
+		source := GinkgoT().TempDir()
+		linkedDirectory := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(linkedDirectory, "step"), []byte("contents"), 0o640)).To(Succeed())
+		Expect(os.Symlink(linkedDirectory, filepath.Join(source, "linked"))).To(Succeed())
+
+		Expect(CopyTreeFollowingSymlinks(root, source, filepath.Join(root, "destination"))).To(Succeed())
+
+		copied := filepath.Join(root, "destination", "linked", "step")
+		data, err := os.ReadFile(copied)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("contents"))
+		info, err := os.Lstat(filepath.Join(root, "destination", "linked"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+	})
+
+	It("follows contained relative links at compatibility copy destinations", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(GinkgoT().TempDir(), "source")
+		Expect(os.WriteFile(source, []byte("contents"), 0o640)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "usr", "lib"), 0o755)).To(Succeed())
+		Expect(os.Symlink("usr/lib", filepath.Join(root, "lib"))).To(Succeed())
+
+		Expect(CopyFileFollowingSymlinks(root, source, filepath.Join(root, "lib", "package"))).To(Succeed())
+
+		data, err := os.ReadFile(filepath.Join(root, "usr", "lib", "package"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("contents"))
+	})
+
+	It("rejects destination links that escape compatibility copy roots", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(GinkgoT().TempDir(), "source")
+		outside := GinkgoT().TempDir()
+		Expect(os.WriteFile(source, []byte("contents"), 0o640)).To(Succeed())
+		Expect(os.Symlink(outside, filepath.Join(root, "linked"))).To(Succeed())
+
+		err := CopyFileFollowingSymlinks(root, source, filepath.Join(root, "linked", "package"))
+
+		Expect(err).To(HaveOccurred())
+		Expect(filepath.Join(outside, "package")).NotTo(BeAnExistingFile())
+	})
+
 	It("rejects a symbolic link as an optional copy source", func() {
 		root := GinkgoT().TempDir()
 		source := filepath.Join(root, "source")

--- a/agent/go/internal/hostfs/hostfs.go
+++ b/agent/go/internal/hostfs/hostfs.go
@@ -34,6 +34,15 @@ import (
 
 const directoryMode = 0o755
 
+// ValidatePathComponent rejects values that could escape or add hierarchy to
+// an agent-owned path.
+func ValidatePathComponent(name, value string) error {
+	if value == "" || value == "." || !filepath.IsLocal(value) || filepath.Base(value) != value {
+		return fmt.Errorf("%s %q must be a single path component", name, value)
+	}
+	return nil
+}
+
 // HostPathToMounted maps an absolute host path beneath the mounted host root.
 func HostPathToMounted(rootMount, hostPath string) (string, error) {
 	if !filepath.IsAbs(rootMount) {

--- a/agent/go/internal/hostfs/hostfs_test.go
+++ b/agent/go/internal/hostfs/hostfs_test.go
@@ -36,6 +36,16 @@ func TestHostFS(t *testing.T) {
 }
 
 var _ = Describe("mounted host filesystem", func() {
+	It("validates path components used below agent-owned directories", func() {
+		Expect(ValidatePathComponent("package name", "driver")).To(Succeed())
+		Expect(ValidatePathComponent("package name", ".")).To(MatchError(
+			`package name "." must be a single path component`,
+		))
+		Expect(ValidatePathComponent("package name", "../driver")).To(MatchError(
+			`package name "../driver" must be a single path component`,
+		))
+	})
+
 	It("resolves absolute host paths beneath the mounted root", func() {
 		root := GinkgoT().TempDir()
 

--- a/agent/go/internal/interrupts/interrupts.go
+++ b/agent/go/internal/interrupts/interrupts.go
@@ -57,6 +57,19 @@ type Interrupt interface {
 	Serialize() ([]byte, error)
 }
 
+// ResumableInterrupt exposes command-level progress so the orchestrator can
+// preserve the legacy agent's indexed completion markers across retries.
+type ResumableInterrupt interface {
+	Interrupt
+	OperationCount() int
+	RunPending(
+		context.Context,
+		execution.Config,
+		[]bool,
+		func(int) error,
+	) (execution.Status, error)
+}
+
 func validateRun(ctx context.Context, config execution.Config, interruptType InterruptType) error {
 	if ctx == nil {
 		return errors.New("running interrupt: context is nil")
@@ -86,7 +99,7 @@ func Encode(i Interrupt) (string, error) {
 }
 
 // Decode parses a base64+JSON serialized interrupt produced by Encode
-// (or its Python counterpart skyhook_agent.interrupts.inflate).
+// (or its legacy counterpart skyhook_agent.interrupts.inflate).
 // Wire-shape errors return errInvalidSerializedInterrupt; unknown type
 // names return a descriptive error listing the supported types.
 func Decode(serializedValue string) (Interrupt, error) {

--- a/agent/go/internal/interrupts/interrupts_linux_test.go
+++ b/agent/go/internal/interrupts/interrupts_linux_test.go
@@ -20,10 +20,12 @@ package interrupts
 
 import (
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
 
@@ -58,11 +60,16 @@ var _ = Describe("interrupt chroot execution", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 
+		restartContext, cancelRestart := context.WithTimeout(context.Background(), time.Second)
+		status, err := NodeRestart{}.Run(restartContext, config)
+		cancelRestart()
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+		Expect(status).To(Equal(execution.StatusFailed))
+
 		for _, testCase := range []struct {
 			interrupt Interrupt
 			status    execution.Status
 		}{
-			{interrupt: NodeRestart{}, status: execution.StatusFailed},
 			{interrupt: ServiceRestart{Services: []string{"containerd", "kubelet"}}, status: execution.StatusSuccess},
 			{interrupt: RestartAllServices{}, status: execution.StatusSuccess},
 		} {

--- a/agent/go/internal/interrupts/interrupts_linux_test.go
+++ b/agent/go/internal/interrupts/interrupts_linux_test.go
@@ -58,14 +58,17 @@ var _ = Describe("interrupt chroot execution", func() {
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		for _, interrupt := range []Interrupt{
-			NodeRestart{},
-			ServiceRestart{Services: []string{"containerd", "kubelet"}},
-			RestartAllServices{},
+		for _, testCase := range []struct {
+			interrupt Interrupt
+			status    execution.Status
+		}{
+			{interrupt: NodeRestart{}, status: execution.StatusFailed},
+			{interrupt: ServiceRestart{Services: []string{"containerd", "kubelet"}}, status: execution.StatusSuccess},
+			{interrupt: RestartAllServices{}, status: execution.StatusSuccess},
 		} {
-			status, err := interrupt.Run(context.Background(), config)
-			Expect(err).NotTo(HaveOccurred(), string(interrupt.Type()))
-			Expect(status).To(Equal(execution.StatusSuccess), string(interrupt.Type()))
+			status, err := testCase.interrupt.Run(context.Background(), config)
+			Expect(err).NotTo(HaveOccurred(), string(testCase.interrupt.Type()))
+			Expect(status).To(Equal(testCase.status), string(testCase.interrupt.Type()))
 		}
 
 		calls, err := os.ReadFile(filepath.Join(root, "package", "interrupt-calls"))

--- a/agent/go/internal/interrupts/node_restart.go
+++ b/agent/go/internal/interrupts/node_restart.go
@@ -59,7 +59,10 @@ func (n NodeRestart) Run(ctx context.Context, config execution.Config) (executio
 	if result.Signal != nil || result.ExitCode != command.SuccessExitCode {
 		return execution.StatusFailed, nil
 	}
-	return execution.StatusSuccess, nil
+	// An exit-zero reboot only proves shutdown was enqueued. Report failure so
+	// the interrupt pod retries after the node returns and the boot-ID marker can
+	// prove that a reboot actually occurred.
+	return execution.StatusFailed, nil
 }
 
 func nodeRestartCompleted(result command.Result) bool {

--- a/agent/go/internal/interrupts/node_restart.go
+++ b/agent/go/internal/interrupts/node_restart.go
@@ -21,14 +21,17 @@ import (
 	"errors"
 	"fmt"
 	"syscall"
+	"time"
 
 	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
 )
 
-// NodeRestart runs reboot inside the configured root mount. A SIGTERM from
-// userspace shutdown marks the reboot complete even when command execution
-// ends with context cancellation or a deadline.
+const nodeRestartConfirmationTimeout = 10 * time.Second
+
+// NodeRestart runs reboot inside the configured root mount. A SIGTERM that
+// terminates the reboot command proves shutdown began; an exit-zero command
+// waits briefly so an enqueued reboot is not reported as an immediate failure.
 type NodeRestart struct{}
 
 var _ Interrupt = NodeRestart{}
@@ -59,10 +62,19 @@ func (n NodeRestart) Run(ctx context.Context, config execution.Config) (executio
 	if result.Signal != nil || result.ExitCode != command.SuccessExitCode {
 		return execution.StatusFailed, nil
 	}
-	// An exit-zero reboot only proves shutdown was enqueued. Report failure so
-	// the interrupt pod retries after the node returns and the boot-ID marker can
-	// prove that a reboot actually occurred.
-	return execution.StatusFailed, nil
+	return execution.StatusFailed, waitForNodeRestart(ctx, nodeRestartConfirmationTimeout)
+}
+
+func waitForNodeRestart(ctx context.Context, timeout time.Duration) error {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("waiting for host restart: %w", ctx.Err())
+	case <-timer.C:
+		return fmt.Errorf("reboot was enqueued but the host did not restart within %s", timeout)
+	}
 }
 
 func nodeRestartCompleted(result command.Result) bool {

--- a/agent/go/internal/interrupts/node_restart_test.go
+++ b/agent/go/internal/interrupts/node_restart_test.go
@@ -45,6 +45,7 @@ var _ = Describe("NodeRestart", func() {
 			Signal:   syscall.SIGKILL,
 		})).To(BeFalse())
 		Expect(nodeRestartCompleted(command.Result{ExitCode: 15})).To(BeFalse())
+		Expect(nodeRestartCompleted(command.Result{ExitCode: command.SuccessExitCode})).To(BeFalse())
 	})
 
 	It("validates context and execution configuration", func() {

--- a/agent/go/internal/interrupts/node_restart_test.go
+++ b/agent/go/internal/interrupts/node_restart_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"errors"
 	"syscall"
+	"time"
 
 	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
@@ -63,5 +64,22 @@ var _ = Describe("NodeRestart", func() {
 		status, err = NodeRestart{}.Run(context.Background(), execution.Config{})
 		Expect(status).To(Equal(execution.StatusFailed))
 		Expect(err).To(MatchError(ContainSubstring("invalid run config")))
+	})
+
+	It("reports when an enqueued reboot does not restart the host", func() {
+		err := waitForNodeRestart(context.Background(), time.Millisecond)
+
+		Expect(err).To(MatchError(
+			"reboot was enqueued but the host did not restart within 1ms",
+		))
+	})
+
+	It("stops waiting for a host restart when execution is canceled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := waitForNodeRestart(ctx, time.Hour)
+
+		Expect(errors.Is(err, context.Canceled)).To(BeTrue())
 	})
 })

--- a/agent/go/internal/interrupts/restart_all_services.go
+++ b/agent/go/internal/interrupts/restart_all_services.go
@@ -28,10 +28,46 @@ import (
 type RestartAllServices struct{}
 
 var _ Interrupt = RestartAllServices{}
+var _ ResumableInterrupt = RestartAllServices{}
 
 func (RestartAllServices) Type() InterruptType { return RestartAllServicesType }
 
 func (r RestartAllServices) Run(ctx context.Context, config execution.Config) (execution.Status, error) {
+	return r.run(ctx, config, nil)
+}
+
+// OperationCount reports the single service reload command.
+func (RestartAllServices) OperationCount() int { return 1 }
+
+// RunPending skips the command when its indexed completion marker exists.
+func (r RestartAllServices) RunPending(
+	ctx context.Context,
+	config execution.Config,
+	completed []bool,
+	markCompleted func(int) error,
+) (execution.Status, error) {
+	if len(completed) != r.OperationCount() {
+		return execution.StatusFailed, fmt.Errorf(
+			"running interrupt %q: received %d completion states for %d operations",
+			r.Type(),
+			len(completed),
+			r.OperationCount(),
+		)
+	}
+	if markCompleted == nil {
+		return execution.StatusFailed, fmt.Errorf("running interrupt %q: completion callback is nil", r.Type())
+	}
+	if completed[0] {
+		return execution.StatusSuccess, nil
+	}
+	return r.run(ctx, config, markCompleted)
+}
+
+func (r RestartAllServices) run(
+	ctx context.Context,
+	config execution.Config,
+	markCompleted func(int) error,
+) (execution.Status, error) {
 	if err := validateRun(ctx, config, r.Type()); err != nil {
 		return execution.StatusFailed, err
 	}
@@ -50,6 +86,11 @@ func (r RestartAllServices) Run(ctx context.Context, config execution.Config) (e
 	}
 	if result.Signal != nil || result.ExitCode != command.SuccessExitCode {
 		return execution.StatusFailed, nil
+	}
+	if markCompleted != nil {
+		if err := markCompleted(0); err != nil {
+			return execution.StatusFailed, fmt.Errorf("marking interrupt %q complete: %w", r.Type(), err)
+		}
 	}
 	return execution.StatusSuccess, nil
 }

--- a/agent/go/internal/interrupts/service_restart.go
+++ b/agent/go/internal/interrupts/service_restart.go
@@ -37,10 +37,47 @@ type ServiceRestart struct {
 }
 
 var _ Interrupt = ServiceRestart{}
+var _ ResumableInterrupt = ServiceRestart{}
 
 func (ServiceRestart) Type() InterruptType { return ServiceRestartType }
 
 func (s ServiceRestart) Run(ctx context.Context, config execution.Config) (execution.Status, error) {
+	return s.runPending(ctx, config, make([]bool, s.OperationCount()), nil)
+}
+
+// OperationCount reports the daemon-reload command plus one command per service.
+func (s ServiceRestart) OperationCount() int {
+	return 1 + len(s.Services)
+}
+
+// RunPending runs only operations without completion markers and marks each
+// operation immediately after it succeeds.
+func (s ServiceRestart) RunPending(
+	ctx context.Context,
+	config execution.Config,
+	completed []bool,
+	markCompleted func(int) error,
+) (execution.Status, error) {
+	if len(completed) != s.OperationCount() {
+		return execution.StatusFailed, fmt.Errorf(
+			"running interrupt %q: received %d completion states for %d operations",
+			s.Type(),
+			len(completed),
+			s.OperationCount(),
+		)
+	}
+	if markCompleted == nil {
+		return execution.StatusFailed, fmt.Errorf("running interrupt %q: completion callback is nil", s.Type())
+	}
+	return s.runPending(ctx, config, completed, markCompleted)
+}
+
+func (s ServiceRestart) runPending(
+	ctx context.Context,
+	config execution.Config,
+	completed []bool,
+	markCompleted func(int) error,
+) (execution.Status, error) {
 	if err := validateRun(ctx, config, s.Type()); err != nil {
 		return execution.StatusFailed, err
 	}
@@ -65,6 +102,9 @@ func (s ServiceRestart) Run(ctx context.Context, config execution.Config) (execu
 
 	runner := command.NewRunner(command.WithChroot(config.RootMount()))
 	for index, cmd := range commands {
+		if completed[index] {
+			continue
+		}
 		result, runErr := runner.Run(ctx, cmd)
 		if runErr != nil {
 			return execution.StatusFailed, fmt.Errorf(
@@ -77,6 +117,16 @@ func (s ServiceRestart) Run(ctx context.Context, config execution.Config) (execu
 		}
 		if result.Signal != nil || result.ExitCode != command.SuccessExitCode {
 			return execution.StatusFailed, nil
+		}
+		if markCompleted != nil {
+			if err := markCompleted(index); err != nil {
+				return execution.StatusFailed, fmt.Errorf(
+					"marking interrupt %q command %d complete: %w",
+					s.Type(),
+					index,
+					err,
+				)
+			}
 		}
 	}
 	return execution.StatusSuccess, nil

--- a/agent/go/internal/stage/stage.go
+++ b/agent/go/internal/stage/stage.go
@@ -79,7 +79,7 @@ var CheckToApply = map[Stage]Stage{
 	PostInterruptCheck: PostInterrupt,
 }
 
-// nonStepStages is the Go counterpart to Python's NON_STEP_MODES list.
+// nonStepStages is the Go counterpart to the legacy NON_STEP_MODES list.
 // A "non-step" stage is one the agent dispatches without an apply/check
 // companion: Interrupt today, possibly more in the future. Adding a
 // stage here is enough to exclude it from IsStepStage.

--- a/agent/go/internal/step/idempotence.go
+++ b/agent/go/internal/step/idempotence.go
@@ -45,7 +45,7 @@ func (i Idempotence) Validate() error {
 	}
 }
 
-// MarshalJSON encodes idempotence as the wire bool Python uses:
+// MarshalJSON encodes idempotence as the wire bool the legacy agent uses:
 // true == Disabled (the step manages its own idempotence), false ==
 // Auto. Owning the codec here lets the step structs serialize via
 // stdlib without a custom marshaler.

--- a/agent/go/internal/step/mock/Step.go
+++ b/agent/go/internal/step/mock/Step.go
@@ -94,6 +94,50 @@ func (_c *MockStep_Encode_Call) RunAndReturn(run func() ([]byte, error)) *MockSt
 	return _c
 }
 
+// ExecutionMetadata provides a mock function for the type MockStep
+func (_mock *MockStep) ExecutionMetadata() step.ExecutionMetadata {
+	ret := _mock.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for ExecutionMetadata")
+	}
+
+	var r0 step.ExecutionMetadata
+	if returnFunc, ok := ret.Get(0).(func() step.ExecutionMetadata); ok {
+		r0 = returnFunc()
+	} else {
+		r0 = ret.Get(0).(step.ExecutionMetadata)
+	}
+	return r0
+}
+
+// MockStep_ExecutionMetadata_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecutionMetadata'
+type MockStep_ExecutionMetadata_Call struct {
+	*mock.Call
+}
+
+// ExecutionMetadata is a helper method to define mock.On call
+func (_e *MockStep_Expecter) ExecutionMetadata() *MockStep_ExecutionMetadata_Call {
+	return &MockStep_ExecutionMetadata_Call{Call: _e.mock.On("ExecutionMetadata")}
+}
+
+func (_c *MockStep_ExecutionMetadata_Call) Run(run func()) *MockStep_ExecutionMetadata_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockStep_ExecutionMetadata_Call) Return(executionMetadata step.ExecutionMetadata) *MockStep_ExecutionMetadata_Call {
+	_c.Call.Return(executionMetadata)
+	return _c
+}
+
+func (_c *MockStep_ExecutionMetadata_Call) RunAndReturn(run func() step.ExecutionMetadata) *MockStep_ExecutionMetadata_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Fingerprint provides a mock function for the type MockStep
 func (_mock *MockStep) Fingerprint() (string, error) {
 	ret := _mock.Called()

--- a/agent/go/internal/step/regular_step.go
+++ b/agent/go/internal/step/regular_step.go
@@ -67,6 +67,12 @@ func (s RegularStep) Idempotence() Idempotence {
 	return s.IdempotenceMode
 }
 
+// ExecutionMetadata reports the regular step's configured command settings.
+func (s RegularStep) ExecutionMetadata() ExecutionMetadata {
+	s.applyDefaults()
+	return newExecutionMetadata(s.Arguments, s.Returncodes, s.OnHost)
+}
+
 // WithVersions returns a copy with the package versions in its command environment.
 func (s RegularStep) WithVersions(previous, current string) Step {
 	s.versions = &stepVersions{previous: previous, current: current}

--- a/agent/go/internal/step/shared.go
+++ b/agent/go/internal/step/shared.go
@@ -29,7 +29,9 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
@@ -77,6 +79,73 @@ func newStepOptions(path string, opts ...Option) stepOptions {
 		&value.idempotence,
 	)
 	return value
+}
+
+func newExecutionMetadata(
+	arguments []string,
+	returnCodes []command.ExitCode,
+	onHost bool,
+) ExecutionMetadata {
+	return ExecutionMetadata{
+		Arguments:   slices.Clone(arguments),
+		ReturnCodes: slices.Clone(returnCodes),
+		OnHost:      onHost,
+	}
+}
+
+// FormatLegacyArguments formats arguments for legacy-agent-compatible state and output.
+func FormatLegacyArguments(values []string) string {
+	encoded := make([]string, len(values))
+	for index, value := range values {
+		encoded[index] = formatLegacyString(value)
+	}
+	return "[" + strings.Join(encoded, ", ") + "]"
+}
+
+// FormatLegacyReturnCodes formats return codes for legacy-agent-compatible state and output.
+func FormatLegacyReturnCodes(values []command.ExitCode) string {
+	encoded := make([]string, len(values))
+	for index, value := range values {
+		encoded[index] = strconv.Itoa(int(value))
+	}
+	return "[" + strings.Join(encoded, ", ") + "]"
+}
+
+func formatLegacyString(value string) string {
+	quote := '\''
+	if strings.ContainsRune(value, '\'') && !strings.ContainsRune(value, '"') {
+		quote = '"'
+	}
+	var encoded strings.Builder
+	encoded.WriteRune(quote)
+	for _, value := range value {
+		switch value {
+		case '\\':
+			encoded.WriteString(`\\`)
+		case quote:
+			encoded.WriteRune('\\')
+			encoded.WriteRune(value)
+		case '\t':
+			encoded.WriteString(`\t`)
+		case '\n':
+			encoded.WriteString(`\n`)
+		case '\r':
+			encoded.WriteString(`\r`)
+		default:
+			switch {
+			case unicode.IsPrint(value):
+				encoded.WriteRune(value)
+			case value <= 0xff:
+				_, _ = fmt.Fprintf(&encoded, `\x%02x`, value)
+			case value <= 0xffff:
+				_, _ = fmt.Fprintf(&encoded, `\u%04x`, value)
+			default:
+				_, _ = fmt.Fprintf(&encoded, `\U%08x`, value)
+			}
+		}
+	}
+	encoded.WriteRune(quote)
+	return encoded.String()
 }
 
 // WithName overrides the default name, which otherwise falls back to the script path.
@@ -192,6 +261,7 @@ func runStep(
 		command.WithEnvironment(environment),
 		command.WithStdout(config.Stdout()),
 		command.WithStderr(config.Stderr()),
+		command.WithRequiredPermissions(0o111),
 	)
 
 	result, err := runner.Run(ctx, cmd)

--- a/agent/go/internal/step/shared_linux_test.go
+++ b/agent/go/internal/step/shared_linux_test.go
@@ -60,4 +60,39 @@ var _ = Describe("shared step execution in a chroot", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(status).To(Equal(execution.StatusSuccess))
 	})
+
+	It("adds execute bits without clearing package-provided permissions", func() {
+		if os.Geteuid() != 0 {
+			Fail("chroot execution requires root privileges")
+		}
+
+		root := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(root, "steps"), 0o755)).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(root, "package"), 0o755)).To(Succeed())
+		testExecutable, err := filepath.Abs(os.Args[0])
+		Expect(err).NotTo(HaveOccurred())
+		data, err := os.ReadFile(testExecutable)
+		Expect(err).NotTo(HaveOccurred())
+		executable := filepath.Join(root, "steps", "step-helper")
+		Expect(os.WriteFile(executable, data, 0o640)).To(Succeed())
+		config, err := execution.NewConfig(
+			execution.WithRootMount(root),
+			execution.WithStepRoot("/steps"),
+			execution.WithSkyhookDir("/package"),
+			execution.WithRunOutput(io.Discard, io.Discard),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		value := NewRegularStep(
+			"step-helper",
+			WithArguments([]string{"-test.run=^TestStep$", "--", "exit", "0"}),
+		)
+
+		status, err := value.Run(context.Background(), config)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		info, err := os.Stat(executable)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o751)))
+	})
 })

--- a/agent/go/internal/step/step.go
+++ b/agent/go/internal/step/step.go
@@ -23,8 +23,17 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
 )
+
+// ExecutionMetadata contains the configured values orchestration needs without
+// depending on a concrete step type.
+type ExecutionMetadata struct {
+	Arguments   []string
+	ReturnCodes []command.ExitCode
+	OnHost      bool
+}
 
 // Step is the interface satisfied by every concrete step type the
 // agent recognises (RegularStep, UpgradeStep). Callers that must
@@ -53,6 +62,9 @@ type Step interface {
 
 	// Idempotence reports how the agent treats re-runs of the step.
 	Idempotence() Idempotence
+
+	// ExecutionMetadata reports the command settings shared by every step type.
+	ExecutionMetadata() ExecutionMetadata
 }
 
 // Decode parses a JSON step payload, returning either a RegularStep or an

--- a/agent/go/internal/step/step_test.go
+++ b/agent/go/internal/step/step_test.go
@@ -91,6 +91,39 @@ var _ = Describe("Step interface", func() {
 		Expect(sawRegular).To(BeTrue())
 		Expect(sawUpgrade).To(BeTrue())
 	})
+
+	It("exposes cloned execution metadata", func() {
+		value := NewRegularStep(
+			"foo.sh",
+			WithArguments([]string{"first"}),
+			WithReturncodes([]command.ExitCode{0, 2}),
+			WithOnHost(false),
+		)
+
+		metadata := value.ExecutionMetadata()
+
+		Expect(metadata).To(Equal(ExecutionMetadata{
+			Arguments:   []string{"first"},
+			ReturnCodes: []command.ExitCode{0, 2},
+			OnHost:      false,
+		}))
+		metadata.Arguments[0] = "changed"
+		metadata.ReturnCodes[0] = 9
+		Expect(value.Arguments).To(Equal([]string{"first"}))
+		Expect(value.Returncodes).To(Equal([]command.ExitCode{0, 2}))
+	})
+})
+
+var _ = Describe("legacy compatibility formatting", func() {
+	It("formats configured arguments with legacy quoting", func() {
+		Expect(FormatLegacyArguments([]string{"plain", "it's", "line\n"})).To(Equal(
+			`['plain', "it's", 'line\n']`,
+		))
+	})
+
+	It("formats configured return codes as a legacy list", func() {
+		Expect(FormatLegacyReturnCodes([]command.ExitCode{0, 2})).To(Equal("[0, 2]"))
+	})
 })
 
 var _ = Describe("Decode", func() {

--- a/agent/go/internal/step/upgrade_step.go
+++ b/agent/go/internal/step/upgrade_step.go
@@ -77,7 +77,11 @@ func (s UpgradeStep) Idempotence() Idempotence {
 // ExecutionMetadata reports the upgrade step's configured command settings.
 func (s UpgradeStep) ExecutionMetadata() ExecutionMetadata {
 	s.applyDefaults()
-	return newExecutionMetadata(s.Arguments, s.Returncodes, s.OnHost)
+	arguments := s.Arguments
+	if s.versions != nil {
+		arguments = []string{s.versions.previous, s.versions.current}
+	}
+	return newExecutionMetadata(arguments, s.Returncodes, s.OnHost)
 }
 
 // WithVersions returns a copy prepared with version environment and arguments.

--- a/agent/go/internal/step/upgrade_step.go
+++ b/agent/go/internal/step/upgrade_step.go
@@ -74,6 +74,12 @@ func (s UpgradeStep) Idempotence() Idempotence {
 	return s.IdempotenceMode
 }
 
+// ExecutionMetadata reports the upgrade step's configured command settings.
+func (s UpgradeStep) ExecutionMetadata() ExecutionMetadata {
+	s.applyDefaults()
+	return newExecutionMetadata(s.Arguments, s.Returncodes, s.OnHost)
+}
+
 // WithVersions returns a copy prepared with version environment and arguments.
 func (s UpgradeStep) WithVersions(previous, current string) Step {
 	s.versions = &stepVersions{previous: previous, current: current}

--- a/agent/go/internal/step/upgrade_step_test.go
+++ b/agent/go/internal/step/upgrade_step_test.go
@@ -150,6 +150,8 @@ printf 'environment=%s,%s\n' "$PREVIOUS_VERSION" "$CURRENT_VERSION"
 		)
 		Expect(err).NotTo(HaveOccurred())
 		runnable := u.WithVersions("previous", "current")
+		Expect(runnable.ExecutionMetadata().Arguments).To(Equal([]string{"previous", "current"}))
+		Expect(u.ExecutionMetadata().Arguments).To(BeEmpty())
 
 		status, err := runnable.Run(
 			context.Background(),

--- a/docs/architecture/interrupt-flow.md
+++ b/docs/architecture/interrupt-flow.md
@@ -16,8 +16,17 @@ When a package requires an interrupt (such as a reboot or service restart), Node
 4. **Drain** - Remaining workloads are gracefully evicted from the node
 5. **Apply** / **Upgrade** (if upgrading) - Package installation/upgrade operations are executed  
 6. **Config** - Configuration and setup operations are performed
-7. **Interrupt** - The actual interrupt operation (reboot, service restart, etc.) is executed
+7. **Interrupt** - The actual interrupt operation (reboot, service restart, etc.) is executed. A node restart is complete only after a later agent invocation observes that the host boot ID changed.
 8. **Post-Interrupt** - Any cleanup or verification operations after the interrupt
+
+Before requesting a node restart, the agent writes a pending marker containing
+the current host boot ID. If `reboot` exits successfully before shutdown reaches
+the agent, the agent waits for up to 10 seconds for shutdown to terminate the
+process. Remaining alive for the full window is reported as a failure because
+the reboot was enqueued but did not take effect. After the node returns, the
+next invocation compares the pending boot ID with the current value. A changed
+boot ID promotes the pending marker to complete and allows post-interrupt work;
+an unchanged boot ID removes the stale marker and retries the restart.
 
 ### For packages WITHOUT interrupts:
 


### PR DESCRIPTION
## Description

Completes the final orchestration for the Go agent rewrite and activates it through the production entrypoint.

- Adds the agent runtime with typed exit codes, signal-aware cancellation, environment configuration, and current and legacy invocation formats.
- Orchestrates package preparation, configuration loading, lifecycle steps and checks, completion flags, upgrade history, logging, and cleanup.
- Runs decoded interrupts with per-resource completion markers and boot-ID-based node restart completion.
- Streams step and interrupt output while retaining collision-safe host log files when enabled.
- Replaces the placeholder executable with the signal-aware agent entrypoint.
- Documents invocation forms, runtime behavior, environment variables, logging, signals, and exit statuses.

Depends on #408.
Closes #219

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.