### PR TITLE
refactor(agent): centralize rooted host filesystem operations

### DIFF
--- a/agent/go/internal/flags/flags.go
+++ b/agent/go/internal/flags/flags.go
@@ -19,15 +19,12 @@
 package flags
 
 import (
-	"crypto/rand"
 	"errors"
 	"fmt"
-	"io/fs"
-	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
 	"github.com/NVIDIA/nodewright/agent/internal/stage"
 	"github.com/NVIDIA/nodewright/agent/internal/step"
 )
@@ -65,6 +62,7 @@ type Decision struct {
 type Store interface {
 	Path(value step.Step) (string, error)
 	Mark(value step.Step, message string) (string, error)
+	Remove(value step.Step) error
 	Write(path string, data []byte) error
 	Check(value step.Step, alwaysRun bool, currentStage stage.Stage) (Decision, error)
 }
@@ -135,31 +133,35 @@ func (s *fileStore) Mark(value step.Step, message string) (string, error) {
 	return path, nil
 }
 
+// Remove deletes a step completion flag. A missing flag is already removed and
+// therefore succeeds.
+func (s *fileStore) Remove(value step.Step) error {
+	path, err := s.Path(value)
+	if err != nil {
+		return fmt.Errorf("removing step flag: resolving flag path: %w", err)
+	}
+	if err := s.validatePath(path); err != nil {
+		return fmt.Errorf("removing step flag: validating store path: %w", err)
+	}
+	if err := hostfs.RemoveFile(s.rootMount, path); err != nil {
+		return fmt.Errorf("removing step flag %q: %w", path, err)
+	}
+	return nil
+}
+
 // Write creates or replaces a flag file owned by this store. In addition to
 // per-step flags, callers can use it for control files such as START and
 // check_results without duplicating directory and permission handling.
-func (s *fileStore) Write(path string, data []byte) (retErr error) {
-	relative, err := s.rootRelativePath(path)
-	if err != nil {
+func (s *fileStore) Write(path string, data []byte) error {
+	if err := s.validatePath(path); err != nil {
 		return fmt.Errorf("validating flag store path %q: %w", path, err)
 	}
-	root, err := os.OpenRoot(s.rootMount)
-	if err != nil {
-		return fmt.Errorf("opening mounted host root %q: %w", s.rootMount, err)
-	}
-	defer closeStoreRoot(root, &retErr)
-
-	if err := ensureDirectoriesNoSymlinks(root, filepath.Dir(relative)); err != nil {
-		return fmt.Errorf("preparing flag directory for %q: %w", path, err)
-	}
-	info, exists, err := lstatNoSymlinks(root, relative)
-	if err != nil {
-		return fmt.Errorf("validating flag target %q: %w", path, err)
-	}
-	if exists && !info.Mode().IsRegular() {
-		return fmt.Errorf("flag path %q is not a regular file", path)
-	}
-	if err := writeFlagFile(root, relative, data, exists); err != nil {
+	if err := hostfs.WriteFile(
+		s.rootMount,
+		path,
+		data,
+		flagFileMode,
+	); err != nil {
 		return fmt.Errorf("writing flag %q: %w", path, err)
 	}
 	return nil
@@ -167,7 +169,7 @@ func (s *fileStore) Write(path string, data []byte) (retErr error) {
 
 // Check reports whether a step should run based on its completion flag and
 // current execution policy.
-func (s *fileStore) Check(value step.Step, alwaysRun bool, currentStage stage.Stage) (decision Decision, retErr error) {
+func (s *fileStore) Check(value step.Step, alwaysRun bool, currentStage stage.Stage) (Decision, error) {
 	if value == nil {
 		return Decision{}, errors.New("checking flag: step must not be nil")
 	}
@@ -181,25 +183,15 @@ func (s *fileStore) Check(value step.Step, alwaysRun bool, currentStage stage.St
 	if err != nil {
 		return Decision{}, fmt.Errorf("checking flag for step %q: resolving store path: %w", value.Path(), err)
 	}
-	relative, err := s.rootRelativePath(path)
-	if err != nil {
+	if err := s.validatePath(path); err != nil {
 		return Decision{}, fmt.Errorf("checking flag for step %q: validating store path: %w", value.Path(), err)
 	}
-	root, err := os.OpenRoot(s.rootMount)
-	if err != nil {
-		return Decision{}, fmt.Errorf("checking flag for step %q: opening mounted host root %q: %w", value.Path(), s.rootMount, err)
-	}
-	defer closeStoreRoot(root, &retErr)
-
-	info, exists, err := lstatNoSymlinks(root, relative)
+	exists, err := hostfs.RegularFileExists(s.rootMount, path)
 	if err != nil {
 		return Decision{}, fmt.Errorf("checking flag for step %q: inspecting store path: %w", value.Path(), err)
 	}
 	if !exists {
 		return Decide(false, alwaysRun, currentStage, value.Idempotence()), nil
-	}
-	if !info.Mode().IsRegular() {
-		return Decision{}, fmt.Errorf("checking flag for step %q: flag path %q is not a regular file", value.Path(), path)
 	}
 	return Decide(true, alwaysRun, currentStage, value.Idempotence()), nil
 }
@@ -222,111 +214,14 @@ func Decide(flagExists, alwaysRun bool, currentStage stage.Stage, idempotence st
 	return Decision{Run: false, Reason: ReasonAlreadyCompleted}
 }
 
-func (s *fileStore) rootRelativePath(path string) (string, error) {
+func (s *fileStore) validatePath(path string) error {
 	storePath := filepath.Join(s.rootMount, s.dir)
 	relative, err := filepath.Rel(storePath, path)
 	if err != nil {
-		return "", fmt.Errorf("resolving path relative to flag store: %w", err)
+		return fmt.Errorf("resolving path relative to flag store: %w", err)
 	}
 	if !filepath.IsLocal(relative) {
-		return "", fmt.Errorf("flag path %q must be contained within %q", path, storePath)
-	}
-	return filepath.Join(s.dir, relative), nil
-}
-
-func ensureDirectoriesNoSymlinks(root *os.Root, directory string) error {
-	current := ""
-	for _, component := range pathComponents(directory) {
-		current = filepath.Join(current, component)
-		info, err := root.Lstat(current)
-		if errors.Is(err, fs.ErrNotExist) {
-			if err := root.Mkdir(current, directoryMode); err != nil && !errors.Is(err, fs.ErrExist) {
-				return fmt.Errorf("creating directory %q: %w", current, err)
-			}
-			info, err = root.Lstat(current)
-		}
-		if err != nil {
-			return fmt.Errorf("inspecting directory %q: %w", current, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("path component %q is a symbolic link", current)
-		}
-		if !info.IsDir() {
-			return fmt.Errorf("path component %q is not a directory", current)
-		}
+		return fmt.Errorf("flag path %q must be contained within %q", path, storePath)
 	}
 	return nil
-}
-
-func lstatNoSymlinks(root *os.Root, path string) (os.FileInfo, bool, error) {
-	components := pathComponents(path)
-	current := ""
-	for i, component := range components {
-		current = filepath.Join(current, component)
-		info, err := root.Lstat(current)
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, false, nil
-		}
-		if err != nil {
-			return nil, false, fmt.Errorf("inspecting path component %q: %w", current, err)
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, false, fmt.Errorf("path component %q is a symbolic link", current)
-		}
-		if i < len(components)-1 && !info.IsDir() {
-			return nil, false, fmt.Errorf("path component %q is not a directory", current)
-		}
-		if i == len(components)-1 {
-			return info, true, nil
-		}
-	}
-	return nil, false, nil
-}
-
-func pathComponents(path string) []string {
-	clean := filepath.Clean(path)
-	if clean == "." {
-		return nil
-	}
-	return strings.Split(clean, string(filepath.Separator))
-}
-
-func writeFlagFile(root *os.Root, path string, data []byte, replace bool) (retErr error) {
-	writePath := path
-	if replace {
-		writePath = filepath.Join(filepath.Dir(path), ".flag-"+rand.Text()+".tmp")
-	}
-	file, err := root.OpenFile(writePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, flagFileMode)
-	if err != nil {
-		return fmt.Errorf("creating flag %q without following symlinks: %w", path, err)
-	}
-	defer func() {
-		if err := file.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
-			retErr = fmt.Errorf("closing flag %q: %w", path, err)
-		}
-		if retErr != nil {
-			if err := root.Remove(writePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
-				retErr = errors.Join(retErr, fmt.Errorf("removing incomplete flag %q: %w", writePath, err))
-			}
-		}
-	}()
-
-	if _, err := file.Write(data); err != nil {
-		return fmt.Errorf("writing flag %q: %w", path, err)
-	}
-	if err := file.Close(); err != nil {
-		return fmt.Errorf("closing flag %q: %w", path, err)
-	}
-	if replace {
-		if err := root.Rename(writePath, path); err != nil {
-			return fmt.Errorf("atomically replacing flag %q: %w", path, err)
-		}
-	}
-	return nil
-}
-
-func closeStoreRoot(root *os.Root, retErr *error) {
-	if err := root.Close(); err != nil && *retErr == nil {
-		*retErr = fmt.Errorf("closing mounted host root %q: %w", root.Name(), err)
-	}
 }

--- a/agent/go/internal/flags/flags_test.go
+++ b/agent/go/internal/flags/flags_test.go
@@ -127,6 +127,44 @@ var _ = Describe("flag store", func() {
 		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o600)))
 	})
 
+	It("removes a completion flag idempotently", func() {
+		path, err := store.Mark(value, "complete")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(store.Remove(value)).To(Succeed())
+		Expect(path).NotTo(BeAnExistingFile())
+		Expect(store.Remove(value)).To(Succeed())
+	})
+
+	It("refuses to remove a non-regular flag path", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(path, 0o755)).To(Succeed())
+
+		Expect(store.Remove(value)).To(MatchError(ContainSubstring("is not a regular file")))
+		Expect(path).To(BeADirectory())
+	})
+
+	It("does not follow a symlinked flag when removing", func() {
+		path, err := store.Path(value)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(filepath.Dir(path), 0o755)).To(Succeed())
+		target := filepath.Join(GinkgoT().TempDir(), "complete")
+		Expect(os.WriteFile(target, nil, 0o600)).To(Succeed())
+		Expect(os.Symlink(target, path)).To(Succeed())
+
+		Expect(store.Remove(value)).To(MatchError(ContainSubstring("is a symbolic link")))
+		Expect(target).To(BeAnExistingFile())
+	})
+
+	It("refuses to remove a flag for a step outside the package root", func() {
+		escaping := step.NewRegularStep("../escape.sh")
+
+		err := store.Remove(escaping)
+		Expect(err).To(MatchError(ContainSubstring("resolving flag path")))
+		Expect(err).To(MatchError(ContainSubstring("must be relative to the package root")))
+	})
+
 	It("writes control flags inside the store", func() {
 		path := filepath.Join(DefaultLayout(root).FlagDir(), "START")
 		Expect(store.Write(path, []byte("started"))).To(Succeed())
@@ -134,25 +172,6 @@ var _ = Describe("flag store", func() {
 		data, err := os.ReadFile(path)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(data)).To(Equal("restarted"))
-	})
-
-	It("keeps the existing path when an atomic replacement fails", func() {
-		rootPath := GinkgoT().TempDir()
-		Expect(os.Mkdir(filepath.Join(rootPath, "flag"), 0o755)).To(Succeed())
-		root, err := os.OpenRoot(rootPath)
-		Expect(err).NotTo(HaveOccurred())
-		DeferCleanup(func() {
-			Expect(root.Close()).To(Succeed())
-		})
-
-		err = writeFlagFile(root, "flag", []byte("replacement"), true)
-		Expect(err).To(MatchError(ContainSubstring("atomically replacing flag")))
-		info, err := os.Stat(filepath.Join(rootPath, "flag"))
-		Expect(err).NotTo(HaveOccurred())
-		Expect(info.IsDir()).To(BeTrue())
-		entries, err := os.ReadDir(rootPath)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(entries).To(HaveLen(1))
 	})
 
 	It("rejects a symlinked flag parent", func() {

--- a/agent/go/internal/flags/layout.go
+++ b/agent/go/internal/flags/layout.go
@@ -19,20 +19,23 @@
 package flags
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
 )
 
 const (
-	DefaultStateRoot = "/etc/skyhook"
-	DefaultLogRoot   = "/var/log/skyhook"
-	logTimeFormat    = "2006-01-02-150405"
-	directoryMode    = 0o755
+	DefaultStateRoot    = "/etc/skyhook"
+	DefaultLogRoot      = "/var/log/skyhook"
+	logTimeFormat       = "2006-01-02-150405.000000000"
+	legacyLogTimeFormat = "2006-01-02-150405"
 )
 
 // Layout resolves agent-owned paths beneath the mounted host root. StateRoot
@@ -78,6 +81,10 @@ func DefaultLayout(rootMount string) Layout {
 	}
 }
 
+func (l Layout) RootMount() string {
+	return l.rootMount
+}
+
 func (l Layout) StateDir() string {
 	return filepath.Join(l.rootMount, l.stateRoot)
 }
@@ -116,6 +123,7 @@ func (l Layout) LogFilePath(cfg config.Config, stepPath string, at time.Time) (s
 // LogFiles identifies prior logs for one step without interpreting the step
 // path as a glob expression.
 type LogFiles struct {
+	rootMount string
 	directory string
 	prefix    string
 	suffix    string
@@ -129,22 +137,73 @@ func (l Layout) LogFilePattern(cfg config.Config, stepPath string) (LogFiles, er
 		return LogFiles{}, fmt.Errorf("building log file pattern for step %q: resolving package log path: %w", stepPath, err)
 	}
 	return LogFiles{
+		rootMount: l.rootMount,
 		directory: filepath.Dir(logBase),
 		prefix:    filepath.Base(logBase) + "-",
 		suffix:    ".log",
 	}, nil
 }
 
-// PrepareLogFile returns the next log path and creates its parent directory.
-func (l Layout) PrepareLogFile(cfg config.Config, stepPath string, at time.Time) (string, error) {
-	path, err := l.LogFilePath(cfg, stepPath, at)
+// CreateLogFile creates and opens a unique log file beneath the mounted host
+// root. The caller owns the returned file and must close it.
+func (l Layout) CreateLogFile(
+	cfg config.Config,
+	stepPath string,
+	at time.Time,
+	mode fs.FileMode,
+) (string, *os.File, error) {
+	basePath, err := l.LogFilePath(cfg, stepPath, at)
 	if err != nil {
-		return "", fmt.Errorf("preparing log file for step %q: resolving log file path: %w", stepPath, err)
+		return "", nil, fmt.Errorf("creating log file for step %q: resolving log file path: %w", stepPath, err)
 	}
-	if err := os.MkdirAll(filepath.Dir(path), directoryMode); err != nil {
-		return "", fmt.Errorf("creating log directory %q: %w", filepath.Dir(path), err)
+	collision, err := nextLogCollision(l.rootMount, basePath)
+	if err != nil {
+		return "", nil, fmt.Errorf("creating log file for step %q: finding next collision index: %w", stepPath, err)
 	}
-	return path, nil
+	for ; ; collision++ {
+		path := basePath
+		if collision > 0 {
+			path = strings.TrimSuffix(basePath, ".log") + fmt.Sprintf("-%d.log", collision)
+		}
+		file, err := hostfs.CreateFileWriter(l.rootMount, path, mode)
+		if errors.Is(err, fs.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return "", nil, fmt.Errorf("creating log file %q: %w", path, err)
+		}
+		return path, file, nil
+	}
+}
+
+func nextLogCollision(rootMount, basePath string) (int, error) {
+	entries, err := hostfs.ReadDir(rootMount, filepath.Dir(basePath))
+	if errors.Is(err, fs.ErrNotExist) {
+		return 0, nil
+	}
+	if err != nil {
+		return 0, fmt.Errorf("reading log directory %q: %w", filepath.Dir(basePath), err)
+	}
+
+	baseName := filepath.Base(basePath)
+	prefix := strings.TrimSuffix(baseName, ".log") + "-"
+	next := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if name == baseName {
+			next = max(next, 1)
+			continue
+		}
+		if !strings.HasPrefix(name, prefix) || !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		value := strings.TrimSuffix(strings.TrimPrefix(name, prefix), ".log")
+		index, ok := parsePositiveDecimal(value)
+		if ok {
+			next = max(next, index+1)
+		}
+	}
+	return next, nil
 }
 
 func (l Layout) packageLogDir(cfg config.Config, stepPath string) (string, error) {

--- a/agent/go/internal/flags/layout_test.go
+++ b/agent/go/internal/flags/layout_test.go
@@ -21,6 +21,7 @@ package flags
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,6 +35,7 @@ var _ = Describe("Layout", func() {
 		root := GinkgoT().TempDir()
 		layout := DefaultLayout(root)
 
+		Expect(layout.RootMount()).To(Equal(root))
 		Expect(layout.StateDir()).To(Equal(filepath.Join(root, "etc", "skyhook")))
 		Expect(layout.FlagDir()).To(Equal(filepath.Join(root, "etc", "skyhook", "flags")))
 		Expect(layout.HistoryDir()).To(Equal(filepath.Join(root, "etc", "skyhook", "history")))
@@ -88,17 +90,41 @@ var _ = Describe("log paths", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(path).To(Equal(filepath.Join(
 			root,
-			"var", "log", "skyhook", "driver", "1.2.3", "scripts", "apply.sh-2026-06-30-103456.log",
+			"var", "log", "skyhook", "driver", "1.2.3", "scripts", "apply.sh-2026-06-30-103456.000000000.log",
 		)))
 	})
 
-	It("creates the parent directory when preparing a log", func() {
-		path, err := layout.PrepareLogFile(cfg, "scripts/apply.sh", time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	It("creates a rooted log file and its parent directory", func() {
+		path, file, err := layout.CreateLogFile(
+			cfg,
+			"scripts/apply.sh",
+			time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
+			0o600,
+		)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
 
 		info, err := os.Stat(filepath.Dir(path))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(info.IsDir()).To(BeTrue())
+	})
+
+	It("does not reuse a log path when timestamps collide", func() {
+		at := time.Date(2026, 1, 2, 3, 4, 5, 123, time.UTC)
+		firstPath, first, err := layout.CreateLogFile(cfg, "apply.sh", at, 0o600)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(first.Close()).To(Succeed())
+		secondPath, second, err := layout.CreateLogFile(cfg, "apply.sh", at, 0o600)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(second.Close()).To(Succeed())
+		Expect(os.Remove(firstPath)).To(Succeed())
+		thirdPath, third, err := layout.CreateLogFile(cfg, "apply.sh", at, 0o600)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(third.Close()).To(Succeed())
+
+		Expect(secondPath).NotTo(Equal(firstPath))
+		Expect(secondPath).To(Equal(strings.TrimSuffix(firstPath, ".log") + "-1.log"))
+		Expect(thirdPath).To(Equal(strings.TrimSuffix(firstPath, ".log") + "-2.log"))
 	})
 
 	It("derives a literal log selector", func() {
@@ -122,8 +148,8 @@ var _ = Describe("log paths", func() {
 		_, err := layout.LogFilePattern(invalidConfig, "apply.sh")
 		Expect(err).To(MatchError(ContainSubstring(`building log file pattern for step "apply.sh": resolving package log path`)))
 
-		_, err = layout.PrepareLogFile(invalidConfig, "apply.sh", time.Now())
-		Expect(err).To(MatchError(ContainSubstring(`preparing log file for step "apply.sh": resolving log file path`)))
+		_, _, err = layout.CreateLogFile(invalidConfig, "apply.sh", time.Now(), 0o600)
+		Expect(err).To(MatchError(ContainSubstring(`creating log file for step "apply.sh": resolving log file path`)))
 
 		_, err = layout.packageLogDir(invalidConfig, "apply.sh")
 		Expect(err).To(MatchError(ContainSubstring(`building package log path for step "apply.sh": validating package path`)))

--- a/agent/go/internal/flags/logs.go
+++ b/agent/go/internal/flags/logs.go
@@ -22,28 +22,31 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
+
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
 )
 
 const DefaultLogRetention = 5
 
 type logCandidate struct {
-	path      string
-	timestamp time.Time
+	path           string
+	timestamp      time.Time
+	collisionIndex int
 }
 
 // CleanupOldLogs removes all but the newest keep regular files matching the
-// literal filename shape. Files with equal timestamps are ordered by path so
-// retention is deterministic.
+// literal filename shape. Collision suffixes preserve creation order when
+// timestamps are equal; remaining ties are ordered by path.
 func CleanupOldLogs(logFiles LogFiles, keep int) error {
 	if keep < 0 {
 		return fmt.Errorf("log retention must not be negative: %d", keep)
 	}
-	entries, err := os.ReadDir(logFiles.directory)
+	entries, err := hostfs.ReadDir(logFiles.rootMount, logFiles.directory)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
@@ -57,9 +60,9 @@ func CleanupOldLogs(logFiles LogFiles, keep int) error {
 		if !strings.HasPrefix(name, logFiles.prefix) || !strings.HasSuffix(name, logFiles.suffix) {
 			continue
 		}
-		timestamp := strings.TrimSuffix(strings.TrimPrefix(name, logFiles.prefix), logFiles.suffix)
-		parsedTimestamp, err := time.Parse(logTimeFormat, timestamp)
-		if err != nil {
+		value := strings.TrimSuffix(strings.TrimPrefix(name, logFiles.prefix), logFiles.suffix)
+		parsedTimestamp, collisionIndex, ok := parseLogTimestamp(value)
+		if !ok {
 			continue
 		}
 		info, err := entry.Info()
@@ -70,21 +73,68 @@ func CleanupOldLogs(logFiles LogFiles, keep int) error {
 			continue
 		}
 		files = append(files, logCandidate{
-			path:      filepath.Join(logFiles.directory, name),
-			timestamp: parsedTimestamp,
+			path:           filepath.Join(logFiles.directory, name),
+			timestamp:      parsedTimestamp,
+			collisionIndex: collisionIndex,
 		})
 	}
 
 	sort.Slice(files, func(i, j int) bool {
 		if files[i].timestamp.Equal(files[j].timestamp) {
+			if files[i].collisionIndex != files[j].collisionIndex {
+				return files[i].collisionIndex > files[j].collisionIndex
+			}
 			return files[i].path < files[j].path
 		}
 		return files[i].timestamp.After(files[j].timestamp)
 	})
 	for _, file := range files[min(keep, len(files)):] {
-		if err := os.Remove(file.path); err != nil {
+		if err := hostfs.RemoveFile(logFiles.rootMount, file.path); err != nil {
 			return fmt.Errorf("removing old log %q: %w", file.path, err)
 		}
 	}
 	return nil
+}
+
+func parseLogTimestamp(value string) (time.Time, int, bool) {
+	if parsed, collision, ok := parseLogTimestampWithFormat(value, logTimeFormat); ok {
+		return parsed, collision, true
+	}
+	return parseLogTimestampWithFormat(value, legacyLogTimeFormat)
+}
+
+func parseLogTimestampWithFormat(value, format string) (time.Time, int, bool) {
+	length := len(format)
+	if len(value) < length {
+		return time.Time{}, 0, false
+	}
+	parsed, err := time.Parse(format, value[:length])
+	if err != nil {
+		return time.Time{}, 0, false
+	}
+	suffix := value[length:]
+	if suffix == "" {
+		return parsed, 0, true
+	}
+	if !strings.HasPrefix(suffix, "-") {
+		return time.Time{}, 0, false
+	}
+	index, ok := parsePositiveDecimal(strings.TrimPrefix(suffix, "-"))
+	if !ok {
+		return time.Time{}, 0, false
+	}
+	return parsed, index, true
+}
+
+func parsePositiveDecimal(value string) (int, bool) {
+	if value == "" {
+		return 0, false
+	}
+	for _, character := range value {
+		if character < '0' || character > '9' {
+			return 0, false
+		}
+	}
+	parsed, err := strconv.Atoi(value)
+	return parsed, err == nil && parsed > 0
 }

--- a/agent/go/internal/flags/logs_test.go
+++ b/agent/go/internal/flags/logs_test.go
@@ -21,6 +21,7 @@ package flags
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -49,8 +50,10 @@ var _ = Describe("CleanupOldLogs", func() {
 		}
 		unrelated := filepath.Join(logFiles.directory, "applyX.sh-2026-01-01-000000.log")
 		malformed := filepath.Join(logFiles.directory, logFiles.prefix+"not-a-timestamp"+logFiles.suffix)
+		legacy := filepath.Join(logFiles.directory, logFiles.prefix+"2025-01-01-000000"+logFiles.suffix)
 		Expect(os.WriteFile(unrelated, nil, 0o600)).To(Succeed())
 		Expect(os.WriteFile(malformed, nil, 0o600)).To(Succeed())
+		Expect(os.WriteFile(legacy, nil, 0o600)).To(Succeed())
 
 		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
 		for _, path := range paths[:5] {
@@ -61,6 +64,7 @@ var _ = Describe("CleanupOldLogs", func() {
 		}
 		Expect(unrelated).To(BeAnExistingFile())
 		Expect(malformed).To(BeAnExistingFile())
+		Expect(legacy).NotTo(BeAnExistingFile())
 	})
 
 	It("does nothing when no files match", func() {
@@ -68,6 +72,71 @@ var _ = Describe("CleanupOldLogs", func() {
 		logFiles, err := layout.LogFilePattern(config.Config{PackageName: "driver", PackageVersion: "1.2.3"}, "apply.sh")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
+	})
+
+	It("ignores collision suffixes containing non-digits", func() {
+		layout := DefaultLayout(GinkgoT().TempDir())
+		cfg := config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+		path, err := layout.LogFilePath(cfg, "apply.sh", time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+		Expect(err).NotTo(HaveOccurred())
+		path = strings.TrimSuffix(path, ".log") + "-+1.log"
+		Expect(os.MkdirAll(filepath.Dir(path), 0o755)).To(Succeed())
+		Expect(os.WriteFile(path, nil, 0o600)).To(Succeed())
+		logFiles, err := layout.LogFilePattern(cfg, "apply.sh")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(CleanupOldLogs(logFiles, 0)).To(Succeed())
+		Expect(path).To(BeAnExistingFile())
+	})
+
+	It("keeps the newest files when timestamps collide", func() {
+		layout := DefaultLayout(GinkgoT().TempDir())
+		cfg := config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
+		at := time.Date(2026, 1, 1, 0, 0, 0, 123, time.UTC)
+		paths := make([]string, 7)
+		for index := range paths {
+			path, file, err := layout.CreateLogFile(cfg, "apply.sh", at, 0o600)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(file.Close()).To(Succeed())
+			paths[index] = path
+		}
+		logFiles, err := layout.LogFilePattern(cfg, "apply.sh")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
+		for _, path := range paths[:2] {
+			Expect(path).NotTo(BeAnExistingFile())
+		}
+		for _, path := range paths[2:] {
+			Expect(path).To(BeAnExistingFile())
+		}
+
+		newPath, file, err := layout.CreateLogFile(cfg, "apply.sh", at, 0o600)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
+		Expect(newPath).NotTo(BeElementOf(paths[:2]))
+
+		Expect(CleanupOldLogs(logFiles, DefaultLogRetention)).To(Succeed())
+		Expect(newPath).To(BeAnExistingFile())
+		Expect(paths[2]).NotTo(BeAnExistingFile())
+		for _, path := range paths[3:] {
+			Expect(path).To(BeAnExistingFile())
+		}
+	})
+
+	It("does not follow a symlinked log directory", func() {
+		root := GinkgoT().TempDir()
+		layout := DefaultLayout(root)
+		logFiles, err := layout.LogFilePattern(
+			config.Config{PackageName: "driver", PackageVersion: "1.2.3"},
+			"scripts/apply.sh",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.MkdirAll(filepath.Dir(logFiles.directory), 0o755)).To(Succeed())
+		Expect(os.Symlink(GinkgoT().TempDir(), logFiles.directory)).To(Succeed())
+
+		err = CleanupOldLogs(logFiles, DefaultLogRetention)
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
 	})
 
 	It("rejects negative retention", func() {

--- a/agent/go/internal/history/history.go
+++ b/agent/go/internal/history/history.go
@@ -24,22 +24,20 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
-	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
 	"github.com/NVIDIA/nodewright/agent/internal/stage"
 )
 
 const (
-	UnknownVersion       = "unknown"
-	UninstalledVersion   = "uninstalled"
-	CurrentVersionEnv    = "CURRENT_VERSION"
-	PreviousVersionEnv   = "PREVIOUS_VERSION"
-	historyDirectoryMode = 0o755
-	historyFileMode      = 0o600
-	historyEntryLimit    = 100
+	UnknownVersion     = "unknown"
+	UninstalledVersion = "uninstalled"
+	historyFileMode    = 0o600
+	historyEntryLimit  = 100
 )
 
 // LedgerEntry is one recorded version transition.
@@ -61,17 +59,6 @@ type Versions struct {
 	Previous string
 }
 
-func (v Versions) Environment() map[string]string {
-	return map[string]string{
-		CurrentVersionEnv:  v.Current,
-		PreviousVersionEnv: v.Previous,
-	}
-}
-
-func (v Versions) UpgradeArguments() []string {
-	return []string{v.Previous, v.Current}
-}
-
 // Store records completed version transitions for one package and reports the
 // versions a step should receive.
 type Store interface {
@@ -81,8 +68,8 @@ type Store interface {
 
 // NewStore returns the file-backed history store. The implementation is
 // unexported so downstream consumers depend on the Store interface.
-func NewStore(dir string, cfg config.Config, logger *slog.Logger) (Store, error) {
-	s, err := newFileStore(dir, cfg, logger)
+func NewStore(layout flags.Layout, cfg config.Config, logger *slog.Logger) (Store, error) {
+	s, err := newFileStore(layout, cfg, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -91,6 +78,7 @@ func NewStore(dir string, cfg config.Config, logger *slog.Logger) (Store, error)
 
 // fileStore keeps one package's install history in a JSON ledger file.
 type fileStore struct {
+	rootMount   string
 	path        string
 	packageName string
 	version     string
@@ -100,9 +88,10 @@ type fileStore struct {
 var _ Store = (*fileStore)(nil)
 
 // newFileStore returns a store for the package described by cfg, keeping its
-// ledger under dir. Package identity is validated once here so later reads
-// and writes cannot escape dir or record an unusable version.
-func newFileStore(dir string, cfg config.Config, logger *slog.Logger) (*fileStore, error) {
+// ledger under the layout's history directory. Package identity is validated
+// once here so later reads and writes cannot escape that directory or record
+// an unusable version.
+func newFileStore(layout flags.Layout, cfg config.Config, logger *slog.Logger) (*fileStore, error) {
 	name := cfg.PackageName
 	if name == "" || !filepath.IsLocal(name) || filepath.Base(name) != name {
 		return nil, fmt.Errorf("package name %q must be a single path component", name)
@@ -114,7 +103,8 @@ func newFileStore(dir string, cfg config.Config, logger *slog.Logger) (*fileStor
 		logger = slog.Default()
 	}
 	return &fileStore{
-		path:        filepath.Join(dir, name+".json"),
+		rootMount:   layout.RootMount(),
+		path:        filepath.Join(layout.HistoryDir(), name+".json"),
 		packageName: name,
 		version:     cfg.PackageVersion,
 		logger:      logger,
@@ -161,22 +151,19 @@ func (s *fileStore) Record(completedStage stage.Stage, at time.Time) error {
 		ledger.Entries = ledger.Entries[:historyEntryLimit]
 	}
 
-	if err := os.MkdirAll(filepath.Dir(s.path), historyDirectoryMode); err != nil {
-		return fmt.Errorf("creating history directory %q: %w", filepath.Dir(s.path), err)
-	}
 	data, err := json.MarshalIndent(ledger, "", "  ")
 	if err != nil {
 		return fmt.Errorf("encoding history for package %q: %w", s.packageName, err)
 	}
 	data = append(data, '\n')
-	if err := writeAtomic(s.path, data); err != nil {
+	if err := hostfs.WriteFile(s.rootMount, s.path, data, historyFileMode); err != nil {
 		return fmt.Errorf("writing history for package %q: %w", s.packageName, err)
 	}
 	return nil
 }
 
 func (s *fileStore) load() (Ledger, error) {
-	data, err := os.ReadFile(s.path)
+	data, err := hostfs.ReadFile(s.rootMount, s.path)
 	if errors.Is(err, fs.ErrNotExist) {
 		s.logger.Info("package history does not exist", "package", s.packageName, "path", s.path)
 		return Ledger{CurrentVersion: UnknownVersion, Entries: []LedgerEntry{}}, nil
@@ -190,7 +177,7 @@ func (s *fileStore) load() (Ledger, error) {
 		backup := s.path + ".backup"
 		// Preserve the damaged bytes and continue from an unknown version so a
 		// corrupt file cannot permanently block package execution on this node.
-		if renameErr := os.Rename(s.path, backup); renameErr != nil {
+		if renameErr := hostfs.RenameFile(s.rootMount, s.path, backup); renameErr != nil {
 			return Ledger{}, fmt.Errorf("moving corrupt history %q to %q: %w", s.path, backup, renameErr)
 		}
 		s.logger.Error(
@@ -209,52 +196,4 @@ func (s *fileStore) load() (Ledger, error) {
 		result.Entries = []LedgerEntry{}
 	}
 	return result, nil
-}
-
-func writeAtomic(path string, data []byte) (retErr error) {
-	tmp, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return fmt.Errorf("creating temporary history file: %w", err)
-	}
-
-	tmpPath := tmp.Name()
-	defer func() {
-		if err := tmp.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
-			retErr = fmt.Errorf("closing temporary history file %q: %w", tmpPath, err)
-		}
-		if err := os.Remove(tmpPath); err != nil && !errors.Is(err, fs.ErrNotExist) && retErr == nil {
-			retErr = fmt.Errorf("removing temporary history file %q: %w", tmpPath, err)
-		}
-	}()
-
-	if err := tmp.Chmod(historyFileMode); err != nil {
-		return fmt.Errorf("setting permissions on temporary history file %q: %w", tmpPath, err)
-	}
-	if _, err := tmp.Write(data); err != nil {
-		return fmt.Errorf("writing temporary history file %q: %w", tmpPath, err)
-	}
-	if err := tmp.Sync(); err != nil {
-		return fmt.Errorf("syncing temporary history file %q: %w", tmpPath, err)
-	}
-	if err := tmp.Close(); err != nil {
-		return fmt.Errorf("closing temporary history file %q: %w", tmpPath, err)
-	}
-	if err := os.Rename(tmpPath, path); err != nil {
-		return fmt.Errorf("replacing history file %q: %w", path, err)
-	}
-	// The rename is only durable once the parent directory's metadata reaches
-	// disk; without this sync a crash after a successful Record could lose the
-	// ledger, and this file exists to survive reboots.
-	dir, err := os.Open(filepath.Dir(path))
-	if err != nil {
-		return fmt.Errorf("opening history directory %q: %w", filepath.Dir(path), err)
-	}
-	if err := dir.Sync(); err != nil {
-		_ = dir.Close()
-		return fmt.Errorf("syncing history directory %q: %w", filepath.Dir(path), err)
-	}
-	if err := dir.Close(); err != nil {
-		return fmt.Errorf("closing history directory %q: %w", filepath.Dir(path), err)
-	}
-	return nil
 }

--- a/agent/go/internal/history/history_test.go
+++ b/agent/go/internal/history/history_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/NVIDIA/nodewright/agent/internal/config"
+	"github.com/NVIDIA/nodewright/agent/internal/flags"
 	"github.com/NVIDIA/nodewright/agent/internal/stage"
 )
 
@@ -41,6 +42,7 @@ func TestHistory(t *testing.T) {
 
 var _ = Describe("history store", func() {
 	var (
+		root   string
 		dir    string
 		store  *fileStore
 		logger *slog.Logger
@@ -49,25 +51,29 @@ var _ = Describe("history store", func() {
 	)
 
 	BeforeEach(func() {
-		dir = filepath.Join(GinkgoT().TempDir(), "history")
+		root = GinkgoT().TempDir()
+		dir = filepath.Join(root, "history")
 		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 		cfg = config.Config{PackageName: "driver", PackageVersion: "1.2.3"}
 		now = time.Date(2026, time.June, 30, 12, 34, 56, 123456789, time.FixedZone("test", -7*60*60))
+		layout := flags.DefaultLayout(root)
+		dir = layout.HistoryDir()
 
 		var err error
-		store, err = newFileStore(dir, cfg, logger)
+		store, err = newFileStore(layout, cfg, logger)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("constructs the store behind its interface", func() {
-		s, err := NewStore(dir, cfg, logger)
+		layout := flags.DefaultLayout(root)
+		s, err := NewStore(layout, cfg, logger)
 		Expect(err).NotTo(HaveOccurred())
 		versions, err := s.Read()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(versions).To(Equal(Versions{Current: "1.2.3", Previous: UnknownVersion}))
 
 		cfg.PackageVersion = ""
-		s, err = NewStore(dir, cfg, logger)
+		s, err = NewStore(layout, cfg, logger)
 		Expect(err).To(MatchError("package version must not be empty"))
 		Expect(s).To(BeNil())
 	})
@@ -76,11 +82,6 @@ var _ = Describe("history store", func() {
 		versions, err := store.Read()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(versions).To(Equal(Versions{Current: "1.2.3", Previous: UnknownVersion}))
-		Expect(versions.Environment()).To(Equal(map[string]string{
-			CurrentVersionEnv:  "1.2.3",
-			PreviousVersionEnv: UnknownVersion,
-		}))
-		Expect(versions.UpgradeArguments()).To(Equal([]string{UnknownVersion, "1.2.3"}))
 		Expect(dir).NotTo(BeADirectory())
 	})
 
@@ -152,7 +153,7 @@ var _ = Describe("history store", func() {
 	It("prepends entries without losing prior history", func() {
 		oldConfig := cfg
 		oldConfig.PackageVersion = "1.1.0"
-		oldStore, err := newFileStore(dir, oldConfig, logger)
+		oldStore, err := newFileStore(flags.DefaultLayout(root), oldConfig, logger)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(oldStore.Record(stage.ApplyCheck, now.Add(-time.Hour))).To(Succeed())
 		Expect(store.Record(stage.UpgradeCheck, now)).To(Succeed())
@@ -210,16 +211,17 @@ var _ = Describe("history store", func() {
 	It("rejects invalid package identities at construction", func() {
 		invalid := cfg
 		invalid.PackageVersion = ""
-		_, err := newFileStore(dir, invalid, logger)
+		layout := flags.DefaultLayout(root)
+		_, err := newFileStore(layout, invalid, logger)
 		Expect(err).To(MatchError("package version must not be empty"))
 
 		invalid = cfg
 		invalid.PackageName = "../driver"
-		_, err = newFileStore(dir, invalid, logger)
+		_, err = newFileStore(layout, invalid, logger)
 		Expect(err).To(MatchError(ContainSubstring(`package name "../driver" must be a single path component`)))
 
 		invalid.PackageName = ""
-		_, err = newFileStore(dir, invalid, logger)
+		_, err = newFileStore(layout, invalid, logger)
 		Expect(err).To(MatchError(ContainSubstring("single path component")))
 		Expect(dir).NotTo(BeADirectory())
 	})
@@ -238,5 +240,15 @@ var _ = Describe("history store", func() {
 
 		_, err := store.Read()
 		Expect(err).To(MatchError(ContainSubstring("reading history")))
+	})
+
+	It("does not follow a symlinked history directory", func() {
+		outside := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Dir(dir), 0o755)).To(Succeed())
+		Expect(os.Symlink(outside, dir)).To(Succeed())
+
+		err := store.Record(stage.ApplyCheck, now)
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		Expect(filepath.Join(outside, "driver.json")).NotTo(BeAnExistingFile())
 	})
 })

--- a/agent/go/internal/hostfs/copy.go
+++ b/agent/go/internal/hostfs/copy.go
@@ -1,0 +1,179 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hostfs
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// CopyTreeIfExists recursively copies source into a destination beneath
+// rootMount. A missing source is treated as an empty tree.
+func CopyTreeIfExists(rootMount, source, destination string) error {
+	info, err := os.Lstat(source)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		return fmt.Errorf("copy source %q is a symbolic link", source)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("copy source %q is not a directory", source)
+	}
+	return CopyTree(rootMount, source, destination)
+}
+
+// CopyTree recursively copies regular files from source into a destination
+// beneath rootMount and rejects symbolic links in the source tree. A failed
+// copy can leave entries already copied to the destination; callers may retry.
+func CopyTree(rootMount, source, destination string) error {
+	return filepath.WalkDir(source, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return fmt.Errorf("walking copy source %q: %w", path, walkErr)
+		}
+		relative, err := filepath.Rel(source, path)
+		if err != nil {
+			return fmt.Errorf("resolving copy source %q: %w", path, err)
+		}
+		if relative != "." && !filepath.IsLocal(relative) {
+			return fmt.Errorf("copy source path %q escapes %q", path, source)
+		}
+		target := destination
+		if relative != "." {
+			target = filepath.Join(destination, relative)
+		}
+
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("stating copy source %q: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("copy source %q is a symbolic link", path)
+		}
+		if info.IsDir() {
+			if err := makeDirectory(rootMount, target, info.Mode().Perm()); err != nil {
+				return fmt.Errorf("creating copy destination directory %q: %w", target, err)
+			}
+			return nil
+		}
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("copy source %q is not a regular file", path)
+		}
+		if err := copyRegularFile(rootMount, path, target, info.Mode().Perm()); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// CopyFile copies a regular file and its permissions to a destination beneath
+// rootMount. Source symbolic links are followed, while symbolic links in the
+// destination path are rejected.
+func CopyFile(rootMount, source, destination string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return fmt.Errorf("stating copy source %q: %w", source, err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("copy source %q is not a regular file", source)
+	}
+	return copyRegularFile(rootMount, source, destination, info.Mode().Perm())
+}
+
+func makeDirectory(rootMount, path string, mode fs.FileMode) (retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	if relative == "." {
+		// CopyTree merges source contents into rootMount without changing the
+		// mounted host root's own permissions.
+		return nil
+	}
+	if err := ensureDirectories(root, filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("preparing parent directory for %q: %w", path, err)
+	}
+	if err := ensureDirectories(root, relative, mode); err != nil {
+		return fmt.Errorf("creating directory %q: %w", path, err)
+	}
+	if err := root.Chmod(relative, mode); err != nil {
+		return fmt.Errorf("setting permissions on directory %q: %w", path, err)
+	}
+	return nil
+}
+
+func copyRegularFile(
+	rootMount, source, destination string,
+	mode fs.FileMode,
+) (retErr error) {
+	root, relative, err := openRoot(rootMount, destination)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	sourceFile, err := os.Open(source)
+	if err != nil {
+		return fmt.Errorf("opening copy source %q: %w", source, err)
+	}
+	defer func() {
+		if err := sourceFile.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing copy source %q: %w", source, err)
+		}
+	}()
+
+	if err := ensureDirectories(root, filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("creating copy destination directory %q: %w", filepath.Dir(destination), err)
+	}
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return fmt.Errorf("validating copy destination %q: %w", destination, err)
+	}
+	if exists {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("copy destination %q is not a regular file", destination)
+		}
+		sourceInfo, err := sourceFile.Stat()
+		if err != nil {
+			return fmt.Errorf("stating open copy source %q: %w", source, err)
+		}
+		if os.SameFile(sourceInfo, info) {
+			return nil
+		}
+	}
+
+	if err := writeRootedFile(root, relative, mode, true, func(destinationFile *os.File) error {
+		if _, err := io.Copy(destinationFile, sourceFile); err != nil {
+			return fmt.Errorf("copying %q to %q: %w", source, destination, err)
+		}
+		return nil
+	}); err != nil {
+		return fmt.Errorf("writing copy destination %q: %w", destination, err)
+	}
+	return nil
+}

--- a/agent/go/internal/hostfs/copy_test.go
+++ b/agent/go/internal/hostfs/copy_test.go
@@ -1,0 +1,224 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hostfs
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("filesystem copying", func() {
+	It("copies directory contents and replaces existing regular files", func() {
+		source := GinkgoT().TempDir()
+		destination := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(source, "nested"), 0o755)).To(Succeed())
+		Expect(os.Chmod(filepath.Join(source, "nested"), 0o701)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(source, "nested", "step"), []byte("new"), 0o700)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(source, "existing"), []byte("new"), 0o600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(destination, "existing"), []byte("old"), 0o600)).To(Succeed())
+		previousUmask := syscall.Umask(0o077)
+		DeferCleanup(syscall.Umask, previousUmask)
+
+		Expect(CopyTree(destination, source, destination)).To(Succeed())
+
+		directoryInfo, err := os.Stat(filepath.Join(destination, "nested"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(directoryInfo.Mode().Perm()).To(Equal(os.FileMode(0o701)))
+		data, err := os.ReadFile(filepath.Join(destination, "nested", "step"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("new"))
+		data, err = os.ReadFile(filepath.Join(destination, "existing"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("new"))
+		info, err := os.Stat(filepath.Join(destination, "nested", "step"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o700)))
+
+		Expect(os.Chmod(filepath.Join(source, "nested"), 0o750)).To(Succeed())
+		Expect(os.Chmod(filepath.Join(destination, "nested"), 0o777)).To(Succeed())
+		Expect(CopyTree(destination, source, destination)).To(Succeed())
+		directoryInfo, err = os.Stat(filepath.Join(destination, "nested"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(directoryInfo.Mode().Perm()).To(Equal(os.FileMode(0o750)))
+	})
+
+	It("uses the default mode for destination ancestors", func() {
+		root := GinkgoT().TempDir()
+		source := GinkgoT().TempDir()
+		destination := filepath.Join(root, "var", "lib", "nodewright", "root")
+		Expect(os.Chmod(source, 0o700)).To(Succeed())
+
+		Expect(CopyTree(root, source, destination)).To(Succeed())
+
+		for _, path := range []string{
+			filepath.Join(root, "var"),
+			filepath.Join(root, "var", "lib"),
+			filepath.Join(root, "var", "lib", "nodewright"),
+		} {
+			info, err := os.Stat(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o755)))
+		}
+		info, err := os.Stat(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o700)))
+	})
+
+	It("rejects symbolic links in copy sources", func() {
+		source := GinkgoT().TempDir()
+		destination := GinkgoT().TempDir()
+		Expect(os.Symlink(GinkgoT().TempDir(), filepath.Join(source, "linked"))).To(Succeed())
+
+		Expect(CopyTree(destination, source, destination)).To(MatchError(ContainSubstring("is a symbolic link")))
+	})
+
+	It("rejects symbolic links at copy destinations", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(GinkgoT().TempDir(), "source")
+		outside := filepath.Join(GinkgoT().TempDir(), "outside")
+		destination := filepath.Join(root, "destination")
+		Expect(os.WriteFile(source, []byte("contents"), 0o600)).To(Succeed())
+		Expect(os.WriteFile(outside, []byte("original"), 0o600)).To(Succeed())
+		Expect(os.Symlink(outside, destination)).To(Succeed())
+
+		err := CopyFile(root, source, destination)
+
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		data, err := os.ReadFile(outside)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("original"))
+	})
+
+	It("rejects a copy destination symlink that points at the source", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(root, "source")
+		destination := filepath.Join(root, "destination")
+		Expect(os.WriteFile(source, []byte("contents"), 0o600)).To(Succeed())
+		Expect(os.Symlink(source, destination)).To(Succeed())
+
+		Expect(CopyFile(root, source, destination)).To(MatchError(ContainSubstring("is a symbolic link")))
+	})
+
+	It("rejects a destination whose parent symlink resolves to the source", func() {
+		root := GinkgoT().TempDir()
+		outside := GinkgoT().TempDir()
+		source := filepath.Join(outside, "source")
+		destination := filepath.Join(root, "linked", "source")
+		Expect(os.WriteFile(source, []byte("contents"), 0o600)).To(Succeed())
+		Expect(os.Symlink(outside, filepath.Join(root, "linked"))).To(Succeed())
+
+		Expect(CopyFile(root, source, destination)).To(MatchError(ContainSubstring("is a symbolic link")))
+	})
+
+	It("follows a symbolic link at a copy source", func() {
+		root := GinkgoT().TempDir()
+		target := filepath.Join(GinkgoT().TempDir(), "target")
+		source := filepath.Join(GinkgoT().TempDir(), "source")
+		destination := filepath.Join(root, "destination")
+		Expect(os.WriteFile(target, []byte("contents"), 0o640)).To(Succeed())
+		Expect(os.Symlink(target, source)).To(Succeed())
+
+		Expect(CopyFile(root, source, destination)).To(Succeed())
+
+		data, err := os.ReadFile(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("contents"))
+		info, err := os.Stat(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o640)))
+	})
+
+	It("rejects a symbolic link as an optional copy source", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(root, "source")
+		Expect(os.Symlink(GinkgoT().TempDir(), source)).To(Succeed())
+
+		Expect(CopyTreeIfExists(root, source, filepath.Join(root, "destination"))).To(
+			MatchError(ContainSubstring("is a symbolic link")),
+		)
+	})
+
+	It("treats a missing optional tree as empty", func() {
+		root := GinkgoT().TempDir()
+
+		Expect(CopyTreeIfExists(
+			root,
+			filepath.Join(root, "missing"),
+			filepath.Join(root, "destination"),
+		)).To(Succeed())
+	})
+
+	It("copies a regular file and its permissions", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(root, "source")
+		destination := filepath.Join(root, "destination", "file")
+		Expect(os.WriteFile(source, []byte("contents"), 0o640)).To(Succeed())
+
+		Expect(CopyFile(root, source, destination)).To(Succeed())
+
+		data, err := os.ReadFile(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("contents"))
+		info, err := os.Stat(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o640)))
+	})
+
+	It("treats copying a regular file onto itself as complete", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "file")
+		Expect(os.WriteFile(path, []byte("contents"), 0o600)).To(Succeed())
+
+		Expect(CopyFile(root, path, path)).To(Succeed())
+
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("contents"))
+	})
+
+	It("applies copied permissions despite the process umask", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(root, "source")
+		destination := filepath.Join(root, "destination")
+		Expect(os.WriteFile(source, []byte("contents"), 0o600)).To(Succeed())
+		Expect(os.Chmod(source, 0o666)).To(Succeed())
+		previousUmask := syscall.Umask(0o077)
+		DeferCleanup(syscall.Umask, previousUmask)
+
+		Expect(CopyFile(root, source, destination)).To(Succeed())
+
+		info, err := os.Stat(destination)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o666)))
+	})
+
+	It("rejects copy destinations outside the mounted root", func() {
+		root := GinkgoT().TempDir()
+		source := filepath.Join(root, "source")
+		Expect(os.WriteFile(source, []byte("contents"), 0o600)).To(Succeed())
+
+		err := CopyFile(root, source, filepath.Join(root, "..", "outside"))
+
+		Expect(err).To(MatchError(ContainSubstring("must be contained")))
+	})
+})

--- a/agent/go/internal/hostfs/hostfs.go
+++ b/agent/go/internal/hostfs/hostfs.go
@@ -1,0 +1,477 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package hostfs provides symlink-safe filesystem operations rooted at the
+// host filesystem mounted into the agent container. Rooted path arguments
+// must already include rootMount; HostPathToMounted explicitly converts a
+// host-absolute path to that mounted form.
+package hostfs
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const directoryMode = 0o755
+
+// HostPathToMounted maps an absolute host path beneath the mounted host root.
+func HostPathToMounted(rootMount, hostPath string) (string, error) {
+	if !filepath.IsAbs(rootMount) {
+		return "", fmt.Errorf("root mount %q is not absolute", rootMount)
+	}
+	if !filepath.IsAbs(hostPath) {
+		return "", fmt.Errorf("host path %q is not absolute", hostPath)
+	}
+
+	rootMount = filepath.Clean(rootMount)
+	relative := strings.TrimPrefix(filepath.Clean(hostPath), string(filepath.Separator))
+	if relative == "" || relative == "." {
+		return rootMount, nil
+	}
+	if !filepath.IsLocal(relative) {
+		return "", fmt.Errorf("host path %q escapes the mounted host root", hostPath)
+	}
+	return filepath.Join(rootMount, relative), nil
+}
+
+// RegularFileExists reports whether path is a regular file beneath rootMount.
+func RegularFileExists(rootMount, path string) (exists bool, retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return false, err
+	}
+	defer closeRoot(root, &retErr)
+
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return false, fmt.Errorf("inspecting file %q: %w", path, err)
+	}
+	if exists && !info.Mode().IsRegular() {
+		return false, fmt.Errorf("path %q is not a regular file", path)
+	}
+	return exists, nil
+}
+
+// ReadFile reads a regular file beneath rootMount without following symbolic
+// links in its path.
+func ReadFile(rootMount, path string) (data []byte, retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRoot(root, &retErr)
+
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return nil, fmt.Errorf("validating file %q: %w", path, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("reading file %q: %w", path, fs.ErrNotExist)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("path %q is not a regular file", path)
+	}
+	data, err = root.ReadFile(relative)
+	if err != nil {
+		return nil, fmt.Errorf("reading file %q: %w", path, err)
+	}
+	return data, nil
+}
+
+// ReadDir reads a directory beneath rootMount without following symbolic
+// links in its path.
+func ReadDir(rootMount, path string) (entries []fs.DirEntry, retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return nil, err
+	}
+	defer closeRoot(root, &retErr)
+
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return nil, fmt.Errorf("validating directory %q: %w", path, err)
+	}
+	if !exists {
+		return nil, fmt.Errorf("reading directory %q: %w", path, fs.ErrNotExist)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("path %q is not a directory", path)
+	}
+	directory, err := root.Open(relative)
+	if err != nil {
+		return nil, fmt.Errorf("opening directory %q: %w", path, err)
+	}
+	defer func() {
+		if err := directory.Close(); err != nil && retErr == nil {
+			retErr = fmt.Errorf("closing directory %q: %w", path, err)
+		}
+	}()
+	entries, err = directory.ReadDir(-1)
+	if err != nil {
+		return nil, fmt.Errorf("reading directory %q: %w", path, err)
+	}
+	return entries, nil
+}
+
+// CreateFile creates a new regular file beneath rootMount without replacing an
+// existing path, then syncs the file and its parent directory.
+func CreateFile(rootMount, path string, data []byte, mode fs.FileMode) (retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	if err := ensureDirectories(root, filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("preparing parent directory for %q: %w", path, err)
+	}
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return fmt.Errorf("validating file target %q: %w", path, err)
+	}
+	if exists {
+		if !info.Mode().IsRegular() {
+			return fmt.Errorf("path %q is not a regular file", path)
+		}
+		return fmt.Errorf("file %q already exists: %w", path, fs.ErrExist)
+	}
+	if err := writeFile(root, relative, data, mode, false); err != nil {
+		return fmt.Errorf("creating file %q: %w", path, err)
+	}
+	return nil
+}
+
+// CreateFileWriter creates a new regular file beneath rootMount and returns it
+// open for writing. The caller owns the returned file and must close it.
+func CreateFileWriter(rootMount, path string, mode fs.FileMode) (file *os.File, retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if retErr != nil && file != nil {
+			retErr = errors.Join(retErr, file.Close())
+			file = nil
+		}
+	}()
+	defer closeRoot(root, &retErr)
+
+	if err := ensureDirectories(root, filepath.Dir(relative), directoryMode); err != nil {
+		return nil, fmt.Errorf("preparing parent directory for %q: %w", path, err)
+	}
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return nil, fmt.Errorf("validating file target %q: %w", path, err)
+	}
+	if exists {
+		if !info.Mode().IsRegular() {
+			return nil, fmt.Errorf("path %q is not a regular file", path)
+		}
+		return nil, fmt.Errorf("file %q already exists: %w", path, fs.ErrExist)
+	}
+	file, err = root.OpenFile(relative, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return nil, fmt.Errorf("creating file %q without following symlinks: %w", path, err)
+	}
+	if err := root.Chmod(relative, mode); err != nil {
+		closeErr := file.Close()
+		file = nil
+		removeErr := root.Remove(relative)
+		return nil, errors.Join(
+			fmt.Errorf("setting permissions on %q: %w", path, err),
+			closeErr,
+			removeErr,
+		)
+	}
+	return file, nil
+}
+
+// WriteFile creates or atomically replaces a regular file beneath rootMount,
+// then syncs the file and its parent directory.
+func WriteFile(rootMount, path string, data []byte, mode fs.FileMode) (retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	if err := ensureDirectories(root, filepath.Dir(relative), directoryMode); err != nil {
+		return fmt.Errorf("preparing parent directory for %q: %w", path, err)
+	}
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return fmt.Errorf("validating file target %q: %w", path, err)
+	}
+	if exists && !info.Mode().IsRegular() {
+		return fmt.Errorf("path %q is not a regular file", path)
+	}
+	if err := writeFile(root, relative, data, mode, true); err != nil {
+		return fmt.Errorf("writing file %q: %w", path, err)
+	}
+	return nil
+}
+
+// RenameFile renames a regular file beneath rootMount and syncs the affected
+// directories. An existing regular destination is replaced.
+func RenameFile(rootMount, oldPath, newPath string) (retErr error) {
+	root, oldRelative, err := openRoot(rootMount, oldPath)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	newRelative, err := filepath.Rel(filepath.Clean(rootMount), filepath.Clean(newPath))
+	if err != nil {
+		return fmt.Errorf("resolving host path %q: %w", newPath, err)
+	}
+	if !filepath.IsLocal(newRelative) {
+		return fmt.Errorf("host path %q must be contained within %q", newPath, rootMount)
+	}
+	oldInfo, exists, err := inspect(root, oldRelative)
+	if err != nil {
+		return fmt.Errorf("validating rename source %q: %w", oldPath, err)
+	}
+	if !exists {
+		return fmt.Errorf("renaming file %q: %w", oldPath, fs.ErrNotExist)
+	}
+	if !oldInfo.Mode().IsRegular() {
+		return fmt.Errorf("path %q is not a regular file", oldPath)
+	}
+	newInfo, exists, err := inspect(root, newRelative)
+	if err != nil {
+		return fmt.Errorf("validating rename destination %q: %w", newPath, err)
+	}
+	if exists && !newInfo.Mode().IsRegular() {
+		return fmt.Errorf("path %q is not a regular file", newPath)
+	}
+	if err := ensureDirectories(root, filepath.Dir(newRelative), directoryMode); err != nil {
+		return fmt.Errorf("preparing parent directory for %q: %w", newPath, err)
+	}
+	if err := root.Rename(oldRelative, newRelative); err != nil {
+		return fmt.Errorf("renaming file %q to %q: %w", oldPath, newPath, err)
+	}
+	newDirectory := filepath.Dir(newRelative)
+	if err := syncRootedDirectory(root, newDirectory); err != nil {
+		return fmt.Errorf("syncing rename destination directory %q: %w", filepath.Dir(newPath), err)
+	}
+	oldDirectory := filepath.Dir(oldRelative)
+	if oldDirectory != newDirectory {
+		if err := syncRootedDirectory(root, oldDirectory); err != nil {
+			return fmt.Errorf("syncing rename source directory %q: %w", filepath.Dir(oldPath), err)
+		}
+	}
+	return nil
+}
+
+// RemoveFile removes a regular file beneath rootMount. A missing file is
+// already removed and succeeds.
+func RemoveFile(rootMount, path string) (retErr error) {
+	root, relative, err := openRoot(rootMount, path)
+	if err != nil {
+		return err
+	}
+	defer closeRoot(root, &retErr)
+
+	info, exists, err := inspect(root, relative)
+	if err != nil {
+		return fmt.Errorf("inspecting file %q: %w", path, err)
+	}
+	if !exists {
+		return nil
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("path %q is not a regular file", path)
+	}
+	if err := root.Remove(relative); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("removing file %q: %w", path, err)
+	}
+	return nil
+}
+
+func openRoot(rootMount, path string) (*os.Root, string, error) {
+	if !filepath.IsAbs(rootMount) {
+		return nil, "", fmt.Errorf("root mount %q is not absolute", rootMount)
+	}
+	relative, err := filepath.Rel(filepath.Clean(rootMount), filepath.Clean(path))
+	if err != nil {
+		return nil, "", fmt.Errorf("resolving host path %q: %w", path, err)
+	}
+	if !filepath.IsLocal(relative) {
+		return nil, "", fmt.Errorf("host path %q must be contained within %q", path, rootMount)
+	}
+	root, err := os.OpenRoot(rootMount)
+	if err != nil {
+		return nil, "", fmt.Errorf("opening mounted host root %q: %w", rootMount, err)
+	}
+	return root, relative, nil
+}
+
+func ensureDirectories(root *os.Root, directory string, mode fs.FileMode) error {
+	current := ""
+	for _, component := range pathComponents(directory) {
+		current = filepath.Join(current, component)
+		info, err := root.Lstat(current)
+		if errors.Is(err, fs.ErrNotExist) {
+			if mkdirErr := root.Mkdir(current, mode); mkdirErr != nil {
+				if !errors.Is(mkdirErr, fs.ErrExist) {
+					return fmt.Errorf("creating directory %q: %w", current, mkdirErr)
+				}
+			} else {
+				// Preserve existing directory modes while correcting umask on directories created here.
+				if err := root.Chmod(current, mode); err != nil {
+					return fmt.Errorf("setting permissions on directory %q: %w", current, err)
+				}
+			}
+			info, err = root.Lstat(current)
+		}
+		if err != nil {
+			return fmt.Errorf("inspecting directory %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("path component %q is a symbolic link", current)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("path component %q is not a directory", current)
+		}
+	}
+	return nil
+}
+
+func inspect(root *os.Root, path string) (os.FileInfo, bool, error) {
+	components := pathComponents(path)
+	current := ""
+	for index, component := range components {
+		current = filepath.Join(current, component)
+		info, err := root.Lstat(current)
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, false, nil
+		}
+		if err != nil {
+			return nil, false, fmt.Errorf("inspecting path component %q: %w", current, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return nil, false, fmt.Errorf("path component %q is a symbolic link", current)
+		}
+		if index < len(components)-1 && !info.IsDir() {
+			return nil, false, fmt.Errorf("path component %q is not a directory", current)
+		}
+		if index == len(components)-1 {
+			return info, true, nil
+		}
+	}
+	return nil, false, nil
+}
+
+func pathComponents(path string) []string {
+	clean := filepath.Clean(path)
+	if clean == "." {
+		return nil
+	}
+	return strings.Split(clean, string(filepath.Separator))
+}
+
+func writeFile(
+	root *os.Root,
+	path string,
+	data []byte,
+	mode fs.FileMode,
+	replace bool,
+) error {
+	return writeRootedFile(root, path, mode, replace, func(file *os.File) error {
+		if _, err := file.Write(data); err != nil {
+			return fmt.Errorf("writing %q: %w", path, err)
+		}
+		return nil
+	})
+}
+
+func writeRootedFile(
+	root *os.Root,
+	path string,
+	mode fs.FileMode,
+	replace bool,
+	write func(*os.File) error,
+) (retErr error) {
+	writePath := path
+	if replace {
+		writePath = filepath.Join(filepath.Dir(path), ".hostfs-"+rand.Text()+".tmp")
+	}
+	file, err := root.OpenFile(writePath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return fmt.Errorf("creating %q without following symlinks: %w", path, err)
+	}
+	defer func() {
+		if err := file.Close(); err != nil && !errors.Is(err, os.ErrClosed) && retErr == nil {
+			retErr = fmt.Errorf("closing %q: %w", path, err)
+		}
+		if retErr != nil {
+			if err := root.Remove(writePath); err != nil && !errors.Is(err, fs.ErrNotExist) {
+				retErr = errors.Join(retErr, fmt.Errorf("removing incomplete file %q: %w", writePath, err))
+			}
+		}
+	}()
+
+	if err := write(file); err != nil {
+		return err
+	}
+	if err := root.Chmod(writePath, mode); err != nil {
+		return fmt.Errorf("setting permissions on %q: %w", path, err)
+	}
+	if err := file.Sync(); err != nil {
+		return fmt.Errorf("syncing %q: %w", path, err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("closing %q: %w", path, err)
+	}
+	if replace {
+		if err := root.Rename(writePath, path); err != nil {
+			return fmt.Errorf("atomically replacing %q: %w", path, err)
+		}
+	}
+	if err := syncRootedDirectory(root, filepath.Dir(path)); err != nil {
+		return fmt.Errorf("syncing parent directory for %q: %w", path, err)
+	}
+	return nil
+}
+
+func syncRootedDirectory(root *os.Root, directory string) (retErr error) {
+	file, err := root.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := file.Close(); err != nil && retErr == nil {
+			retErr = err
+		}
+	}()
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func closeRoot(root *os.Root, retErr *error) {
+	if err := root.Close(); err != nil && *retErr == nil {
+		*retErr = fmt.Errorf("closing mounted host root %q: %w", root.Name(), err)
+	}
+}

--- a/agent/go/internal/hostfs/hostfs_test.go
+++ b/agent/go/internal/hostfs/hostfs_test.go
@@ -1,0 +1,207 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package hostfs
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHostFS(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Host Filesystem Suite")
+}
+
+var _ = Describe("mounted host filesystem", func() {
+	It("resolves absolute host paths beneath the mounted root", func() {
+		root := GinkgoT().TempDir()
+
+		path, err := HostPathToMounted(root, "/etc/nodewright/config")
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(path).To(Equal(filepath.Join(root, "etc", "nodewright", "config")))
+	})
+
+	It("rejects relative roots and host paths", func() {
+		_, err := HostPathToMounted("root", "/etc/config")
+		Expect(err).To(MatchError(ContainSubstring("root mount")))
+
+		_, err = HostPathToMounted(GinkgoT().TempDir(), "etc/config")
+		Expect(err).To(MatchError(ContainSubstring("host path")))
+	})
+
+	It("creates, replaces, finds, and removes regular files", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "state", "marker")
+
+		Expect(CreateFile(root, path, []byte("created"), 0o600)).To(Succeed())
+		exists, err := RegularFileExists(root, path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeTrue())
+		err = CreateFile(root, path, nil, 0o600)
+		Expect(errors.Is(err, fs.ErrExist)).To(BeTrue())
+
+		Expect(WriteFile(root, path, []byte("replaced"), 0o600)).To(Succeed())
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("replaced"))
+
+		Expect(RemoveFile(root, path)).To(Succeed())
+		Expect(RemoveFile(root, path)).To(Succeed())
+		exists, err = RegularFileExists(root, path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exists).To(BeFalse())
+	})
+
+	It("reads regular files and directories", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "state", "marker")
+		Expect(CreateFile(root, path, []byte("value"), 0o600)).To(Succeed())
+
+		data, err := ReadFile(root, path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("value"))
+		entries, err := ReadDir(root, filepath.Dir(path))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+		Expect(entries[0].Name()).To(Equal("marker"))
+	})
+
+	It("creates an exclusive file for streaming writes", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "logs", "step.log")
+
+		file, err := CreateFileWriter(root, path, 0o600)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = file.Write([]byte("streamed"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(file.Close()).To(Succeed())
+		_, err = CreateFileWriter(root, path, 0o600)
+		Expect(errors.Is(err, fs.ErrExist)).To(BeTrue())
+
+		data, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("streamed"))
+	})
+
+	It("renames regular files without following symbolic links", func() {
+		root := GinkgoT().TempDir()
+		oldPath := filepath.Join(root, "state", "old")
+		newPath := filepath.Join(root, "state", "new")
+		Expect(CreateFile(root, oldPath, []byte("value"), 0o600)).To(Succeed())
+		Expect(CreateFile(root, newPath, []byte("replaced"), 0o600)).To(Succeed())
+
+		Expect(RenameFile(root, oldPath, newPath)).To(Succeed())
+		Expect(oldPath).NotTo(BeAnExistingFile())
+		data, err := os.ReadFile(newPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(Equal("value"))
+	})
+
+	It("rejects a non-regular rename destination", func() {
+		root := GinkgoT().TempDir()
+		oldPath := filepath.Join(root, "state", "old")
+		newPath := filepath.Join(root, "state", "new")
+		Expect(CreateFile(root, oldPath, []byte("value"), 0o600)).To(Succeed())
+		Expect(os.Mkdir(newPath, 0o755)).To(Succeed())
+
+		Expect(RenameFile(root, oldPath, newPath)).To(MatchError(ContainSubstring("is not a regular file")))
+		Expect(oldPath).To(BeAnExistingFile())
+		Expect(newPath).To(BeADirectory())
+	})
+
+	It("applies requested write permissions despite the process umask", func() {
+		root := GinkgoT().TempDir()
+		path := filepath.Join(root, "state", "marker")
+		previousUmask := syscall.Umask(0o077)
+		DeferCleanup(syscall.Umask, previousUmask)
+
+		Expect(WriteFile(root, path, []byte("value"), 0o666)).To(Succeed())
+
+		info, err := os.Stat(path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Mode().Perm()).To(Equal(os.FileMode(0o666)))
+	})
+
+	It("rejects paths outside the mounted root", func() {
+		root := GinkgoT().TempDir()
+
+		err := CreateFile(root, filepath.Join(root, "..", "outside"), nil, 0o600)
+
+		Expect(err).To(MatchError(ContainSubstring("must be contained")))
+	})
+
+	It("does not follow symbolic links in rooted paths", func() {
+		root := GinkgoT().TempDir()
+		outside := GinkgoT().TempDir()
+		Expect(os.Symlink(outside, filepath.Join(root, "linked"))).To(Succeed())
+
+		err := WriteFile(root, filepath.Join(root, "linked", "marker"), nil, 0o600)
+
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		Expect(filepath.Join(outside, "marker")).NotTo(BeAnExistingFile())
+	})
+
+	It("rejects symbolic links for reads, directory listings, writers, and renames", func() {
+		root := GinkgoT().TempDir()
+		outside := GinkgoT().TempDir()
+		Expect(os.WriteFile(filepath.Join(outside, "marker"), []byte("outside"), 0o600)).To(Succeed())
+		Expect(os.Symlink(outside, filepath.Join(root, "linked"))).To(Succeed())
+
+		_, err := ReadFile(root, filepath.Join(root, "linked", "marker"))
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		_, err = ReadDir(root, filepath.Join(root, "linked"))
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		_, err = CreateFileWriter(root, filepath.Join(root, "linked", "log"), 0o600)
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+		err = RenameFile(
+			root,
+			filepath.Join(root, "linked", "marker"),
+			filepath.Join(root, "renamed"),
+		)
+		Expect(err).To(MatchError(ContainSubstring("is a symbolic link")))
+	})
+
+	It("keeps an existing path when an atomic replacement fails", func() {
+		rootPath := GinkgoT().TempDir()
+		Expect(os.Mkdir(filepath.Join(rootPath, "target"), 0o755)).To(Succeed())
+		root, err := os.OpenRoot(rootPath)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			Expect(root.Close()).To(Succeed())
+		})
+
+		err = writeFile(root, "target", []byte("replacement"), 0o600, true)
+
+		Expect(err).To(MatchError(ContainSubstring("atomically replacing")))
+		info, err := os.Stat(filepath.Join(rootPath, "target"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.IsDir()).To(BeTrue())
+		entries, err := os.ReadDir(rootPath)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(entries).To(HaveLen(1))
+	})
+})


### PR DESCRIPTION
## Description

Centralizes host-mounted filesystem ownership behind a symlink-safe rooted I/O package and migrates the agent state stores to use it.

- Adds rooted file, directory, rename, removal, and copy operations that reject destination-path symlink traversal while retaining copyfile source-link semantics.
- Makes mounted-path conversion explicit and derives history storage from one Layout so rootMount and host paths cannot disagree.
- Preserves atomic replacement, explicit permissions, syncing, and cleanup behavior for host writes.
- Moves completion flags, package history, and retained logs onto the shared host filesystem boundary.
- Stages the copy primitives consumed by upstack PR #379 for package-data staging, host-root overlays, and resolver copying.
- Rehomes the step-version execution contract in upstack PR #407 through Step.WithVersions; PR #379 applies persisted history during upgrade execution, preserving CURRENT_VERSION, PREVIOUS_VERSION, and the [previous, current] upgrade arguments.
- Adds focused coverage for traversal rejection, copy behavior, permissions, retention, and persistent state.

Depends on #405.
Part of #219

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.