### PR TITLE
docs(operator): clarify that autoTaintNewNodes means never-touched, and is one-way

### DIFF
--- a/docs/runtime_required.md
+++ b/docs/runtime_required.md
@@ -80,6 +80,34 @@ When enabled, the operator automatically applies the runtime-required taint to n
 
 A node is considered "new" if it has no NodeWright annotations. This works for both initial cluster setup (day 0) and nodes joining an existing cluster (day 2+). Nodes that have already been processed by NodeWright (and had their taint removed after completion) will not be re-tainted because they retain their NodeWright annotations.
 
+### "New" means never touched, and it is one-way
+
+This is deliberately **not** "new to this NodeWright". The check is for *any* `nodewright.nvidia.com/*` annotation, so once **any** NodeWright has touched a node, auto-taint never considers it new again. Two consequences that surprise people:
+
+- **A different NodeWright does not make it new again.** If NodeWright A has run on a node, and runtime-required NodeWright B later selects that same node for the first time, B does **not** auto-taint it. The node is not new, even though B has never run there.
+- **`kubectl nodewright reset` does not make it new again.** Reset clears a NodeWright's package state so its packages re-run, but the node keeps other `nodewright.nvidia.com/*` annotations, including the node-scoped `autoTaint_<taintKey>` marker. So the packages re-run **without** the runtime-required taint being re-applied.
+
+That second point is the important one: **reset is not a way to re-gate a node.** If you need the runtime-required taint back on a node that NodeWright has already handled, do it explicitly:
+
+```bash
+# Re-apply the taint yourself, then reset:
+kubectl taint node <node> nodewright.nvidia.com=runtime-required:NoSchedule
+kubectl nodewright reset <nodewright-name> --confirm
+```
+
+Returning a node to genuinely "new" is a deliberate human action, not something the operator or the CLI does for you. It means removing the NodeWright annotations from the node yourself:
+
+```bash
+# Inspect what is keeping the node from being "new"
+kubectl get node <node> -o jsonpath='{range .metadata.annotations}{...}' \
+  | tr ',' '\n' | grep nodewright.nvidia.com
+
+# Remove them (this discards NodeWright's record of the node)
+kubectl annotate node <node> nodewright.nvidia.com/autoTaint_nodewright.nvidia.com-
+```
+
+This is intentional. Auto-taint exists to gate nodes arriving in the cluster, typically from an autoscaler; it is not a general re-gating mechanism, and it is not a substitute for pre-tainting at provisioning. If you need the gate to hold reliably across resets, reboots, and re-runs, **pre-taint at provisioning** as recommended above rather than relying on `autoTaintNewNodes`.
+
 **Exception: reboot with `REAPPLY_ON_REBOOT=true`.** When the operator is configured with `REAPPLY_ON_REBOOT=true` and a NodeWright has both `runtimeRequired: true` and `autoTaintNewNodes: true`, a node whose boot ID changes is treated as new for taint purposes. The runtime-required taint is re-applied alongside the state reset in the same atomic operation, ensuring no workloads can schedule on the rebooted node before NodeWright finishes re-applying. The taint is removed again by the normal completion path once all runtime-required NodeWrights finish on that node.
 
 ## What runtimeRequired: true will NOT do


### PR DESCRIPTION
## Summary

Docs-only. **No behavior change**, and no code change: the diff is 28 added lines in `docs/runtime_required.md`.

Supersedes the original intent of this PR. See [#457](https://github.com/NVIDIA/nodewright/issues/457) for why that turned out not to be a bug.

## What this clarifies

`docs/runtime_required.md` said:

> A node is considered "new" if it has no NodeWright annotations.

That is accurate but easy to read as *"new to this NodeWright"*. It is not. The check is for **any** `nodewright.nvidia.com/*` annotation, so once **any** NodeWright has touched a node, auto-taint never treats it as new again.

Two consequences were undocumented:

- **A different NodeWright does not make a node new again.** If NodeWright A has run on a node and runtime-required NodeWright B later selects it for the first time, B does not auto-taint it.
- **`kubectl nodewright reset` does not re-gate a node.** Reset clears package state so packages re-run, but the node keeps its other annotations, including the node-scoped `autoTaint_<taintKey>` marker. So the packages re-run **without** the runtime-required taint.

The second is the one worth writing down: reset is not a way to re-gate a node, and reading the old wording as per-NodeWright leads you to assume it is.

## What was added

- A `"New" means never touched, and it is one-way` subsection covering both consequences
- The explicit sequence for re-applying the taint when that is what you actually want (`kubectl taint` then `reset`)
- How to return a node to genuinely new, framed as a deliberate human action
- A pointer back to pre-tainting at provisioning as the reliable gate, since `autoTaintNewNodes` gates nodes *arriving* in the cluster and is not a general re-gating mechanism