### PR TITLE
docs(operator): correct where a timed-out stage's logs actually live

### DIFF
--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -109,10 +109,12 @@ For the full commit-level log see CHANGELOG.md.
   executor is now a Job, so `kubectl logs job/<name>` works during and after a
   run and finished work is retained instead of deleted on completion.
 - **Failure logs survive the failure.** Each genuinely failing stage keeps up to
-  two full-log archive pods (its first failure and its most recent). A stage
-  killed by its own deadline additionally gets a ~16KiB log tail snapshotted into
-  the Job's `nodewright.nvidia.com/last-logs` annotation, so evidence remains
-  even after the pod's logs are garbage-collected.
+  two full-log archive pods (its first failure and its most recent), including an
+  attempt killed by its own `stageTimeout` — the deadline fails the pod in place
+  rather than deleting it, so its logs are read like any other failed attempt's.
+  An interrupt Job, which keeps a whole-stage deadline, is the case where the pod
+  *is* deleted; there the operator falls back to a best-effort ~16KiB log tail in
+  the Job's `nodewright.nvidia.com/last-logs` annotation.
 - **New per-package `stageTimeout`** bounds the wall-clock runtime of one attempt
   at each of a package's stages. A hung stage (stuck script, unpullable image,
   dead registry) is killed and retried instead of sitting `in_progress`


### PR DESCRIPTION
> [!IMPORTANT]
> **Base this work on `feature/package-as-jobs`, not `main`.**
>
> The Jobs migration (#223) is integrating on that branch. `main` does not yet execute
> packages as Jobs, so a PR opened against `main` will be missing the code this depends
> on. `feature/package-as-jobs` merges to `main` once #305 lands.
>
> That branch squash-merges, so if your branch is stacked on another PR in this epic,
> replay only your own commits when restacking:
> `git rebase --onto origin/feature/package-as-jobs <last-inherited-commit>`

Part of #223. Refs #449 — this corrects the *claim*; the underlying gap is tracked there.

## The claim that was wrong

The Jobs release notes promised:

> A stage killed by its own deadline additionally gets a ~16KiB log tail snapshotted into the Job's `nodewright.nvidia.com/last-logs` annotation

It does not. A per-attempt `stageTimeout` fails the pod **in place** rather than deleting it, so the timed-out attempt survives as an ordinary full-log archive and `snapshotFailureLogs` deliberately skips ("a genuine failed archive already holds full logs"). I wrote that sentence in #402 from the pre-#402 design, where a Job-level deadline could delete the running pod.

Manual validation found the annotation empty in every package-stage case, twice:

| Case | Build | `last-logs` |
| --- | --- | --- |
| stage timeout (`stageTimeout: 20s`, `SLEEP_LEN: 600`) | `93caf2ac` | empty — logs read from the archive pod, showing the `SIGTERM` |
| kubelet-refused attempts | `93caf2ac` | empty |
| unpullable image (`stageTimeout: 60s`) | `93caf2ac` | empty |
| stage timeout, re-run after main merged | `3e3886ea` | empty |
| unpullable image, re-run | `3e3886ea` | empty |

## What it says now

That the archive holds the logs for a timed-out attempt, and that the `last-logs` fallback belongs to the interrupt Job's whole-stage deadline — the one case where the pod really is deleted.

Deliberately **not** claiming the fallback works for package stages, because per #449 it currently cannot fire for them at all: the snapshot is gated on `FailureTarget`, which a package Job only reaches once the final attempt has already failed, at which point either a genuine archive exists (skip) or no live pod remains to read. Fixing that is #449's job; this PR just stops the release notes promising something users will not find.

Docs only — no code, no test changes.
