### PR TITLE
feat: add runtimeRequiredCordonAfter to support persistent node cordons

### DIFF
--- a/chart/templates/nodewright-crd.yaml
+++ b/chart/templates/nodewright-crd.yaml
@@ -643,6 +643,15 @@ spec:
                 description: This NodeWright is required to have been completed before
                   any workloads can start
                 type: boolean
+              runtimeRequiredCordonAfter:
+                default: false
+                description: |-
+                  RuntimeRequiredCordonAfter will result in the operator applying a persistent node cordon
+                  after all runtime-required NodeWrights complete against a given node if the node currently
+                  has the runtime-required taint applied. The operator will apply a runtimeRequiredCordon
+                  annotation and mark the given node as unschedulable. This setting is only respected if
+                  RuntimeRequired is also true.
+                type: boolean
               sequencing:
                 default: node
                 description: |-

--- a/docs/architecture/interrupt-flow.md
+++ b/docs/architecture/interrupt-flow.md
@@ -108,17 +108,17 @@ and then drained together on the following pass.
 
 ### Shared Cordon Ownership
 
-Each NodeWright that cordons a node records ownership with a `nodewright.nvidia.com/cordon_<nodewright-name>` annotation. When that NodeWright completes, it removes only its own cordon annotation. The node is marked schedulable only after no `nodewright.nvidia.com/cordon_*` annotations remain, so one NodeWright cannot uncordon a node that another NodeWright is still preparing for interrupt work.
+Each NodeWright that cordons a node records ownership with a `nodewright.nvidia.com/cordon_<nodewright-name>` annotation. When that NodeWright completes, it removes only its own cordon annotation. The node is marked schedulable only after no `nodewright.nvidia.com/cordon_*` annotations remain, so one NodeWright cannot uncordon a node that another NodeWright is still preparing for interrupt work. Additionally, if a persistent cordon was previously applied from a NodeWright which set `runtimeRequiredCordonAfter` to true, the cordon will persist even after all `nodewright.nvidia.com/cordon_*` annotations are removed.
 
-Other NodeWright annotations, such as `status_*`, `nodeState_*`, and `version_*`, do not keep a node cordoned. Only the `cordon_*` annotation family participates in shared cordon ownership.
+Other NodeWright annotations, such as `status_*`, `nodeState_*`, and `version_*`, do not keep a node cordoned. Only the `cordon_*` annotation family and `runtimeRequiredCordon` participate in shared cordon ownership.
 
 ### Orphaned Cordon Recovery
 
 If a NodeWright is force-deleted in a way that bypasses finalizer cleanup, or cleanup fails after the node was cordoned, its `cordon_<nodewright-name>` annotation can be left behind. That stale annotation will keep the node unschedulable from the operator's point of view until it is removed.
 
-Use `kubectl nodewright reset <nodewright-name> --confirm` to clear NodeWright metadata for affected nodes that still have `nodeState_<nodewright-name>` annotations, or `kubectl nodewright node reset <node-name> --nodewright <nodewright-name> --confirm` for a specific node. These reset commands remove the matching `cordon_<nodewright-name>` annotation, but they do not clear `spec.unschedulable`. After the stale cordon annotation is removed, if no other `nodewright.nvidia.com/cordon_*` annotations remain and no live NodeWright is expected to uncordon the node, run `kubectl uncordon <node-name>` to make it schedulable again.
+Use `kubectl nodewright reset <nodewright-name> --confirm` to clear NodeWright metadata for affected nodes that still have `nodeState_<nodewright-name>` annotations, or `kubectl nodewright node reset <node-name> --nodewright <nodewright-name> --confirm` for a specific node. These reset commands remove the matching `cordon_<nodewright-name>` annotation, but they do not clear `spec.unschedulable`. After the stale cordon annotation is removed, if no other `nodewright.nvidia.com/cordon_*` annotations remain and no live NodeWright is expected to uncordon the node, check for the `runtimeRequiredCordon` annotation before running `kubectl uncordon <node-name>`. If the annotation is absent, uncordoning is a safe recovery step. If the annotation is present, it means a NodeWright intentionally applied a persistent cordon, and `kubectl uncordon` is not a recovery step unless removing the persistent cordon is intentional.
 
-If the node only has a stale `cordon_<nodewright-name>` annotation and its `nodeState_<nodewright-name>` annotation has already been removed, `kubectl nodewright reset` will not discover the node. In that case, remove the orphaned annotation manually, then uncordon the node as above if no other NodeWright still owns a cordon.
+If the node only has a stale `cordon_<nodewright-name>` annotation and its `nodeState_<nodewright-name>` annotation has already been removed, `kubectl nodewright reset` will not discover the node. In that case, remove the orphaned annotation manually, then uncordon the node as above, subject to the same `runtimeRequiredCordon` check.
 
 ## Drain Configuration
 

--- a/docs/user-guide/runtime-required.md
+++ b/docs/user-guide/runtime-required.md
@@ -130,7 +130,25 @@ This per-node behavior prevents deadlocks where a few bad nodes would block all 
 
 ## What happens when the taint is removed
 
-1. The node becomes available for general workload scheduling (pods without the runtime-required toleration can now be scheduled on it).
+- If `runtimeRequiredCordonAfter` is false on all `runtimeRequired` NodeWrights, the node is eligible for general workload scheduling (pods without the runtime-required toleration can now be scheduled on it), unless another NodeWright's `cordon_*` annotation is still holding it.
+- If `runtimeRequiredCordonAfter` is true on one or more `runtimeRequired` NodeWrights, the node will be cordoned at the same time the runtime-required taint is removed. The operator will also set the `nodewright.nvidia.com/runtimeRequiredCordon` annotation on each cordoned node. Note that this setting is only respected on a given NodeWright if `runtimeRequired` is also true. The cordon is only applied to nodes that currently hold the runtime-required taint. Recall that the runtime-required taint could be applied externally of NodeWright for new nodes or via the autoTaintNewNodes feature described above. As a result, when the operator is configured with `REAPPLY_ON_REBOOT=true` and a NodeWright has `runtimeRequired: true`, `autoTaintNewNodes: true`, and `runtimeRequiredCordonAfter: true`, the cordon would be re-applied after the reboot and re-run complete.
+
+```yaml
+spec:
+  runtimeRequired: true
+  runtimeRequiredCordonAfter: true
+```
+
+An external actor can clear the node cordon by setting `unschedulable` to false and removing the annotation. If a node is uncordoned but the external actor does not remove the `runtimeRequiredCordon` annotation, the operator will automatically remove the annotation from the node.
+
+```bash
+kubectl patch node <node-name> --type=merge \
+  -p '{"metadata":{"annotations":{"nodewright.nvidia.com/runtimeRequiredCordon":null}},"spec":{"unschedulable":false}}'
+```
+
+Note that a cordon applied via `runtimeRequiredCordonAfter` will persist after running the reset CLI command: `kubectl nodewright reset`
+
+`kubectl nodewright node status` reports `CORDONED` and `RUNTIME-REQUIRED-CORDON` for each node, so you can tell whether a cordoned node needs an external actor to uncordon it, as described above.
 
 ## Why would you use runtime required
 

--- a/docs/user-guide/uninstall.md
+++ b/docs/user-guide/uninstall.md
@@ -87,7 +87,7 @@ Cancellation semantics depend on which stage the node is at when `apply` is flip
 
 When a NodeWright CR is deleted (`kubectl delete nodewright my-nodewright`):
 
-- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then removes this NodeWright's own cordon ownership and metadata. A node is uncordoned only once no `cordon_*` ownership annotations remain (other NodeWrights sharing the node may still hold it); the CR finalizer is removed last.
+- **`enabled: true` packages**: The finalizer triggers uninstall pods, waits for completion on all nodes, then removes this NodeWright's own cordon ownership and metadata. A node is uncordoned only once no `cordon_*` ownership annotations remain (other NodeWrights sharing the node may still hold it); the CR finalizer is removed last. Note that if a persistent cordon was previously applied from a NodeWright which set `runtimeRequiredCordonAfter` to true, the cordon will persist even after all `cordon_*` ownership annotations are removed.
 - **`enabled: false` packages (or nil)**: No uninstall pods — state is cleaned up immediately. The package state remains on nodes so administrators can see what was previously applied.
 
 #### Deletion edge cases

--- a/k8s-tests/chainsaw/nodewright/runtime-required-cordon-after/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/nodewright/runtime-required-cordon-after/chainsaw-test.yaml
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: runtime-required-cordon-after
+  labels:
+    pool: interrupt
+spec:
+  timeouts:
+    assert: 120s
+  catch:
+  - get:
+      apiVersion: v1
+      kind: Node
+      selector: nodewright.nvidia.com/runtime-required-cordon-after-test=true
+      format: yaml
+  - get:
+      apiVersion: nodewright.nvidia.com/v1alpha1
+      kind: NodeWright
+      name: runtime-required-cordon-after
+      format: yaml
+  - get:
+      apiVersion: nodewright.nvidia.com/v1alpha1
+      kind: NodeWright
+      name: runtime-required-no-cordon
+      format: yaml
+  - get:
+      apiVersion: nodewright.nvidia.com/v1alpha1
+      kind: NodeWright
+      name: runtime-required-cordon-after-interrupt
+      format: yaml
+  steps:
+  # Phase 1: Apply node label matching NodeWright selector and apply runtime-required taint to the matching node
+  - name: setup
+    try:
+    - script:
+        content: |
+          ../nodewright-cli reset runtime-required-cordon-after --confirm 2>/dev/null || true
+          ../nodewright-cli reset runtime-required-no-cordon --confirm 2>/dev/null || true
+          ../nodewright-cli reset runtime-required-cordon-after-interrupt --confirm 2>/dev/null || true
+          kubectl patch node kind-worker --type=merge \
+            -p '{"metadata":{"annotations":{"nodewright.nvidia.com/runtimeRequiredCordon":null}},"spec":{"unschedulable":false}}' \
+            2>/dev/null || true
+
+          kubectl label node kind-worker nodewright.nvidia.com/runtime-required-cordon-after-test=true --overwrite
+          ../nodes_add_taint.sh all skyhook.nvidia.com=runtime-required:NoSchedule nodewright.nvidia.com/runtime-required-cordon-after-test=true
+
+  # Phase 2: Create two NodeWrights targeting the same node where one sets runtimeRequiredCordonAfter to true
+  # and the other sets runtimeRequiredCordonAfter to false.
+  - name: apply-nodewrights
+    try:
+    - create:
+        resource:
+          apiVersion: nodewright.nvidia.com/v1alpha1
+          kind: NodeWright
+          metadata:
+            labels:
+              app.kubernetes.io/part-of: skyhook-operator
+              app.kubernetes.io/created-by: skyhook-operator
+            name: runtime-required-cordon-after
+          spec:
+            runtimeRequired: true
+            runtimeRequiredCordonAfter: true
+            nodeSelectors:
+              matchLabels:
+                nodewright.nvidia.com/runtime-required-cordon-after-test: "true"
+            packages:
+              spencer:
+                version: "3.2.3"
+                image: ghcr.io/nvidia/skyhook/agentless
+                env:
+                  - name: SLEEP_LEN
+                    value: "2"
+    - create:
+        resource:
+          apiVersion: nodewright.nvidia.com/v1alpha1
+          kind: NodeWright
+          metadata:
+            labels:
+              app.kubernetes.io/part-of: skyhook-operator
+              app.kubernetes.io/created-by: skyhook-operator
+            name: runtime-required-no-cordon
+          spec:
+            runtimeRequired: true
+            runtimeRequiredCordonAfter: false
+            nodeSelectors:
+              matchLabels:
+                nodewright.nvidia.com/runtime-required-cordon-after-test: "true"
+            packages:
+              casey:
+                version: "3.2.3"
+                image: ghcr.io/nvidia/skyhook/agentless
+                env:
+                  - name: SLEEP_LEN
+                    value: "2"
+
+  # Phase 3: Wait for both NodeWrights to complete on the targeted node
+  - name: assert-nodewrights-complete
+    try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: kind-worker
+            labels:
+              nodewright.nvidia.com/status_runtime-required-cordon-after: complete
+              nodewright.nvidia.com/status_runtime-required-no-cordon: complete
+            annotations:
+              nodewright.nvidia.com/status_runtime-required-cordon-after: complete
+              nodewright.nvidia.com/status_runtime-required-no-cordon: complete
+
+  # Phase 4: Assert the runtime-required taint was removed and the cordon was applied
+  - name: assert-taint-removed-and-node-cordoned
+    try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: kind-worker
+            annotations:
+              nodewright.nvidia.com/runtimeRequiredCordon: "true"
+          spec:
+            unschedulable: true
+            (!taints || length(taints[?key == 'skyhook.nvidia.com' && effect == 'NoSchedule' && value == 'runtime-required'])==`0`): true
+
+  # Phase 5: A later NodeWright with an interrupt package runs on the same node with the persistent cordon.
+  - name: apply-interrupting-nodewright
+    try:
+    - create:
+        resource:
+          apiVersion: nodewright.nvidia.com/v1alpha1
+          kind: NodeWright
+          metadata:
+            labels:
+              app.kubernetes.io/part-of: skyhook-operator
+              app.kubernetes.io/created-by: skyhook-operator
+            name: runtime-required-cordon-after-interrupt
+          spec:
+            nodeSelectors:
+              matchLabels:
+                nodewright.nvidia.com/runtime-required-cordon-after-test: "true"
+            packages:
+              hank:
+                version: "1.2.3"
+                image: ghcr.io/nvidia/skyhook/agentless
+                interrupt:
+                  type: service
+                  services: [rsyslog]
+                env:
+                  - name: SLEEP_LEN
+                    value: "2"
+
+  # Phase 6: Wait for the interrupting NodeWright to complete and assert the persistent cordon
+  # exists after the interrupt sequence.
+  - name: assert-cordon-survives-interrupt
+    try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: kind-worker
+            labels:
+              nodewright.nvidia.com/status_runtime-required-cordon-after-interrupt: complete
+            annotations:
+              nodewright.nvidia.com/status_runtime-required-cordon-after-interrupt: complete
+              nodewright.nvidia.com/runtimeRequiredCordon: "true"
+          spec:
+            unschedulable: true
+
+  # Phase 7: External actor releases the cordon but leaves the runtimeRequiredCordon annotation.
+  - name: release-cordon
+    try:
+    - script:
+        content: |
+          kubectl patch node kind-worker --type=merge -p '{"spec":{"unschedulable":false}}'
+
+  # Phase 8: The operator automatically removes the stale runtimeRequiredCordon annotation after the
+  # node is uncordoned.
+  - name: assert-annotation-removed
+    try:
+    - assert:
+        resource:
+          apiVersion: v1
+          kind: Node
+          metadata:
+            name: kind-worker
+            (annotations."nodewright.nvidia.com/runtimeRequiredCordon" == null): true
+          spec:
+            (!unschedulable): true
+
+    finally:
+    - script:
+        content: |
+          ../nodes_remove_taint.sh all skyhook.nvidia.com=runtime-required:NoSchedule nodewright.nvidia.com/runtime-required-cordon-after-test=true
+          kubectl patch node kind-worker --type=merge \
+            -p '{"metadata":{"annotations":{"nodewright.nvidia.com/runtimeRequiredCordon":null}},"spec":{"unschedulable":false}}' \
+            2>/dev/null || true
+          kubectl label node kind-worker nodewright.nvidia.com/runtime-required-cordon-after-test- 2>/dev/null || true

--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -226,6 +226,16 @@ For the full commit-level log see CHANGELOG.md.
 
 ### New Features
 
+- **New `spec.runtimeRequiredCordonAfter`** applies a persistent cordon at the
+  same time the runtime-required taint is removed, for any NodeWright that sets
+  both `runtimeRequired: true` and `runtimeRequiredCordonAfter: true`. The node
+  is marked with a `runtimeRequiredCordon` annotation so the cordon survives
+  later NodeWright interrupts. Releasing it requires removing the annotation
+  and setting `unschedulable` to false in the same patch. If the node is
+  uncordoned externally without removing the annotation, the operator removes
+  it automatically. `kubectl nodewright node status` reports the cordon via new
+  `CORDONED` and `RUNTIME-REQUIRED-CORDON` columns. See
+  [docs/user-guide/runtime-required.md](../docs/user-guide/runtime-required.md#what-happens-when-the-taint-is-removed).
 - **Package stages now execute as `batch/v1` Jobs**, one per (NodeWright,
   package, stage, node), instead of operator-managed raw pods. The lifecycle
   state machine is unchanged — stages, Status/State derivation, interrupt /

--- a/operator/api/nodewright/v1alpha1/nodewright_types.go
+++ b/operator/api/nodewright/v1alpha1/nodewright_types.go
@@ -77,6 +77,14 @@ type NodeWrightSpec struct {
 	//+kubebuilder:default=false
 	RuntimeRequired bool `json:"runtimeRequired,omitempty"`
 
+	// RuntimeRequiredCordonAfter will result in the operator applying a persistent node cordon
+	// after all runtime-required NodeWrights complete against a given node if the node currently
+	// has the runtime-required taint applied. The operator will apply a runtimeRequiredCordon
+	// annotation and mark the given node as unschedulable. This setting is only respected if
+	// RuntimeRequired is also true.
+	//+kubebuilder:default=false
+	RuntimeRequiredCordonAfter bool `json:"runtimeRequiredCordonAfter,omitempty"`
+
 	// AutoTaintNewNodes enables the operator to automatically apply the runtime-required taint
 	// to new nodes that match this NodeWright's node selector. Only meaningful when RuntimeRequired is true.
 	// A node is considered "new" if it has no nodewright.nvidia.com/* annotations.
@@ -882,6 +890,10 @@ type State string
 
 const (
 	METADATA_PREFIX string = "nodewright.nvidia.com"
+
+	// The RuntimeRequiredCordonAnnotation annotation and cordon are applied to a node when RuntimeRequiredCordonAfter
+	// is true, a node completes all runtime-required NodeWrights, and the runtime-required taint is present.
+	RuntimeRequiredCordonAnnotation = METADATA_PREFIX + "/runtimeRequiredCordon"
 
 	StateComplete   State = "complete"
 	StateInProgress State = "in_progress" // this means its actually running, pod started

--- a/operator/cmd/cli/app/node/node_status.go
+++ b/operator/cmd/cli/app/node/node_status.go
@@ -112,12 +112,21 @@ Node names can be exact matches or regex patterns.`,
 
 // nodeSkyhookSummary represents a summary of NodeWright activity on a node
 type nodeSkyhookSummary struct {
-	NodeName         string                 `json:"nodeName"`
-	SkyhookName      string                 `json:"skyhookName"`
-	Status           string                 `json:"status"`
-	PackagesComplete int                    `json:"packagesComplete"`
-	PackagesTotal    int                    `json:"packagesTotal"`
-	Packages         []nodeSkyhookPkgStatus `json:"packages,omitempty"`
+	NodeName              string                 `json:"nodeName"`
+	SkyhookName           string                 `json:"skyhookName"`
+	Status                string                 `json:"status"`
+	PackagesComplete      int                    `json:"packagesComplete"`
+	PackagesTotal         int                    `json:"packagesTotal"`
+	Cordoned              bool                   `json:"cordoned"`
+	RuntimeRequiredCordon bool                   `json:"runtimeRequiredCordon"`
+	Packages              []nodeSkyhookPkgStatus `json:"packages,omitempty"`
+}
+
+// hasRuntimeRequiredCordonAnnotation reports whether the node carries the persistent
+// runtime-required cordon annotation.
+func hasRuntimeRequiredCordonAnnotation(annotations map[string]string) bool {
+	_, ok := annotations[v1alpha1.RuntimeRequiredCordonAnnotation]
+	return ok
 }
 
 // nodeSkyhookPkgStatus represents the status of a single package
@@ -234,12 +243,14 @@ func runNodeStatus(ctx context.Context, kubeClient *client.Client, nodePatterns 
 			})
 
 			summaries = append(summaries, nodeSkyhookSummary{
-				NodeName:         node.Name,
-				SkyhookName:      skyhookName,
-				Status:           status,
-				PackagesComplete: completeCount,
-				PackagesTotal:    len(packages),
-				Packages:         packages,
+				NodeName:              node.Name,
+				SkyhookName:           skyhookName,
+				Status:                status,
+				PackagesComplete:      completeCount,
+				PackagesTotal:         len(packages),
+				Cordoned:              node.Spec.Unschedulable,
+				RuntimeRequiredCordon: hasRuntimeRequiredCordonAnnotation(node.Annotations),
+				Packages:              packages,
 			})
 		}
 	}
@@ -273,13 +284,15 @@ func runNodeStatus(ctx context.Context, kubeClient *client.Client, nodePatterns 
 // nodeStatusTableConfig returns the table configuration for node status output
 func nodeStatusTableConfig() utils.TableConfig[nodeSkyhookSummary] {
 	return utils.TableConfig[nodeSkyhookSummary]{
-		Headers: []string{"NODE", "SKYHOOK", "STATUS", "PACKAGES"}, //nolint:goconst
+		Headers: []string{"NODE", "SKYHOOK", "STATUS", "PACKAGES", "CORDONED", "RUNTIME-REQUIRED-CORDON"}, //nolint:goconst
 		Extract: func(s nodeSkyhookSummary) []string {
 			return []string{
 				s.NodeName,
 				s.SkyhookName,
 				s.Status,
 				fmt.Sprintf("%d/%d", s.PackagesComplete, s.PackagesTotal),
+				fmt.Sprintf("%t", s.Cordoned),
+				fmt.Sprintf("%t", s.RuntimeRequiredCordon),
 			}
 		},
 	}
@@ -291,9 +304,11 @@ func outputNodeStatusTable(out io.Writer, summaries []nodeSkyhookSummary) error 
 
 // nodeStatusWideEntry represents a flattened entry for wide output (one row per package)
 type nodeStatusWideEntry struct {
-	NodeName    string
-	SkyhookName string
-	Package     nodeSkyhookPkgStatus
+	NodeName              string
+	SkyhookName           string
+	Cordoned              bool
+	RuntimeRequiredCordon bool
+	Package               nodeSkyhookPkgStatus
 }
 
 func outputNodeStatusWide(out io.Writer, summaries []nodeSkyhookSummary) error {
@@ -310,9 +325,14 @@ func outputNodeStatusWide(out io.Writer, summaries []nodeSkyhookSummary) error {
 				e.Package.State,
 			}
 		},
-		WideHeaders: []string{"RESTARTS", "IMAGE"},
+		WideHeaders: []string{"RESTARTS", "IMAGE", "CORDONED", "RUNTIME-REQUIRED-CORDON"},
 		WideExtract: func(e nodeStatusWideEntry) []string {
-			return []string{fmt.Sprintf("%d", e.Package.Restarts), e.Package.Image}
+			return []string{
+				fmt.Sprintf("%d", e.Package.Restarts),
+				e.Package.Image,
+				fmt.Sprintf("%t", e.Cordoned),
+				fmt.Sprintf("%t", e.RuntimeRequiredCordon),
+			}
 		},
 	}
 
@@ -321,9 +341,11 @@ func outputNodeStatusWide(out io.Writer, summaries []nodeSkyhookSummary) error {
 	for _, s := range summaries {
 		for _, pkg := range s.Packages {
 			entries = append(entries, nodeStatusWideEntry{
-				NodeName:    s.NodeName,
-				SkyhookName: s.SkyhookName,
-				Package:     pkg,
+				NodeName:              s.NodeName,
+				SkyhookName:           s.SkyhookName,
+				Cordoned:              s.Cordoned,
+				RuntimeRequiredCordon: s.RuntimeRequiredCordon,
+				Package:               pkg,
 			})
 		}
 	}

--- a/operator/cmd/cli/app/node/node_status_test.go
+++ b/operator/cmd/cli/app/node/node_status_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Node Status Command", func() {
 	Describe("outputNodeStatusTable", func() {
 		It("should output table with headers", func() {
 			summaries := []nodeSkyhookSummary{
-				{NodeName: "node1", SkyhookName: "skyhook1", Status: "complete", PackagesComplete: 3, PackagesTotal: 3},
+				{NodeName: "node1", SkyhookName: "skyhook1", Status: "complete", PackagesComplete: 3, PackagesTotal: 3, Cordoned: true, RuntimeRequiredCordon: true},
 			}
 			output := &bytes.Buffer{}
 
@@ -70,6 +70,8 @@ var _ = Describe("Node Status Command", func() {
 			Expect(outputStr).To(ContainSubstring("SKYHOOK"))
 			Expect(outputStr).To(ContainSubstring("STATUS"))
 			Expect(outputStr).To(ContainSubstring("PACKAGES"))
+			Expect(outputStr).To(ContainSubstring("CORDONED"))
+			Expect(outputStr).To(ContainSubstring("RUNTIME-REQUIRED-CORDON"))
 			Expect(outputStr).To(ContainSubstring("node1"))
 			Expect(outputStr).To(ContainSubstring("skyhook1"))
 			Expect(outputStr).To(ContainSubstring("complete"))
@@ -339,6 +341,69 @@ var _ = Describe("Node Status Command", func() {
 			Expect(statusMap["complete-skyhook"]).To(Equal("complete"))
 			Expect(statusMap["error-skyhook"]).To(Equal("erroring"))
 			Expect(statusMap["inprogress-skyhook"]).To(Equal("in_progress"))
+		})
+
+		It("should display a node cordoned by runtimeRequiredCordonAfter", func() {
+			nodeState := v1alpha1.NodeState{
+				"pkg1|1.0": {Name: "pkg1", Version: "1.0", Stage: v1alpha1.StageApply, State: v1alpha1.StateComplete},
+			}
+			nodeStateJSON, _ := json.Marshal(nodeState)
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						nodeStateAnnotationPrefix + "my-skyhook": string(nodeStateJSON),
+						v1alpha1.RuntimeRequiredCordonAnnotation: "true",
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+			_, err := mockKube.CoreV1().Nodes().Create(gocontext.Background(), node, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			opts := &nodeStatusOptions{}
+			cliCtx.GlobalFlags.OutputFormat = utils.OutputFormatJSON
+			err = runNodeStatus(gocontext.Background(), kubeClient, []string{"worker-1"}, opts, cliCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			var result []nodeSkyhookSummary
+			err = json.Unmarshal(output.Bytes(), &result)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Cordoned).To(BeTrue())
+			Expect(result[0].RuntimeRequiredCordon).To(BeTrue())
+		})
+
+		It("should not report runtime-required-cordon when only manually cordoned", func() {
+			nodeState := v1alpha1.NodeState{
+				"pkg1|1.0": {Name: "pkg1", Version: "1.0", Stage: v1alpha1.StageApply, State: v1alpha1.StateComplete},
+			}
+			nodeStateJSON, _ := json.Marshal(nodeState)
+
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "worker-1",
+					Annotations: map[string]string{
+						nodeStateAnnotationPrefix + "my-skyhook": string(nodeStateJSON),
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+			_, err := mockKube.CoreV1().Nodes().Create(gocontext.Background(), node, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			opts := &nodeStatusOptions{}
+			cliCtx.GlobalFlags.OutputFormat = utils.OutputFormatJSON
+			err = runNodeStatus(gocontext.Background(), kubeClient, []string{"worker-1"}, opts, cliCtx)
+			Expect(err).NotTo(HaveOccurred())
+
+			var result []nodeSkyhookSummary
+			err = json.Unmarshal(output.Bytes(), &result)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result[0].Cordoned).To(BeTrue())
+			Expect(result[0].RuntimeRequiredCordon).To(BeFalse())
 		})
 	})
 })

--- a/operator/config/crd/bases/nodewright.nvidia.com_nodewrights.yaml
+++ b/operator/config/crd/bases/nodewright.nvidia.com_nodewrights.yaml
@@ -648,6 +648,15 @@ spec:
                 description: This NodeWright is required to have been completed before
                   any workloads can start
                 type: boolean
+              runtimeRequiredCordonAfter:
+                default: false
+                description: |-
+                  RuntimeRequiredCordonAfter will result in the operator applying a persistent node cordon
+                  after all runtime-required NodeWrights complete against a given node if the node currently
+                  has the runtime-required taint applied. The operator will apply a runtimeRequiredCordon
+                  annotation and mark the given node as unschedulable. This setting is only respected if
+                  RuntimeRequired is also true.
+                type: boolean
               sequencing:
                 default: node
                 description: |-

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -555,7 +555,7 @@ func (r *SkyhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		errs = append(errs, err)
 	}
 
-	err = r.HandleRuntimeRequired(ctx, clusterState)
+	err = r.HandleRuntimeRequired(ctx, clusterState, nodes)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -3392,7 +3392,7 @@ func (r *SkyhookReconciler) ApplyPackage(ctx context.Context, logger logr.Logger
 
 // HandleRuntimeRequired finds any nodes for which all runtime required Skyhooks are complete and remove their runtime required taint
 // Will return an error if the patching of the nodes is not possible
-func (r *SkyhookReconciler) HandleRuntimeRequired(ctx context.Context, clusterState *clusterState) error {
+func (r *SkyhookReconciler) HandleRuntimeRequired(ctx context.Context, clusterState *clusterState, nodes *corev1.NodeList) error {
 	node_to_skyhooks, skyhook_node_map := groupSkyhooksByNode(clusterState)
 	to_remove := getRuntimeRequiredTaintCompleteNodes(node_to_skyhooks, skyhook_node_map)
 	// Remove every recognised runtime-required taint, not just the configured one: a node
@@ -3410,16 +3410,53 @@ func (r *SkyhookReconciler) HandleRuntimeRequired(ctx context.Context, clusterSt
 			}
 		}
 		if changed {
-			err := r.Patch(ctx, current, client.MergeFrom(node))
-			if err != nil {
+			// If any runtime-required Skyhook sets runtimeRequiredCordonAfter to true, the cordon and
+			// runtimeRequiredCordon annotation are only applied if the runtime-required taint exists. This means that a
+			// runtime-required Skyhook with runtimeRequiredCordonAfter true will not apply the persistent cordon if the
+			// runtime-required taint was already removed. Removing the taint and applying the node cordon in the same patch
+			// request ensures a scheduling gate is always applied to the targeted node.
+			if runtimeRequiredCordonAfterEnabled(node_to_skyhooks[node.UID]) {
+				if current.Annotations == nil {
+					current.Annotations = make(map[string]string)
+				}
+				current.Annotations[v1alpha1.RuntimeRequiredCordonAnnotation] = annotationTrueValue
+				current.Spec.Unschedulable = true
+			}
+			if err := r.Patch(ctx, current, client.MergeFrom(node)); err != nil {
 				errs = append(errs, err)
 			}
 		}
 	}
+
+	// Remove any stale runtimeRequiredCordon annotation from nodes which were originally cordoned via a
+	// runtimeRequiredCordonAfter NodeWright but were externally uncordoned without removing the corresponding
+	// annotation.
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		_, annotated := node.Annotations[v1alpha1.RuntimeRequiredCordonAnnotation]
+		if !node.Spec.Unschedulable && annotated {
+			new_node := node.DeepCopy()
+			delete(new_node.Annotations, v1alpha1.RuntimeRequiredCordonAnnotation)
+			if err := r.Patch(ctx, new_node, client.MergeFromWithOptions(node, client.MergeFromWithOptimisticLock{})); err != nil {
+				errs = append(errs, fmt.Errorf("removing runtime-required cordon annotation from node %s: %w", node.Name, err))
+			}
+		}
+	}
+
 	if len(errs) > 0 {
 		return utilerrors.NewAggregate(errs)
 	}
 	return nil
+}
+
+func runtimeRequiredCordonAfterEnabled(skyhooks []SkyhookNodes) bool {
+	for _, skyhook := range skyhooks {
+		spec := skyhook.GetSkyhook().Spec
+		if spec.RuntimeRequired && spec.RuntimeRequiredCordonAfter {
+			return true
+		}
+	}
+	return false
 }
 
 // Group Skyhooks by what node they target

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -1540,6 +1540,171 @@ var _ = Describe("skyhook controller tests", func() {
 		Expect(to_remove).To(HaveLen(1))
 		Expect(to_remove[0].UID).To(BeEquivalentTo(nodeA.UID))
 	})
+	It("runtimeRequiredCordonAfterEnabled should return false for no skyhooks", func() {
+		Expect(runtimeRequiredCordonAfterEnabled(nil)).To(BeFalse())
+		Expect(runtimeRequiredCordonAfterEnabled([]SkyhookNodes{})).To(BeFalse())
+	})
+	It("runtimeRequiredCordonAfterEnabled should return false when no skyhook has it enabled", func() {
+		sh := &skyhookNodes{skyhook: wrapper.NewSkyhookWrapper(&v1alpha1.NodeWright{
+			Spec: v1alpha1.NodeWrightSpec{RuntimeRequired: true, RuntimeRequiredCordonAfter: false},
+		})}
+		Expect(runtimeRequiredCordonAfterEnabled([]SkyhookNodes{sh})).To(BeFalse())
+	})
+	It("runtimeRequiredCordonAfterEnabled should return false when RuntimeRequiredCordonAfter is true but RuntimeRequired is false", func() {
+		sh := &skyhookNodes{skyhook: wrapper.NewSkyhookWrapper(&v1alpha1.NodeWright{
+			Spec: v1alpha1.NodeWrightSpec{RuntimeRequired: false, RuntimeRequiredCordonAfter: true},
+		})}
+		Expect(runtimeRequiredCordonAfterEnabled([]SkyhookNodes{sh})).To(BeFalse())
+	})
+	It("runtimeRequiredCordonAfterEnabled should return true when any skyhook has it enabled", func() {
+		sh1 := &skyhookNodes{skyhook: wrapper.NewSkyhookWrapper(&v1alpha1.NodeWright{
+			Spec: v1alpha1.NodeWrightSpec{RuntimeRequired: true, RuntimeRequiredCordonAfter: false},
+		})}
+		sh2 := &skyhookNodes{skyhook: wrapper.NewSkyhookWrapper(&v1alpha1.NodeWright{
+			Spec: v1alpha1.NodeWrightSpec{RuntimeRequired: true, RuntimeRequiredCordonAfter: true},
+		})}
+		Expect(runtimeRequiredCordonAfterEnabled([]SkyhookNodes{sh1, sh2})).To(BeTrue())
+	})
+	Context("HandleRuntimeRequired with runtimeRequiredCordonAfter", func() {
+		It("should cordon the node and remove the taint when runtimeRequiredCordonAfter is true", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "rr-cordon-after-node",
+					Labels: map[string]string{"nodewright.nvidia.com/rr-cordon-after-test": "true"},
+				},
+				Spec: corev1.NodeSpec{Taints: []corev1.Taint{opts.GetRuntimeRequiredTaint()}},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+			nodeWright := v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr-cordon-after"},
+				Spec: v1alpha1.NodeWrightSpec{
+					RuntimeRequired:            true,
+					RuntimeRequiredCordonAfter: true,
+					NodeSelector:               metav1.LabelSelector{MatchLabels: map[string]string{"nodewright.nvidia.com/rr-cordon-after-test": "true"}},
+				},
+			}
+			cs, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{nodeWright}},
+				&corev1.NodeList{Items: []corev1.Node{*node}},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+
+			updated := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			for _, t := range updated.Spec.Taints {
+				Expect(t.Key).ToNot(Equal(opts.GetRuntimeRequiredTaint().Key), "runtime-required taint should have been removed")
+			}
+			Expect(updated.Spec.Unschedulable).To(BeTrue())
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1alpha1.RuntimeRequiredCordonAnnotation, "true"))
+		})
+
+		It("should remove the taint without cordoning when runtimeRequiredCordonAfter is false", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "rr-no-cordon-node",
+					Labels: map[string]string{"nodewright.nvidia.com/rr-no-cordon-test": "true"},
+				},
+				Spec: corev1.NodeSpec{Taints: []corev1.Taint{opts.GetRuntimeRequiredTaint()}},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+			nodeWright := v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr-no-cordon"},
+				Spec: v1alpha1.NodeWrightSpec{
+					RuntimeRequired:            true,
+					RuntimeRequiredCordonAfter: false,
+					NodeSelector:               metav1.LabelSelector{MatchLabels: map[string]string{"nodewright.nvidia.com/rr-no-cordon-test": "true"}},
+				},
+			}
+			cs, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{nodeWright}},
+				&corev1.NodeList{Items: []corev1.Node{*node}},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+
+			updated := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			for _, t := range updated.Spec.Taints {
+				Expect(t.Key).ToNot(Equal(opts.GetRuntimeRequiredTaint().Key), "runtime-required taint should have been removed")
+			}
+			Expect(updated.Spec.Unschedulable).To(BeFalse())
+			Expect(updated.Annotations).ToNot(HaveKey(v1alpha1.RuntimeRequiredCordonAnnotation))
+		})
+
+		It("should not cordon a node that does not have the runtime-required taint", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   "rr-no-taint-node",
+					Labels: map[string]string{"nodewright.nvidia.com/rr-no-taint-test": "true"},
+				},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+			nodeWright := v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr-no-taint"},
+				Spec: v1alpha1.NodeWrightSpec{
+					RuntimeRequired:            true,
+					RuntimeRequiredCordonAfter: true,
+					NodeSelector:               metav1.LabelSelector{MatchLabels: map[string]string{"nodewright.nvidia.com/rr-no-taint-test": "true"}},
+				},
+			}
+			cs, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{nodeWright}},
+				&corev1.NodeList{Items: []corev1.Node{*node}},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+
+			updated := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			Expect(updated.Spec.Unschedulable).To(BeFalse())
+			Expect(updated.Annotations).ToNot(HaveKey(v1alpha1.RuntimeRequiredCordonAnnotation))
+		})
+
+		It("should remove the runtimeRequiredCordon annotation without re-cordoning when the node has been manually uncordoned", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "rr-manual-uncordon-node",
+					Labels:      map[string]string{"nodewright.nvidia.com/rr-manual-uncordon-test": "true"},
+					Annotations: map[string]string{v1alpha1.RuntimeRequiredCordonAnnotation: "true"},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: false},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+
+			nodeWright := v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "rr-manual-uncordon"},
+				Spec: v1alpha1.NodeWrightSpec{
+					RuntimeRequired:            true,
+					RuntimeRequiredCordonAfter: true,
+					NodeSelector:               metav1.LabelSelector{MatchLabels: map[string]string{"nodewright.nvidia.com/rr-manual-uncordon-test": "true"}},
+				},
+			}
+			cs, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{nodeWright}},
+				&corev1.NodeList{Items: []corev1.Node{*node}},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+
+			updated := &corev1.Node{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
+			Expect(updated.Spec.Unschedulable).To(BeFalse(), "manual uncordon should not be undone")
+			Expect(updated.Annotations).ToNot(HaveKey(v1alpha1.RuntimeRequiredCordonAnnotation))
+		})
+	})
+
 	It("CreateTolerationForTaint should tolerate both the configured and the legacy taint", func() {
 		tolerations := opts.GetRuntimeRequiredTolerations()
 
@@ -4465,7 +4630,7 @@ var _ = Describe("HandleRuntimeRequired legacy taint removal", func() {
 		pkg := skyhook.Spec.Packages[pkgRef.Name]
 		Expect(nodeWrapper.Upsert(pkg.PackageRef, pkg.Image, v1alpha1.StateComplete, v1alpha1.StageConfig, int32(0), "")).To(Succeed())
 
-		Expect(r.HandleRuntimeRequired(ctx, clusterState)).To(Succeed())
+		Expect(r.HandleRuntimeRequired(ctx, clusterState, &corev1.NodeList{Items: []corev1.Node{*node.DeepCopy()}})).To(Succeed())
 
 		live := &corev1.Node{}
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: nodeName}, live)).To(Succeed())

--- a/operator/internal/wrapper/node.go
+++ b/operator/internal/wrapper/node.go
@@ -628,7 +628,13 @@ func hasSkyhookCordon(annotations map[string]string) bool {
 			return true
 		}
 	}
-	return false
+	// If a non-runtime-required Skyhook with an interrupt runs after all runtime-required Skyhooks and one of the
+	// runtime-required Skyhooks sets runtimeRequiredCordonAfter (and the runtime-required taint still exists),
+	// preserve the persistent cordon. Note that any runtime-required Skyhooks that run initially are free to
+	// add and remove the interrupt cordon because the persistent cordon is only applied when the runtime-required
+	// taint is removed.
+	_, ok := annotations[v1alpha1.RuntimeRequiredCordonAnnotation]
+	return ok
 }
 
 // Reset clears Skyhook-related state and annotations so the node can be reconfigured from scratch.

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -370,6 +370,29 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(sn.Changed()).To(BeTrue())
 		})
 
+		It("should keep the node cordoned if the runtimeRequiredCordon annotation is present", func() {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Annotations: map[string]string{
+						myCordonKey:                              cordonAnnotationValue,
+						v1alpha1.RuntimeRequiredCordonAnnotation: cordonAnnotationValue,
+					},
+				},
+				Spec: corev1.NodeSpec{Unschedulable: true},
+			}
+
+			sn, err := NewSkyhookNodeOnly(node, "my-skyhook")
+			Expect(err).ToNot(HaveOccurred())
+
+			sn.Uncordon()
+
+			Expect(node.Spec.Unschedulable).To(BeTrue())
+			Expect(node.Annotations).ToNot(HaveKey(myCordonKey))
+			Expect(node.Annotations).To(HaveKeyWithValue(v1alpha1.RuntimeRequiredCordonAnnotation, cordonAnnotationValue))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
 		It("should not change the node if this Skyhook does not own a cordon", func() {
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
## Description
This PR adds a runtimeRequiredCordonAfter field to the NodeWright API to support persistent node cordons. This PR implements the behavior outlined in the following comment: https://github.com/NVIDIA/nodewright/issues/284#issuecomment-4860869982. 

Feature overview:
- The persistent node cordon is applied if any runtimeRequired NodeWright CR enables runtimeRequiredCordonAfter. If any NodeWright CR sets runtimeRequired to false but runtimeRequiredCordonAfter to true, the cordon will not be applied.
- The cordon is only applied at the same time as taint removal if the taint currently exists on the node.  If the taint has already been removed from a node, the cordon is not applied even if a new runtime-required NodeWright targets it.
- The cordon applied by runtimeRequiredCordonAfter will persist through any future  NodeWright CR executions with interrupts that may require cordoning the node (which themselves may have runtimeRequired set to true). This is accomplished by using a runtimeRequiredCordon annotation which ensures the cordon is preserved after the interrupt package completes. Any pre-existing cordon applied outside NodeWright is not preserved, which is consistent with current behavior.
- Releasing this persistent cordon requires removing the runtimeRequiredCordon annotation and setting unschedulable to false in the same patch. If the node is uncordoned externally but the runtimeRequiredCordon annotation is orphaned, the controller will automatically remove the annotation.

Closes #284 

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
