### PR TITLE
refactor(agent): unify regular and upgrade step execution

### DIFF
--- a/agent/README.md
+++ b/agent/README.md
@@ -20,10 +20,18 @@ A basic example of using a container overlay
 
 The Go rewrite under `agent/go` shares execution policy between steps and
 interrupts through `execution.Config`. A `Config` composes the host root mount,
-the child-visible step and package directories, and the stdout and stderr
-writers that receive raw command output. Operations report `execution.Status`:
+the package directories inside that host, and the stdout and stderr writers
+that receive raw command output. Non-host steps resolve those directories
+through the mounted host root before execution. Operations report
+`execution.Status`:
 `execution.StatusSuccess` means the operation satisfied its execution policy,
 while `execution.StatusFailed` means it did not.
+
+The agent reserves `STEP_ROOT` and `SKYHOOK_DIR` for every step and
+`PREVIOUS_VERSION` and `CURRENT_VERSION` for upgrade steps. Runtime values
+overwrite matching keys from a package's configured `env`. For host steps,
+`STEP_ROOT` and `SKYHOOK_DIR` are host-absolute paths. For non-host steps, they
+are paths inside the agent container, resolved through the mounted host root.
 
 Each Go interrupt owns its command construction and execution. The `Interrupt`
 contract exposes `Type` for the wire identity, `Run` for execution using an

--- a/agent/go/internal/config/schemas/v1/step-schema.json
+++ b/agent/go/internal/config/schemas/v1/step-schema.json
@@ -31,11 +31,11 @@
             "minItems": 1
         },
         "on_host": {
-            "description": "Run the step on the host or inside the agent",
+            "description": "Run the step on the host or inside the agent. In the Go agent, STEP_ROOT and SKYHOOK_DIR are host-absolute for host steps and mounted-container paths for non-host steps.",
             "type": "boolean"
         },
         "env": {
-            "description": "Environment variables to set for the step",
+            "description": "Environment variables to set for the step. STEP_ROOT and SKYHOOK_DIR are reserved for every step; PREVIOUS_VERSION and CURRENT_VERSION are also reserved for upgrade steps. Agent runtime values overwrite configured values for those keys.",
             "type": "object",
             "patternProperties": {
                 ".*": { "type": "string" }
@@ -47,6 +47,10 @@
         },
         "upgrade_step": {
             "description": "Whether the step is an upgrade step",
+            "type": "boolean"
+        },
+        "requires_interrupt": {
+            "description": "Whether completing this step requires an interrupt",
             "type": "boolean"
         }
     },

--- a/agent/go/internal/config/validate_test.go
+++ b/agent/go/internal/config/validate_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/NVIDIA/nodewright/agent/internal/step"
 )
 
-func mustUpgradeStep(path string, opts ...step.RegularStepOption) step.UpgradeStep {
+func mustUpgradeStep(path string, opts ...step.Option) step.UpgradeStep {
 	u, err := step.NewUpgradeStep(path, opts...)
 	Expect(err).NotTo(HaveOccurred())
 	return u

--- a/agent/go/internal/execution/execution.go
+++ b/agent/go/internal/execution/execution.go
@@ -19,7 +19,7 @@
 // Package execution defines runtime contracts shared by agent operations.
 //
 // Status records an operation outcome as StatusSuccess or StatusFailed. Config
-// composes the host root mount, child-visible step and package directories, and
+// composes the host root mount, step and package paths within that host, and
 // the stdout and stderr writers used to stream command output.
 package execution
 
@@ -51,10 +51,10 @@ type Config struct {
 // RootMount returns the absolute host root used by host operations.
 func (config Config) RootMount() string { return config.rootMount }
 
-// StepRoot returns the child-visible directory containing step scripts.
+// StepRoot returns the directory containing step scripts inside the target host.
 func (config Config) StepRoot() string { return config.stepRoot }
 
-// SkyhookDir returns the child-visible package working directory.
+// SkyhookDir returns the package working directory inside the target host.
 func (config Config) SkyhookDir() string { return config.skyhookDir }
 
 // Stdout returns the destination for command standard output.
@@ -108,14 +108,14 @@ func WithRootMount(rootMount string) Option {
 	}
 }
 
-// WithStepRoot sets the child-visible absolute path containing step scripts.
+// WithStepRoot sets the absolute path containing step scripts inside the target host.
 func WithStepRoot(stepRoot string) Option {
 	return func(config *Config) {
 		config.stepRoot = stepRoot
 	}
 }
 
-// WithSkyhookDir sets the child-visible absolute package working directory.
+// WithSkyhookDir sets the absolute package working directory inside the target host.
 func WithSkyhookDir(skyhookDir string) Option {
 	return func(config *Config) {
 		config.skyhookDir = skyhookDir

--- a/agent/go/internal/history/history.go
+++ b/agent/go/internal/history/history.go
@@ -55,8 +55,8 @@ type Ledger struct {
 // Versions is the current package version and the previously recorded host
 // version. It is returned to callers instead of mutating a step in place.
 type Versions struct {
-	Current  string
 	Previous string
+	Current  string
 }
 
 // Store records completed version transitions for one package and reports the

--- a/agent/go/internal/step/regular_step.go
+++ b/agent/go/internal/step/regular_step.go
@@ -20,269 +20,93 @@ package step
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"encoding/json"
-	"errors"
-	"fmt"
-	"maps"
-	"os"
-	"path/filepath"
-	"slices"
-	"strings"
 
 	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
 )
 
-// RegularStep is the default Step implementation. Its fields are
-// exported with JSON tags so stdlib json.Marshal / json.Unmarshal
-// operate on it directly; Idempotence carries its own enum<->bool
-// codec, so no custom marshaler is needed here.
-//
-// applyDefaults makes Name fall back to ScriptPath, Arguments to []string{},
-// Returncodes to command.SuccessExitCode, Env to map[string]string{}, and
-// Idempotence to Auto.
-// NewRegularStep additionally defaults OnHost to true.
-//
-// ScriptPath carries the json:"path" wire name and IdempotenceMode the
-// json:"idempotence" wire name; both fields are named distinctly so
-// RegularStep can expose Path() and Idempotence() to satisfy Step.
+// RegularStep is the default Step implementation.
 type RegularStep struct {
-	Name            string             `json:"name"`
-	ScriptPath      string             `json:"path"`
-	Arguments       []string           `json:"arguments"`
-	Returncodes     []command.ExitCode `json:"returncodes"`
-	OnHost          bool               `json:"on_host"`
-	IdempotenceMode Idempotence        `json:"idempotence"`
-	UpgradeStep     bool               `json:"upgrade_step"`
-	Env             map[string]string  `json:"env,omitempty"`
+	Name              string             `json:"name"`
+	ScriptPath        string             `json:"path"`
+	Arguments         []string           `json:"arguments"`
+	Returncodes       []command.ExitCode `json:"returncodes"`
+	OnHost            bool               `json:"on_host"`
+	IdempotenceMode   Idempotence        `json:"idempotence"`
+	UpgradeStep       bool               `json:"upgrade_step"`
+	Env               map[string]string  `json:"env,omitempty"`
+	RequiresInterrupt bool               `json:"requires_interrupt,omitempty"`
 
-	// RequiresInterrupt round-trips via the wire as "requires_interrupt",
-	// emitted only when true; it stays schema-valid because the step schema
-	// permits extra properties.
-	RequiresInterrupt bool `json:"requires_interrupt,omitempty"`
+	versions *stepVersions
 }
 
 var _ Step = RegularStep{}
 
+// NewRegularStep constructs a RegularStep with canonical defaults.
+func NewRegularStep(path string, opts ...Option) RegularStep {
+	configured := newStepOptions(path, opts...)
+	return RegularStep{
+		Name:              configured.name,
+		ScriptPath:        path,
+		Arguments:         configured.arguments,
+		Returncodes:       configured.returncodes,
+		OnHost:            configured.onHost,
+		IdempotenceMode:   configured.idempotence,
+		Env:               configured.env,
+		RequiresInterrupt: configured.requiresInterrupt,
+	}
+}
+
 // Path returns the step's script path, relative to the package root.
-func (s RegularStep) Path() string { return s.ScriptPath }
+func (s RegularStep) Path() string {
+	return s.ScriptPath
+}
 
 // Idempotence reports how the agent treats re-runs of the step.
-func (s RegularStep) Idempotence() Idempotence { return s.IdempotenceMode }
+func (s RegularStep) Idempotence() Idempotence {
+	return s.IdempotenceMode
+}
 
-// Run resolves the step into a command and executes it in its configured host context.
+// WithVersions returns a copy with the package versions in its command environment.
+func (s RegularStep) WithVersions(previous, current string) Step {
+	s.versions = &stepVersions{previous: previous, current: current}
+	return s
+}
+
+// Run executes the configured command.
 func (s RegularStep) Run(ctx context.Context, config execution.Config) (execution.Status, error) {
-	if ctx == nil {
-		return execution.StatusFailed, errors.New("running step: context is nil")
-	}
-	if err := ctx.Err(); err != nil {
-		return execution.StatusFailed, fmt.Errorf("running step %q: %w", s.ScriptPath, err)
-	}
-	if err := config.Validate(); err != nil {
-		return execution.StatusFailed, fmt.Errorf("running step %q: invalid run config: %w", s.ScriptPath, err)
-	}
-	if !filepath.IsLocal(s.ScriptPath) {
-		return execution.StatusFailed, fmt.Errorf("running step: path %q must be relative to the step root", s.ScriptPath)
-	}
-
 	s.applyDefaults()
-	arguments, missing := s.resolveArguments()
-	if len(missing) > 0 {
-		return execution.StatusFailed, fmt.Errorf(
-			"running step %q: expected environment variables do not exist: %s",
-			s.ScriptPath,
-			strings.Join(missing, ", "),
-		)
-	}
-
-	runner := command.NewRunner(command.WithChroot(config.RootMount()))
-	if !s.OnHost {
-		runner = command.NewRunner()
-	}
-
-	environment := maps.Clone(s.Env)
-	environment["STEP_ROOT"] = config.StepRoot()
-	environment["SKYHOOK_DIR"] = config.SkyhookDir()
-	cmd := command.NewCommand(
-		filepath.Join(config.StepRoot(), s.ScriptPath),
-		command.WithArguments(arguments...),
-		command.WithWorkingDirectory(config.SkyhookDir()),
-		command.WithEnvironment(environment),
-		command.WithStdout(config.Stdout()),
-		command.WithStderr(config.Stderr()),
+	return runStep(
+		ctx,
+		config,
+		s.ScriptPath,
+		s.Arguments,
+		s.Returncodes,
+		s.OnHost,
+		s.Env,
+		s.versions,
 	)
-
-	commandResult, runErr := runner.Run(ctx, cmd)
-	if runErr != nil {
-		return execution.StatusFailed, fmt.Errorf("running step %q command: %w", s.ScriptPath, runErr)
-	}
-	if commandResult.Signal != nil || !slices.Contains(s.Returncodes, commandResult.ExitCode) {
-		return execution.StatusFailed, nil
-	}
-
-	return execution.StatusSuccess, nil
 }
 
-// Fingerprint returns a stable SHA-256 hex digest of the step's
-// execution-relevant inputs. Nil and empty arguments, return codes, and
-// env hash identically so hand-constructed and decoded steps agree.
+// Fingerprint returns a stable digest of the step's execution-relevant inputs.
 func (s RegularStep) Fingerprint() (string, error) {
-	arguments := s.Arguments
-	if arguments == nil {
-		arguments = []string{}
-	}
-	returnCodes := s.Returncodes
-	if returnCodes == nil {
-		returnCodes = []command.ExitCode{}
-	}
-	env := s.Env
-	if env == nil {
-		env = map[string]string{}
-	}
-	payload, err := json.Marshal(struct {
-		Path        string             `json:"path"`
-		Arguments   []string           `json:"arguments"`
-		ReturnCodes []command.ExitCode `json:"returnCodes"`
-		Env         map[string]string  `json:"env"`
-		OnHost      bool               `json:"onHost"`
-	}{
-		Path:        s.ScriptPath,
-		Arguments:   arguments,
-		ReturnCodes: returnCodes,
-		Env:         env,
-		OnHost:      s.OnHost,
-	})
-	if err != nil {
-		return "", fmt.Errorf("encoding step fingerprint: %w", err)
-	}
-	sum := sha256.Sum256(payload)
-	return hex.EncodeToString(sum[:]), nil
+	return stepFingerprint(s.ScriptPath, s.Arguments, s.Returncodes, s.Env, s.OnHost)
 }
 
-// Encode writes the JSON wire form with upgrade_step:false. Defaults
-// are applied to a local copy so the caller's value is not mutated;
-// Idempotence is validated after defaulting so a zero-value RegularStep
-// (which defaults to Auto) still encodes successfully. The discriminator
-// is pinned to false here so a caller that set the exported UpgradeStep
-// field cannot coerce a RegularStep into the upgrade-step wire form.
+// Encode serializes the regular-step wire form.
 func (s RegularStep) Encode() ([]byte, error) {
-	s.UpgradeStep = false
-	return s.encode()
-}
-
-// encode is the shared marshal path for RegularStep and UpgradeStep:
-// each public Encode pins its own discriminator on the value copy, then
-// delegates here for defaulting, validation, and marshaling.
-func (s RegularStep) encode() ([]byte, error) {
 	s.applyDefaults()
-	if err := s.IdempotenceMode.Validate(); err != nil {
-		return nil, fmt.Errorf("validate idempotence: %w", err)
-	}
-	out, err := json.Marshal(s)
-	if err != nil {
-		return nil, fmt.Errorf("marshal RegularStep: %w", err)
-	}
-	return out, nil
+	s.UpgradeStep = false
+	return encodeStep(s, s.IdempotenceMode)
 }
 
-// RegularStepOption configures a RegularStep during construction. Use
-// the With* helpers; the type is exported so callers can build option
-// slices and pass them through.
-type RegularStepOption func(*RegularStep)
-
-// WithName overrides the default Name (which otherwise falls back to ScriptPath).
-func WithName(name string) RegularStepOption { return func(s *RegularStep) { s.Name = name } }
-
-// WithArguments sets the step's arguments.
-func WithArguments(args []string) RegularStepOption {
-	return func(s *RegularStep) { s.Arguments = args }
-}
-
-// WithReturncodes sets the accepted return codes (default: [0]).
-func WithReturncodes(codes []command.ExitCode) RegularStepOption {
-	return func(s *RegularStep) { s.Returncodes = codes }
-}
-
-// WithEnv sets the environment map applied to the step process.
-func WithEnv(env map[string]string) RegularStepOption {
-	return func(s *RegularStep) { s.Env = env }
-}
-
-// WithOnHost overrides the default OnHost=true.
-func WithOnHost(onHost bool) RegularStepOption {
-	return func(s *RegularStep) { s.OnHost = onHost }
-}
-
-// WithIdempotence overrides the default Idempotence=Auto.
-func WithIdempotence(i Idempotence) RegularStepOption {
-	return func(s *RegularStep) { s.IdempotenceMode = i }
-}
-
-// WithRequiresInterrupt sets the requires_interrupt flag.
-func WithRequiresInterrupt(r bool) RegularStepOption {
-	return func(s *RegularStep) { s.RequiresInterrupt = r }
-}
-
-// NewRegularStep constructs a RegularStep, applying defaults (Name
-// from Path, Arguments=[], Returncodes=[0], Env={}, Idempotence=Auto,
-// OnHost=true) for any fields the caller did not set via With* options.
-func NewRegularStep(path string, opts ...RegularStepOption) RegularStep {
-	// OnHost is seeded true here because Go's bool has no "absent"
-	// state, so applyDefaults can't tell zero apart from "explicit
-	// false"; WithOnHost(false) overrides this initial value.
-	rs := RegularStep{ScriptPath: path, OnHost: true}
-	for _, opt := range opts {
-		opt(&rs)
-	}
-	rs.applyDefaults()
-	return rs
-}
-
-// applyDefaults fills zero-valued fields with their canonical defaults.
-// Encode and Decode both call this so callers can construct a
-// RegularStep{} literally and still round-trip cleanly.
-//
-// OnHost is intentionally not defaulted here: Go's bool has no "absent"
-// state, and a schema-valid config always carries on_host, so the
-// constructor seeds it and stdlib decode reads whatever the payload set.
 func (s *RegularStep) applyDefaults() {
-	if s.Name == "" {
-		s.Name = s.ScriptPath
-	}
-	if len(s.Arguments) == 0 {
-		s.Arguments = []string{}
-	}
-	if len(s.Returncodes) == 0 {
-		s.Returncodes = []command.ExitCode{command.SuccessExitCode}
-	}
-	if s.Env == nil {
-		s.Env = map[string]string{}
-	}
-	if s.IdempotenceMode == "" {
-		s.IdempotenceMode = Auto
-	}
-}
-
-func (s RegularStep) resolveArguments() ([]string, []string) {
-	arguments := slices.Clone(s.Arguments)
-	missing := make([]string, 0)
-	seenMissing := make(map[string]struct{})
-	for index, argument := range arguments {
-		name, found := strings.CutPrefix(argument, "env:")
-		if !found {
-			continue
-		}
-		value, ok := os.LookupEnv(name)
-		if !ok {
-			if _, seen := seenMissing[name]; !seen {
-				missing = append(missing, name)
-				seenMissing[name] = struct{}{}
-			}
-			continue
-		}
-		arguments[index] = value
-	}
-	return arguments, missing
+	applyStepDefaults(
+		&s.Name,
+		s.ScriptPath,
+		&s.Arguments,
+		&s.Returncodes,
+		&s.Env,
+		&s.IdempotenceMode,
+	)
 }

--- a/agent/go/internal/step/regular_step_test.go
+++ b/agent/go/internal/step/regular_step_test.go
@@ -75,7 +75,7 @@ var _ = Describe("RegularStep.applyDefaults", func() {
 		Expect(s.Idempotence()).To(Equal(Auto))
 	})
 
-	It("does not change OnHost (the constructor seeds it; the schema requires it)", func() {
+	It("does not change OnHost after the constructor or Decode seeds it", func() {
 		s := RegularStep{ScriptPath: "foo.sh", OnHost: true}
 		s.applyDefaults()
 		Expect(s.OnHost).To(BeTrue())
@@ -100,7 +100,10 @@ var _ = Describe("RegularStep.Encode", func() {
 	})
 
 	It("rejects an explicitly invalid idempotence value", func() {
-		s := RegularStep{ScriptPath: "foo.sh", IdempotenceMode: "bogus"}
+		s := RegularStep{
+			ScriptPath:      "foo.sh",
+			IdempotenceMode: "bogus",
+		}
 		_, err := s.Encode()
 		Expect(err).To(MatchError(ContainSubstring("bogus is not a valid idempotence value")))
 	})
@@ -174,7 +177,11 @@ var _ = Describe("RegularStep.Run", func() {
 			WithArguments([]string{
 				"-test.run=^TestStep$", "--", "inspect", "literal", "env:NODEWRIGHT_STEP_VALUE",
 			}),
-			WithEnv(map[string]string{"NODEWRIGHT_CUSTOM": "configured"}),
+			WithEnv(map[string]string{
+				"NODEWRIGHT_CUSTOM": "configured",
+				stepRootEnv:         "configured-step-root",
+				skyhookDirEnv:       "configured-skyhook-dir",
+			}),
 		)
 
 		status, err := value.Run(context.Background(), config)
@@ -188,6 +195,42 @@ var _ = Describe("RegularStep.Run", func() {
 			skyhookDir,
 		)))
 		Expect(stderr.String()).To(Equal("step-helper-stderr\n"))
+	})
+
+	It("resolves non-host paths through the mounted host root", func() {
+		rootMount := GinkgoT().TempDir()
+		stepRoot := "/package/steps"
+		skyhookDir := "/package"
+		mountedStepRoot := filepath.Join(rootMount, "package", "steps")
+		mountedSkyhookDir := filepath.Join(rootMount, "package")
+		Expect(os.MkdirAll(mountedStepRoot, 0o755)).To(Succeed())
+		testExecutable, err := filepath.Abs(os.Args[0])
+		Expect(err).NotTo(HaveOccurred())
+		data, err := os.ReadFile(testExecutable)
+		Expect(err).NotTo(HaveOccurred())
+		executable := filepath.Join(mountedStepRoot, "step-helper")
+		Expect(os.WriteFile(executable, data, 0o700)).To(Succeed())
+		stdout := &bytes.Buffer{}
+		config, err := execution.NewConfig(
+			execution.WithRootMount(rootMount),
+			execution.WithStepRoot(stepRoot),
+			execution.WithSkyhookDir(skyhookDir),
+			execution.WithRunOutput(stdout, io.Discard),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		value := NewRegularStep(
+			filepath.Base(executable),
+			WithOnHost(false),
+			WithArguments([]string{"-test.run=^TestStep$", "--", "inspect"}),
+		)
+
+		status, err := value.Run(context.Background(), config)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(stdout.String()).To(ContainSubstring("step-root=" + mountedStepRoot))
+		Expect(stdout.String()).To(ContainSubstring("skyhook-dir=" + mountedSkyhookDir))
+		Expect(stdout.String()).To(ContainSubstring("working-directory=" + mountedSkyhookDir))
 	})
 
 	It("uses the configured accepted return codes", func() {
@@ -275,6 +318,45 @@ var _ = Describe("RegularStep.Run", func() {
 	})
 })
 
+var _ = Describe("RegularStep.WithVersions", func() {
+	It("injects versions into the execution environment", func() {
+		stepRoot, skyhookDir, executable := prepareStepTestExecutable()
+		stdout := &bytes.Buffer{}
+		configured := NewRegularStep(
+			filepath.Base(executable),
+			WithOnHost(false),
+			WithArguments([]string{"-test.run=^TestStep$", "--", "versions"}),
+		)
+
+		status, err := configured.WithVersions("previous", "current").Run(
+			context.Background(),
+			newStepRunConfig(
+				stepRoot,
+				skyhookDir,
+				execution.WithRunOutput(stdout, io.Discard),
+			),
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(stdout.String()).To(Equal("versions=previous,current\n"))
+	})
+
+	It("keeps runtime versions out of serialized configuration", func() {
+		configured := NewRegularStep("upgrade.sh", WithEnv(map[string]string{"CUSTOM": "value"}))
+
+		prepared := configured.WithVersions("1.0.0", "2.0.0").(RegularStep)
+
+		Expect(configured.versions).To(BeNil())
+		Expect(prepared.versions).NotTo(BeNil())
+		Expect(prepared.Env).To(Equal(map[string]string{"CUSTOM": "value"}))
+		dumped, err := prepared.Encode()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(dumped)).NotTo(ContainSubstring(previousVersionEnv))
+		Expect(string(dumped)).NotTo(ContainSubstring(currentVersionEnv))
+	})
+})
+
 func newStepRunConfig(stepRoot, skyhookDir string, options ...execution.Option) execution.Config {
 	options = append([]execution.Option{
 		execution.WithRootMount("/"),
@@ -336,6 +418,14 @@ func runStepTestHelper() bool {
 		time.Sleep(time.Hour)
 	case "wait":
 		time.Sleep(time.Hour)
+	case "versions":
+		_, _ = fmt.Fprintf(
+			os.Stdout,
+			"versions=%s,%s\n",
+			os.Getenv(previousVersionEnv),
+			os.Getenv(currentVersionEnv),
+		)
+		os.Exit(0)
 	default:
 		os.Exit(2)
 	}

--- a/agent/go/internal/step/shared.go
+++ b/agent/go/internal/step/shared.go
@@ -1,0 +1,302 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package step
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+	"github.com/NVIDIA/nodewright/agent/internal/hostfs"
+)
+
+type stepVersions struct {
+	previous string
+	current  string
+}
+
+type stepOptions struct {
+	name              string
+	arguments         []string
+	returncodes       []command.ExitCode
+	onHost            bool
+	idempotence       Idempotence
+	env               map[string]string
+	requiresInterrupt bool
+}
+
+// Option configures a command-backed step during construction.
+type Option func(*stepOptions)
+
+const (
+	currentVersionEnv  = "CURRENT_VERSION"
+	previousVersionEnv = "PREVIOUS_VERSION"
+	stepRootEnv        = "STEP_ROOT"
+	skyhookDirEnv      = "SKYHOOK_DIR"
+)
+
+func newStepOptions(path string, opts ...Option) stepOptions {
+	// Seed OnHost here because the later defaulting pass cannot distinguish an
+	// omitted bool from an explicit WithOnHost(false).
+	value := stepOptions{onHost: true}
+	for _, opt := range opts {
+		opt(&value)
+	}
+	applyStepDefaults(
+		&value.name,
+		path,
+		&value.arguments,
+		&value.returncodes,
+		&value.env,
+		&value.idempotence,
+	)
+	return value
+}
+
+// WithName overrides the default name, which otherwise falls back to the script path.
+func WithName(name string) Option {
+	return func(value *stepOptions) { value.name = name }
+}
+
+// WithArguments sets the step's arguments.
+func WithArguments(arguments []string) Option {
+	return func(value *stepOptions) { value.arguments = arguments }
+}
+
+// WithReturncodes sets the accepted return codes.
+func WithReturncodes(returncodes []command.ExitCode) Option {
+	return func(value *stepOptions) { value.returncodes = returncodes }
+}
+
+// WithEnv sets the environment map applied to the step process.
+func WithEnv(environment map[string]string) Option {
+	return func(value *stepOptions) { value.env = environment }
+}
+
+// WithOnHost controls whether the command runs inside the host root.
+func WithOnHost(onHost bool) Option {
+	return func(value *stepOptions) { value.onHost = onHost }
+}
+
+// WithIdempotence sets the step's idempotence mode.
+func WithIdempotence(idempotence Idempotence) Option {
+	return func(value *stepOptions) { value.idempotence = idempotence }
+}
+
+// WithRequiresInterrupt sets whether the step requires an interrupt.
+func WithRequiresInterrupt(requiresInterrupt bool) Option {
+	return func(value *stepOptions) { value.requiresInterrupt = requiresInterrupt }
+}
+
+func runStep(
+	ctx context.Context,
+	config execution.Config,
+	path string,
+	arguments []string,
+	returncodes []command.ExitCode,
+	onHost bool,
+	environment map[string]string,
+	versions *stepVersions,
+) (execution.Status, error) {
+	if ctx == nil {
+		return execution.StatusFailed, errors.New("running step: context is nil")
+	}
+	if err := ctx.Err(); err != nil {
+		return execution.StatusFailed, fmt.Errorf("running step %q: %w", path, err)
+	}
+	if err := config.Validate(); err != nil {
+		return execution.StatusFailed, fmt.Errorf("running step %q: invalid run config: %w", path, err)
+	}
+	if !filepath.IsLocal(path) {
+		return execution.StatusFailed, fmt.Errorf(
+			"running step: path %q must be relative to the step root",
+			path,
+		)
+	}
+
+	resolvedArguments, missing := resolveArguments(arguments)
+	if len(missing) > 0 {
+		return execution.StatusFailed, fmt.Errorf(
+			"running step %q: expected environment variables do not exist: %s",
+			path,
+			strings.Join(missing, ", "),
+		)
+	}
+
+	runner := command.NewRunner(command.WithChroot(config.RootMount()))
+	stepRoot := config.StepRoot()
+	skyhookDir := config.SkyhookDir()
+	if !onHost {
+		runner = command.NewRunner()
+		mountedStepRoot, err := hostfs.HostPathToMounted(config.RootMount(), stepRoot)
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"running step %q: resolving mounted step root: %w",
+				path,
+				err,
+			)
+		}
+		stepRoot = mountedStepRoot
+		mountedSkyhookDir, err := hostfs.HostPathToMounted(config.RootMount(), skyhookDir)
+		if err != nil {
+			return execution.StatusFailed, fmt.Errorf(
+				"running step %q: resolving mounted package directory: %w",
+				path,
+				err,
+			)
+		}
+		skyhookDir = mountedSkyhookDir
+	}
+
+	if environment == nil {
+		environment = map[string]string{}
+	} else {
+		environment = maps.Clone(environment)
+	}
+	if versions != nil {
+		environment[previousVersionEnv] = versions.previous
+		environment[currentVersionEnv] = versions.current
+	}
+	environment[stepRootEnv] = stepRoot
+	environment[skyhookDirEnv] = skyhookDir
+	cmd := command.NewCommand(
+		filepath.Join(stepRoot, path),
+		command.WithArguments(resolvedArguments...),
+		command.WithWorkingDirectory(skyhookDir),
+		command.WithEnvironment(environment),
+		command.WithStdout(config.Stdout()),
+		command.WithStderr(config.Stderr()),
+	)
+
+	result, err := runner.Run(ctx, cmd)
+	if err != nil {
+		return execution.StatusFailed, fmt.Errorf("running step %q command: %w", path, err)
+	}
+	if result.Signal != nil || !slices.Contains(returncodes, result.ExitCode) {
+		return execution.StatusFailed, nil
+	}
+
+	return execution.StatusSuccess, nil
+}
+
+func stepFingerprint(
+	path string,
+	arguments []string,
+	returncodes []command.ExitCode,
+	environment map[string]string,
+	onHost bool,
+) (string, error) {
+	if arguments == nil {
+		arguments = []string{}
+	}
+	if returncodes == nil {
+		returncodes = []command.ExitCode{}
+	}
+	if environment == nil {
+		environment = map[string]string{}
+	}
+	payload, err := json.Marshal(struct {
+		Path        string             `json:"path"`
+		Arguments   []string           `json:"arguments"`
+		ReturnCodes []command.ExitCode `json:"returnCodes"`
+		Env         map[string]string  `json:"env"`
+		OnHost      bool               `json:"onHost"`
+	}{
+		Path:        path,
+		Arguments:   arguments,
+		ReturnCodes: returncodes,
+		Env:         environment,
+		OnHost:      onHost,
+	})
+	if err != nil {
+		return "", fmt.Errorf("encoding step fingerprint: %w", err)
+	}
+	sum := sha256.Sum256(payload)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func encodeStep(value any, idempotence Idempotence) ([]byte, error) {
+	if err := idempotence.Validate(); err != nil {
+		return nil, fmt.Errorf("validate idempotence: %w", err)
+	}
+	out, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("marshal step: %w", err)
+	}
+	return out, nil
+}
+
+// OnHost is intentionally excluded: constructors and Decode preserve whether
+// false was explicitly selected before applying the remaining defaults.
+func applyStepDefaults(
+	name *string,
+	path string,
+	arguments *[]string,
+	returncodes *[]command.ExitCode,
+	environment *map[string]string,
+	idempotence *Idempotence,
+) {
+	if *name == "" {
+		*name = path
+	}
+	if len(*arguments) == 0 {
+		*arguments = []string{}
+	}
+	if len(*returncodes) == 0 {
+		*returncodes = []command.ExitCode{command.SuccessExitCode}
+	}
+	if *environment == nil {
+		*environment = map[string]string{}
+	}
+	if *idempotence == "" {
+		*idempotence = Auto
+	}
+}
+
+func resolveArguments(configured []string) ([]string, []string) {
+	arguments := slices.Clone(configured)
+	missing := make([]string, 0)
+	seenMissing := make(map[string]struct{})
+	for index, argument := range arguments {
+		name, found := strings.CutPrefix(argument, "env:")
+		if !found {
+			continue
+		}
+		value, ok := os.LookupEnv(name)
+		if !ok {
+			if _, seen := seenMissing[name]; !seen {
+				missing = append(missing, name)
+				seenMissing[name] = struct{}{}
+			}
+			continue
+		}
+		arguments[index] = value
+	}
+	return arguments, missing
+}

--- a/agent/go/internal/step/shared_linux_test.go
+++ b/agent/go/internal/step/shared_linux_test.go
@@ -30,8 +30,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("RegularStep.Run in a chroot", func() {
-	It("executes an on-host step inside the mounted root", func() {
+var _ = Describe("shared step execution in a chroot", func() {
+	It("executes a command inside the mounted root", func() {
 		if os.Geteuid() != 0 {
 			Fail("chroot execution requires root privileges")
 		}
@@ -55,7 +55,6 @@ var _ = Describe("RegularStep.Run in a chroot", func() {
 			"step-helper",
 			WithArguments([]string{"-test.run=^TestStep$", "--", "exit", "0"}),
 		)
-
 		status, err := value.Run(context.Background(), config)
 
 		Expect(err).NotTo(HaveOccurred())

--- a/agent/go/internal/step/shared_test.go
+++ b/agent/go/internal/step/shared_test.go
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package step
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/NVIDIA/nodewright/agent/internal/command"
+	"github.com/NVIDIA/nodewright/agent/internal/execution"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("shared step behavior", func() {
+	It("applies every construction option and the remaining defaults", func() {
+		configured := newStepOptions(
+			"step.sh",
+			WithName("custom"),
+			WithArguments([]string{"argument"}),
+			WithReturncodes([]command.ExitCode{0, 2}),
+			WithEnv(map[string]string{"KEY": "value"}),
+			WithOnHost(false),
+			WithIdempotence(Disabled),
+			WithRequiresInterrupt(true),
+		)
+
+		Expect(configured.name).To(Equal("custom"))
+		Expect(configured.arguments).To(Equal([]string{"argument"}))
+		Expect(configured.returncodes).To(Equal([]command.ExitCode{0, 2}))
+		Expect(configured.env).To(Equal(map[string]string{"KEY": "value"}))
+		Expect(configured.onHost).To(BeFalse())
+		Expect(configured.idempotence).To(Equal(Disabled))
+		Expect(configured.requiresInterrupt).To(BeTrue())
+
+		defaults := newStepOptions("step.sh")
+		Expect(defaults.name).To(Equal("step.sh"))
+		Expect(defaults.arguments).To(Equal([]string{}))
+		Expect(defaults.returncodes).To(Equal([]command.ExitCode{command.SuccessExitCode}))
+		Expect(defaults.env).To(Equal(map[string]string{}))
+		Expect(defaults.onHost).To(BeTrue())
+		Expect(defaults.idempotence).To(Equal(Auto))
+	})
+
+	It("normalizes nil and empty values when fingerprinting", func() {
+		nilFingerprint, err := stepFingerprint("step.sh", nil, nil, nil, false)
+		Expect(err).NotTo(HaveOccurred())
+
+		emptyFingerprint, err := stepFingerprint(
+			"step.sh",
+			[]string{},
+			[]command.ExitCode{},
+			map[string]string{},
+			false,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(nilFingerprint).To(Equal(emptyFingerprint))
+
+		changedFingerprint, err := stepFingerprint(
+			"other.sh",
+			[]string{},
+			[]command.ExitCode{},
+			map[string]string{},
+			false,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(changedFingerprint).NotTo(Equal(emptyFingerprint))
+	})
+
+	It("resolves environment arguments and reports each missing variable once", func() {
+		const (
+			present = "NODEWRIGHT_SHARED_STEP_PRESENT"
+			missing = "NODEWRIGHT_SHARED_STEP_MISSING"
+		)
+		GinkgoT().Setenv(present, "resolved")
+		previous, existed := os.LookupEnv(missing)
+		Expect(os.Unsetenv(missing)).To(Succeed())
+		DeferCleanup(func() {
+			if existed {
+				Expect(os.Setenv(missing, previous)).To(Succeed())
+			}
+		})
+
+		arguments, missingVariables := resolveArguments([]string{
+			"literal",
+			"env:" + present,
+			"env:" + missing,
+			"env:" + missing,
+		})
+
+		Expect(arguments).To(Equal([]string{
+			"literal",
+			"resolved",
+			"env:" + missing,
+			"env:" + missing,
+		}))
+		Expect(missingVariables).To(Equal([]string{missing}))
+	})
+
+	It("wraps JSON encoding failures", func() {
+		_, err := encodeStep(make(chan struct{}), Auto)
+		Expect(err).To(MatchError(ContainSubstring("marshal step:")))
+	})
+
+	It("allocates a nil command environment before adding runtime values", func() {
+		stepRoot, skyhookDir, executable := prepareStepTestExecutable()
+
+		status, err := runStep(
+			context.Background(),
+			newStepRunConfig(stepRoot, skyhookDir),
+			filepath.Base(executable),
+			[]string{"-test.run=^TestStep$", "--", "inspect"},
+			[]command.ExitCode{command.SuccessExitCode},
+			false,
+			nil,
+			&stepVersions{previous: "1.0.0", current: "2.0.0"},
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+	})
+})

--- a/agent/go/internal/step/step.go
+++ b/agent/go/internal/step/step.go
@@ -34,6 +34,10 @@ type Step interface {
 	// composition.
 	Run(context.Context, execution.Config) (execution.Status, error)
 
+	// WithVersions returns a copy prepared with the package versions supplied
+	// by upgrade-stage orchestration.
+	WithVersions(previous, current string) Step
+
 	// Encode serializes the step to its JSON wire form. Each concrete
 	// type owns its own discriminator bit and any invariants it
 	// enforces before marshaling.
@@ -56,12 +60,13 @@ type Step interface {
 // parsing (the exported tags + the Idempotence codec); Decode routes on the
 // discriminator and applies defaults.
 //
-// Missing JSON fields retain their Go zero values unless applyDefaults handles
-// them. Full package configs are schema-validated before they reach Decode, so
-// required fields such as on_host are present on that path.
+// Missing JSON fields receive the constructor defaults. Full package configs
+// are schema-validated before they reach Decode, but Decode also preserves the
+// default OnHost behavior for direct callers while retaining an explicit false.
 func Decode(data []byte) (Step, error) {
 	var probe struct {
-		UpgradeStep bool `json:"upgrade_step"`
+		UpgradeStep bool  `json:"upgrade_step"`
+		OnHost      *bool `json:"on_host"`
 	}
 	if err := json.Unmarshal(data, &probe); err != nil {
 		return nil, fmt.Errorf("decode step: %w", err)
@@ -72,17 +77,23 @@ func Decode(data []byte) (Step, error) {
 		if err := json.Unmarshal(data, &u); err != nil {
 			return nil, fmt.Errorf("decode upgrade step: %w", err)
 		}
-		u.RegularStep.applyDefaults()
+		if probe.OnHost == nil {
+			u.OnHost = true
+		}
+		u.applyDefaults()
 		if err := u.Validate(); err != nil {
 			return nil, fmt.Errorf("upgrade step validation failed: %w", err)
 		}
 		return u, nil
 	}
 
-	var rs RegularStep
-	if err := json.Unmarshal(data, &rs); err != nil {
+	var regular RegularStep
+	if err := json.Unmarshal(data, &regular); err != nil {
 		return nil, fmt.Errorf("decode step: %w", err)
 	}
-	rs.applyDefaults()
-	return rs, nil
+	if probe.OnHost == nil {
+		regular.OnHost = true
+	}
+	regular.applyDefaults()
+	return regular, nil
 }

--- a/agent/go/internal/step/step_test.go
+++ b/agent/go/internal/step/step_test.go
@@ -47,13 +47,13 @@ var _ = Describe("Step interface", func() {
 		Expect(s.Path()).To(Equal("foo.sh"))
 	})
 
-	It("is satisfied by UpgradeStep and promotes Path through embedding", func() {
-		var s Step = UpgradeStep{RegularStep: RegularStep{ScriptPath: "foo.sh"}}
+	It("is satisfied by UpgradeStep and exposes its path", func() {
+		var s Step = UpgradeStep{ScriptPath: "foo.sh"}
 		Expect(s.Path()).To(Equal("foo.sh"))
 	})
 
-	It("promotes RegularStep fields to UpgradeStep through embedding", func() {
-		rs := RegularStep{
+	It("exposes the shared command fields on UpgradeStep", func() {
+		u := UpgradeStep{
 			Name:            "explicit-name",
 			ScriptPath:      "foo.sh",
 			Arguments:       []string{},
@@ -62,7 +62,6 @@ var _ = Describe("Step interface", func() {
 			OnHost:          true,
 			IdempotenceMode: Auto,
 		}
-		u := UpgradeStep{RegularStep: rs}
 
 		Expect(u.Name).To(Equal("explicit-name"))
 		Expect(u.ScriptPath).To(Equal("foo.sh"))
@@ -77,7 +76,7 @@ var _ = Describe("Step interface", func() {
 	It("supports type-switching between RegularStep and UpgradeStep", func() {
 		steps := []Step{
 			RegularStep{ScriptPath: "foo.sh"},
-			UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}},
+			UpgradeStep{ScriptPath: "upgrade.sh"},
 		}
 
 		var sawRegular, sawUpgrade bool
@@ -112,11 +111,40 @@ var _ = Describe("Decode", func() {
 		Expect(rs.Idempotence()).To(Equal(Auto))
 	})
 
-	It("leaves on_host at its zero value when absent", func() {
-		data := []byte(`{"path":"foo.sh","upgrade_step":false}`)
-		s, err := Decode(data)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(s.(RegularStep).OnHost).To(BeFalse())
+	It("defaults an omitted on_host to true for both step types", func() {
+		for _, data := range [][]byte{
+			[]byte(`{"path":"foo.sh","upgrade_step":false}`),
+			[]byte(`{"path":"upgrade.sh","upgrade_step":true}`),
+		} {
+			s, err := Decode(data)
+			Expect(err).NotTo(HaveOccurred())
+			switch value := s.(type) {
+			case RegularStep:
+				Expect(value.OnHost).To(BeTrue())
+			case UpgradeStep:
+				Expect(value.OnHost).To(BeTrue())
+			default:
+				Fail("unexpected step type")
+			}
+		}
+	})
+
+	It("preserves an explicit on_host false for both step types", func() {
+		for _, data := range [][]byte{
+			[]byte(`{"path":"foo.sh","on_host":false,"upgrade_step":false}`),
+			[]byte(`{"path":"upgrade.sh","on_host":false,"upgrade_step":true}`),
+		} {
+			s, err := Decode(data)
+			Expect(err).NotTo(HaveOccurred())
+			switch value := s.(type) {
+			case RegularStep:
+				Expect(value.OnHost).To(BeFalse())
+			case UpgradeStep:
+				Expect(value.OnHost).To(BeFalse())
+			default:
+				Fail("unexpected step type")
+			}
+		}
 	})
 
 	It("decodes the legacy idempotence boolean", func() {

--- a/agent/go/internal/step/upgrade_step.go
+++ b/agent/go/internal/step/upgrade_step.go
@@ -20,68 +20,127 @@ package step
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/NVIDIA/nodewright/agent/internal/command"
 	"github.com/NVIDIA/nodewright/agent/internal/execution"
 )
 
-// UpgradeStep is a Step that runs only during the Upgrade and
-// UpgradeCheck modes.
-//
-// Invariant: UpgradeSteps may not declare arguments. Construct via
-// NewUpgradeStep or call Validate() before encoding.
+// UpgradeStep runs during the Upgrade and UpgradeCheck modes.
 type UpgradeStep struct {
-	RegularStep
+	Name              string             `json:"name"`
+	ScriptPath        string             `json:"path"`
+	Arguments         []string           `json:"arguments"`
+	Returncodes       []command.ExitCode `json:"returncodes"`
+	OnHost            bool               `json:"on_host"`
+	IdempotenceMode   Idempotence        `json:"idempotence"`
+	UpgradeStep       bool               `json:"upgrade_step"`
+	Env               map[string]string  `json:"env,omitempty"`
+	RequiresInterrupt bool               `json:"requires_interrupt,omitempty"`
+
+	versions *stepVersions
 }
 
 var _ Step = UpgradeStep{}
 
-// NewUpgradeStep constructs an UpgradeStep using the same option set
-// as NewRegularStep, sets the upgrade_step discriminator on the
-// embedded value, then checks the no-arguments invariant. Passing
-// WithArguments returns the invariant error at construction.
-func NewUpgradeStep(path string, opts ...RegularStepOption) (UpgradeStep, error) {
-	rs := NewRegularStep(path, opts...)
-	rs.UpgradeStep = true
-	u := UpgradeStep{RegularStep: rs}
-	if err := u.Validate(); err != nil {
+// NewUpgradeStep constructs an UpgradeStep with canonical defaults.
+func NewUpgradeStep(path string, opts ...Option) (UpgradeStep, error) {
+	configured := newStepOptions(path, opts...)
+	value := UpgradeStep{
+		Name:              configured.name,
+		ScriptPath:        path,
+		Arguments:         configured.arguments,
+		Returncodes:       configured.returncodes,
+		OnHost:            configured.onHost,
+		IdempotenceMode:   configured.idempotence,
+		UpgradeStep:       true,
+		Env:               configured.env,
+		RequiresInterrupt: configured.requiresInterrupt,
+	}
+	if err := value.Validate(); err != nil {
 		return UpgradeStep{}, fmt.Errorf("NewUpgradeStep: %w", err)
 	}
-	return u, nil
+	return value, nil
 }
 
-// Run validates the upgrade-step invariant before executing the embedded regular step.
-func (u UpgradeStep) Run(ctx context.Context, config execution.Config) (execution.Status, error) {
-	if err := u.Validate(); err != nil {
+// Path returns the step's script path, relative to the package root.
+func (s UpgradeStep) Path() string {
+	return s.ScriptPath
+}
+
+// Idempotence reports how the agent treats re-runs of the step.
+func (s UpgradeStep) Idempotence() Idempotence {
+	return s.IdempotenceMode
+}
+
+// WithVersions returns a copy prepared with version environment and arguments.
+func (s UpgradeStep) WithVersions(previous, current string) Step {
+	s.versions = &stepVersions{previous: previous, current: current}
+	return s
+}
+
+// Run executes the upgrade command with the previous and current versions as arguments.
+func (s UpgradeStep) Run(ctx context.Context, config execution.Config) (execution.Status, error) {
+	if err := s.Validate(); err != nil {
 		return execution.StatusFailed, fmt.Errorf("upgrade step validation failed: %w", err)
 	}
-	return u.RegularStep.Run(ctx, config)
+	if s.versions == nil {
+		return execution.StatusFailed, errors.New("running upgrade step: versions were not provided")
+	}
+	if s.versions.previous == "" {
+		return execution.StatusFailed, errors.New("running upgrade step: previous version must not be empty")
+	}
+	if s.versions.current == "" {
+		return execution.StatusFailed, errors.New("running upgrade step: current version must not be empty")
+	}
+	s.applyDefaults()
+	return runStep(
+		ctx,
+		config,
+		s.ScriptPath,
+		[]string{s.versions.previous, s.versions.current},
+		s.Returncodes,
+		s.OnHost,
+		s.Env,
+		s.versions,
+	)
 }
 
-// Validate reports whether u satisfies the UpgradeStep invariant:
-// arguments must be empty.
-func (u UpgradeStep) Validate() error {
-	if len(u.Arguments) != 0 {
+// Fingerprint returns a stable digest of the step's execution-relevant inputs.
+func (s UpgradeStep) Fingerprint() (string, error) {
+	return stepFingerprint(s.ScriptPath, s.Arguments, s.Returncodes, s.Env, s.OnHost)
+}
+
+// Validate reports whether the upgrade step has configured arguments.
+func (s UpgradeStep) Validate() error {
+	if len(s.Arguments) != 0 {
 		return fmt.Errorf(
 			"UpgradeStep %s can not have any arguments, but found: %v",
-			u.Name, u.Arguments,
+			s.Name,
+			s.Arguments,
 		)
 	}
 	return nil
 }
 
-// Encode overrides RegularStep.Encode to validate the no-arguments
-// invariant and pin the discriminator before serializing. It forces
-// upgrade_step:true on the value copy so even a directly-constructed
-// UpgradeStep{} (which never set the embedded flag) serializes as an
-// upgrade step, then delegates to the shared encode workhorse. The
-// override is required for correctness: RegularStep.Encode pins the
-// discriminator to false, so plain method promotion would emit the
-// wrong wire form.
-func (u UpgradeStep) Encode() ([]byte, error) {
-	if err := u.Validate(); err != nil {
+// Encode validates and serializes the upgrade-step wire form.
+func (s UpgradeStep) Encode() ([]byte, error) {
+	if err := s.Validate(); err != nil {
 		return nil, fmt.Errorf("upgrade step validation failed: %w", err)
 	}
-	u.UpgradeStep = true
-	return u.RegularStep.encode()
+	s.applyDefaults()
+	s.UpgradeStep = true
+	return encodeStep(s, s.IdempotenceMode)
+}
+
+func (s *UpgradeStep) applyDefaults() {
+	applyStepDefaults(
+		&s.Name,
+		s.ScriptPath,
+		&s.Arguments,
+		&s.Returncodes,
+		&s.Env,
+		&s.IdempotenceMode,
+	)
 }

--- a/agent/go/internal/step/upgrade_step_test.go
+++ b/agent/go/internal/step/upgrade_step_test.go
@@ -19,7 +19,11 @@
 package step
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/NVIDIA/nodewright/agent/internal/command"
@@ -67,16 +71,16 @@ var _ = Describe("NewUpgradeStep", func() {
 
 var _ = Describe("UpgradeStep.Validate", func() {
 	It("passes when arguments are empty", func() {
-		u := UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}}
+		u := UpgradeStep{ScriptPath: "upgrade.sh"}
 		Expect(u.Validate()).To(Succeed())
 	})
 
 	It("rejects directly-constructed values with non-empty arguments", func() {
-		u := UpgradeStep{RegularStep: RegularStep{
+		u := UpgradeStep{
 			Name:       "upgrade",
 			ScriptPath: "upgrade.sh",
 			Arguments:  []string{"x"},
-		}}
+		}
 		Expect(u.Validate()).To(MatchError(
 			"UpgradeStep upgrade can not have any arguments, but found: [x]",
 		))
@@ -85,11 +89,11 @@ var _ = Describe("UpgradeStep.Validate", func() {
 
 var _ = Describe("UpgradeStep.Run", func() {
 	It("rejects invalid arguments before running the regular step", func() {
-		u := UpgradeStep{RegularStep: RegularStep{
+		u := UpgradeStep{
 			Name:       "upgrade",
 			ScriptPath: "upgrade.sh",
 			Arguments:  []string{"x"},
-		}}
+		}
 
 		status, err := u.Run(context.Background(), execution.Config{})
 
@@ -98,11 +102,78 @@ var _ = Describe("UpgradeStep.Run", func() {
 			ContainSubstring("UpgradeStep upgrade can not have any arguments, but found: [x]"),
 		))
 	})
+
+	It("requires orchestration to provide package versions", func() {
+		u, err := NewUpgradeStep("upgrade.sh")
+		Expect(err).NotTo(HaveOccurred())
+
+		status, err := u.Run(context.Background(), execution.Config{})
+
+		Expect(status).To(Equal(execution.StatusFailed))
+		Expect(err).To(MatchError("running upgrade step: versions were not provided"))
+	})
+
+	DescribeTable(
+		"rejects empty package versions",
+		func(previous, current, message string) {
+			u, err := NewUpgradeStep("upgrade.sh")
+			Expect(err).NotTo(HaveOccurred())
+
+			status, err := u.WithVersions(previous, current).Run(
+				context.Background(),
+				execution.Config{},
+			)
+
+			Expect(status).To(Equal(execution.StatusFailed))
+			Expect(err).To(MatchError(message))
+		},
+		Entry("missing previous version", "", "current", "running upgrade step: previous version must not be empty"),
+		Entry("missing current version", "previous", "", "running upgrade step: current version must not be empty"),
+	)
+
+	It("runs package versions without treating them as configured arguments", func() {
+		stepRoot := GinkgoT().TempDir()
+		skyhookDir := GinkgoT().TempDir()
+		executable := filepath.Join(stepRoot, "upgrade.sh")
+		Expect(os.WriteFile(executable, []byte(`#!/bin/sh
+printf 'arguments=%s,%s\n' "$1" "$2"
+printf 'environment=%s,%s\n' "$PREVIOUS_VERSION" "$CURRENT_VERSION"
+`), 0o700)).To(Succeed())
+		stdout := &bytes.Buffer{}
+		u, err := NewUpgradeStep(
+			filepath.Base(executable),
+			WithOnHost(false),
+			WithEnv(map[string]string{
+				previousVersionEnv: "configured-previous",
+				currentVersionEnv:  "configured-current",
+			}),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		runnable := u.WithVersions("previous", "current")
+
+		status, err := runnable.Run(
+			context.Background(),
+			newStepRunConfig(stepRoot, skyhookDir, execution.WithRunOutput(stdout, io.Discard)),
+		)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(execution.StatusSuccess))
+		Expect(stdout.String()).To(ContainSubstring("arguments=previous,current"))
+		Expect(stdout.String()).To(ContainSubstring("environment=previous,current"))
+		Expect(u.Validate()).To(Succeed())
+		dumped, err := runnable.Encode()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(dumped)).To(ContainSubstring(`"arguments":[]`))
+		Expect(string(dumped)).To(ContainSubstring(`"CURRENT_VERSION":"configured-current"`))
+		Expect(string(dumped)).To(ContainSubstring(`"PREVIOUS_VERSION":"configured-previous"`))
+		Expect(string(dumped)).NotTo(ContainSubstring(`"CURRENT_VERSION":"current"`))
+		Expect(string(dumped)).NotTo(ContainSubstring(`"PREVIOUS_VERSION":"previous"`))
+	})
 })
 
 var _ = Describe("UpgradeStep fields", func() {
-	It("promote field access from the embedded RegularStep", func() {
-		rs := RegularStep{
+	It("exposes the shared command fields", func() {
+		u := UpgradeStep{
 			Name:            "explicit",
 			ScriptPath:      "upgrade.sh",
 			Returncodes:     []command.ExitCode{command.SuccessExitCode},
@@ -110,7 +181,6 @@ var _ = Describe("UpgradeStep fields", func() {
 			OnHost:          true,
 			IdempotenceMode: Disabled,
 		}
-		u := UpgradeStep{RegularStep: rs}
 
 		Expect(u.Name).To(Equal("explicit"))
 		Expect(u.ScriptPath).To(Equal("upgrade.sh"))
@@ -132,32 +202,35 @@ var _ = Describe("UpgradeStep.Encode", func() {
 	})
 
 	It("forces upgrade_step:true for a directly-constructed value", func() {
-		u := UpgradeStep{RegularStep: RegularStep{ScriptPath: "upgrade.sh"}}
+		u := UpgradeStep{ScriptPath: "upgrade.sh"}
 		dumped, err := u.Encode()
 		Expect(err).NotTo(HaveOccurred())
 		Expect(string(dumped)).To(ContainSubstring(`"upgrade_step":true`))
 	})
 
 	It("returns the invariant error before marshaling when arguments are set", func() {
-		u := UpgradeStep{RegularStep: RegularStep{
+		u := UpgradeStep{
 			Name:       "upgrade",
 			ScriptPath: "upgrade.sh",
 			Arguments:  []string{"x"},
-		}}
+		}
 		_, err := u.Encode()
 		Expect(err).To(MatchError(
 			ContainSubstring("UpgradeStep upgrade can not have any arguments, but found: [x]"),
 		))
 	})
 
-	// Pins the override against Go's embedding gotcha. If someone
-	// deletes UpgradeStep.Encode, embedding silently calls
-	// RegularStep.Encode; the invariant check would be skipped. This
-	// test keeps the override honest by asserting the only wire
-	// difference from a RegularStep is the upgrade_step discriminator.
 	It("produces wire bytes that differ from RegularStep only in upgrade_step", func() {
-		rs := NewRegularStep("shared.sh")
-		u, err := NewUpgradeStep("shared.sh")
+		options := []Option{
+			WithName("shared"),
+			WithReturncodes([]command.ExitCode{0, 2}),
+			WithOnHost(false),
+			WithIdempotence(Disabled),
+			WithEnv(map[string]string{"KEY": "value"}),
+			WithRequiresInterrupt(true),
+		}
+		rs := NewRegularStep("shared.sh", options...)
+		u, err := NewUpgradeStep("shared.sh", options...)
 		Expect(err).NotTo(HaveOccurred())
 
 		rsBytes, err := rs.Encode()

--- a/agent/skyhook-agent/src/skyhook_agent/schemas/v1/step-schema.json
+++ b/agent/skyhook-agent/src/skyhook_agent/schemas/v1/step-schema.json
@@ -35,7 +35,7 @@
             "type": "boolean"
         },
         "env": {
-            "description": "Environment variables to set for the step",
+            "description": "Environment variables to set for the step. STEP_ROOT and SKYHOOK_DIR are reserved for every step; PREVIOUS_VERSION and CURRENT_VERSION are also reserved for upgrade steps. Agent runtime values overwrite configured values for those keys.",
             "type": "object",
             "patternProperties": {
                 ".*": { "type": "string" }
@@ -47,6 +47,10 @@
         },
         "upgrade_step": {
             "description": "Whether the step is an upgrade step",
+            "type": "boolean"
+        },
+        "requires_interrupt": {
+            "description": "Whether completing this step requires an interrupt",
             "type": "boolean"
         }
     },
@@ -60,5 +64,3 @@
         "upgrade_step"
     ]
 }
-  
-  


### PR DESCRIPTION
## Description

Consolidates regular and upgrade steps onto one command-execution implementation while keeping their wire types and stage-specific behavior explicit.

- Extracts shared construction, defaults, execution, fingerprinting, and environment handling.
- Adds immutable version injection through the Step interface for upgrade-stage orchestration.
- Resolves non-host execution paths through the mounted host root while preserving host chroot behavior.
- Keeps configured upgrade arguments separate from runtime previous/current version values.
- Expands regular, upgrade, shared, and Linux-specific execution coverage.

Depends on #406.
Part of #219

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.