### PR TITLE
fix(chart): template hardcoded skyhook-operator resource names

### DIFF
--- a/chart/RELEASE_NOTES.md
+++ b/chart/RELEASE_NOTES.md
@@ -7,6 +7,101 @@ For the full commit-level log see CHANGELOG.md.
 
 ### Breaking Changes
 
+- **In-cluster resource names are now templated off the chart name and render
+  `nodewright-*` instead of `skyhook-operator-*`** (#440). These objects are
+  renamed on upgrade:
+
+  | Before | After |
+  | --- | --- |
+  | `skyhook-operator-manager-role` / `-manager-rolebinding` | `nodewright-manager-role` / `-manager-rolebinding` |
+  | `skyhook-operator-leader-election-role` / `-rolebinding` | `nodewright-leader-election-role` / `-rolebinding` |
+  | `skyhook-operator-metrics-reader` / `-metrics-reader-rolebinding` | `nodewright-metrics-reader` / `-metrics-reader-rolebinding` |
+  | `skyhook-operator-controller-manager-metrics-service` | `nodewright-controller-manager-metrics-service` |
+  | `skyhook-operator-webhook-service` | `nodewright-webhook-service` |
+  | `skyhook-operator-validating-webhook` / `-mutating-webhook` | `nodewright-validating-webhook` / `-mutating-webhook` |
+
+  The `app.kubernetes.io/created-by` and `app.kubernetes.io/part-of` labels move
+  from `skyhook-operator` to `nodewright` for the same reason. The
+  controller-manager Deployment name and `spec.selector` are **unchanged**, so
+  the immutable-selector failure fixed in #285 does not recur; every renamed
+  object is created new and the old one removed, and none of them has an
+  immutable field that a rename would trip.
+
+  Four consequences worth planning for:
+
+  1. **This chart requires an operator built from #440 or later.** The webhook
+     Service name is now passed to the operator as `WEBHOOK_SERVICE_NAME`, and
+     the operator finds its webhook configurations by the
+     `nodewright.nvidia.com/webhook-config` label rather than by name. An older
+     operator ignores both, keeps looking for `skyhook-operator-*`, and never
+     injects a caBundle, which leaves admission failing closed. Do not pin
+     `controllerManager.manager.image.tag` to a pre-#440 operator with this chart.
+  2. **The controller-manager Deployment is deleted and recreated during the one
+     upgrade that crosses the rename.** A pre-#440 operator looks its webhook
+     configurations up by name, so renaming them makes the running pod error, stay
+     un-Ready, and hold the webhook bootstrap lease forever; the rolling update
+     then never terminates it and `helm upgrade` wedges on `Pending termination`.
+     The existing `selectorMigration` pre-upgrade hook now also detects this case
+     (the live Deployment has no `WEBHOOK_SERVICE_NAME` env var) and deletes the
+     Deployment so Helm can recreate it. This costs a short operator gap on that
+     one upgrade and is a no-op on every normal upgrade. If you run with
+     `selectorMigration.enabled: false`, do it by hand instead:
+     `kubectl -n <ns> delete deploy <fullname>-controller-manager` before upgrading.
+  3. **A brief admission gap during that same upgrade.** Helm creates the renamed
+     webhook configurations with an empty `caBundle` and the operator fills it in
+     once the new pod is running, so for roughly the length of the rollout,
+     `create`/`update` on NodeWright, Skyhook, and DeploymentPolicy resources is
+     rejected. Nothing already running is affected; retry the apply. If you cannot
+     tolerate the gap, pin the old names with `fullnameOverride: skyhook-operator`,
+     which keeps every legacy name including the webhook configurations.
+  4. **`nodewright-metrics-reader` is the one renamed object you bind to yourself.**
+     Re-point any ClusterRoleBinding at the new name; the rule is identical, so
+     nothing else changes. A binding left on the old name fails as an empty scrape
+     rather than a visible error, so make the swap when you upgrade. See
+     [docs/metrics/README.md](../docs/metrics/README.md).
+
+  Anyone who already sets `fullnameOverride` or `nameOverride` keeps their own
+  prefix on all of the above, unchanged.
+
+### Bug Fixes (continued)
+
+- **`helm rollback` no longer destroys every NodeWright.** The chart ships its CRDs
+  under `templates/` (they interpolate the conversion-webhook Service name), so Helm
+  manages them as release resources. Rolling back to a pre-rename revision dropped
+  `nodewrights.nodewright.nvidia.com` and `deploymentpolicies.nodewright.nvidia.com`
+  from the rendered manifest, and Helm deleted them — cascade-deleting every object
+  they defined. Both CRDs now carry `helm.sh/resource-policy: keep` (#464).
+
+  `keep` suppresses **deletion only**. Helm still creates and patches these CRDs on
+  install and upgrade, so schema changes apply exactly as before. Two consequences:
+
+  - `helm uninstall` now leaves the two CRDs (and therefore any surviving `NodeWright`
+    / `DeploymentPolicy` objects) in the cluster. Remove them explicitly if you want a
+    full teardown: `kubectl delete crd nodewrights.nodewright.nvidia.com
+    deploymentpolicies.nodewright.nvidia.com`.
+  - A kept CRD keeps its `meta.helm.sh/release-name` annotation. Reinstalling under the
+    **same** release name and namespace adopts it; reinstalling under a **different**
+    release name fails with `invalid ownership metadata`. Delete the CRDs first if you
+    are renaming the release.
+
+- **The webhook serving certificate is reminted when the webhook Service is
+  renamed.** `Secret/webhook-cert` is operator-owned, not chart-owned, so it
+  survives a chart upgrade. The operator only reminted on expiry or a
+  cert-on-disk mismatch, so after a Service rename it kept serving a
+  year-valid certificate whose SAN was the old DNS name and every admission
+  call failed with
+  `x509: certificate is valid for skyhook-operator-webhook-service..., not
+  nodewright-webhook-service`. The operator now also remints when the Service
+  recorded on the Secret no longer matches its configured `WEBHOOK_SERVICE_NAME`.
+
+- **The pre-delete cleanup job can actually delete the webhook configurations.**
+  The manager ClusterRole granted only `get` and `update` on them, so the job's
+  `kubectl delete ...webhookconfiguration` was silently RBAC-denied and the
+  trailing `|| true` swallowed the error. `delete` is now granted, and the job
+  sweeps the pre-rename names as well, since an orphaned webhook configuration
+  with `failurePolicy: Fail` and no operator behind it rejects every matching
+  API call cluster-wide.
+
 - **`controllerManager.manager.env.runtimeRequiredTaint` now defaults to
   `nodewright.nvidia.com=runtime-required:NoSchedule`** (was
   `skyhook.nvidia.com=runtime-required:NoSchedule`). This is a coordinated change
@@ -53,9 +148,10 @@ For the full commit-level log see CHANGELOG.md.
 
 - **The operator pod now contains only the `manager` container.** Secure metrics
   are served directly by controller-runtime on port `8443`; the separate metrics
-  proxy image, resources, values, and RBAC objects have been removed. Existing
-  Prometheus clients should continue using a bearer token authorized for the
-  `skyhook-operator-metrics-reader` ClusterRole.
+  proxy image, resources, values, and RBAC objects have been removed. Prometheus
+  clients need a bearer token authorized for the `nodewright-metrics-reader`
+  ClusterRole (renamed from `skyhook-operator-metrics-reader` in the same release,
+  see the resource-rename entry above).
 
 - **Maintenance jobs moved off `bitnami/kubectl` to `alpine/kubectl`.** The
   webhook and skyhook cleanup pre-delete hooks and the new selector-migration

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -66,6 +66,35 @@ control-plane: controller-manager
 {{- end }}
 
 {{/*
+Name of the webhook Service.
+
+Also handed to the operator as WEBHOOK_SERVICE_NAME: the operator mints the
+webhook serving certificate itself and puts this name in the SAN, so a Service
+named anything other than what the operator was told produces a cert the API
+server rejects. Truncated at 63 because a Service name is a DNS-1035 label.
+*/}}
+{{- define "chart.webhookServiceName" -}}
+{{- default (printf "%s-webhook-service" (include "chart.fullname" .)) .Values.webhook.serviceName | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Names of the webhook configurations.
+
+NOT handed to the operator: it discovers these objects by the
+nodewright.nvidia.com/webhook-config label, so their names are free to change.
+The names are still needed here because the manager ClusterRole scopes `update`
+to them by resourceNames, and the pre-delete cleanup job deletes them by name.
+Both render from these helpers, so they stay in lockstep with the objects.
+*/}}
+{{- define "chart.validatingWebhookName" -}}
+{{- printf "%s-validating-webhook" (include "chart.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "chart.mutatingWebhookName" -}}
+{{- printf "%s-mutating-webhook" (include "chart.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Create the name of the service account to use
 */}}
 {{- define "chart.serviceAccountName" -}}

--- a/chart/templates/cleanup-webhook-job.yaml
+++ b/chart/templates/cleanup-webhook-job.yaml
@@ -97,9 +97,16 @@ spec:
         - -c
         - |
           NAMESPACE="{{ .Release.Namespace }}"
-          VALIDATING_WEBHOOK_CONFIGURATION_NAME="skyhook-operator-validating-webhook"
-          MUTATING_WEBHOOK_CONFIGURATION_NAME="skyhook-operator-mutating-webhook"
           kubectl delete secret -n $NAMESPACE "{{ .Values.webhook.secretName | default "webhook-cert" }}" || true
-          kubectl delete validatingwebhookconfiguration $VALIDATING_WEBHOOK_CONFIGURATION_NAME || true
-          kubectl delete mutatingwebhookconfiguration $MUTATING_WEBHOOK_CONFIGURATION_NAME || true
+          {{- /* MIGRATION-SHIM (skyhook-operator -> nodewright resource rename, #440):
+                 the legacy names are swept too. An orphaned webhook configuration has
+                 failurePolicy: Fail with no operator left to serve it, which rejects every
+                 matching API call cluster-wide, so leaving one behind is worse than a
+                 redundant delete. Drop the legacy names once the rename window closes. */}}
+          for name in "{{ include "chart.validatingWebhookName" . }}" "skyhook-operator-validating-webhook"; do
+            kubectl delete validatingwebhookconfiguration "$name" --ignore-not-found || true
+          done
+          for name in "{{ include "chart.mutatingWebhookName" . }}" "skyhook-operator-mutating-webhook"; do
+            kubectl delete mutatingwebhookconfiguration "$name" --ignore-not-found || true
+          done
 {{- end }} 

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     app: {{ include "chart.fullname" . }}-controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
     control-plane: controller-manager
   {{- include "chart.labels" . | nindent 4 }}
 spec:
@@ -85,6 +85,14 @@ spec:
           value: {{ quote .Values.controllerManager.manager.env.logLevel }}
         - name: ENABLE_WEBHOOKS
           value: {{ quote .Values.webhook.enable }}
+        {{- /* The operator mints its own webhook serving cert, so it has to be told the
+               Service name the chart rendered: that name goes in the cert SAN, and if it
+               does not match the Service the API server dials, admission fails closed.
+               The webhook configurations themselves are found by label, not by name. */}}
+        - name: WEBHOOK_SECRET_NAME
+          value: {{ quote (.Values.webhook.secretName | default "webhook-cert") }}
+        - name: WEBHOOK_SERVICE_NAME
+          value: {{ quote (include "chart.webhookServiceName" .) }}
         - name: NAMESPACE
           value: {{ .Release.Namespace }}
         - name: IMAGE_PULL_SECRET

--- a/chart/templates/deploymentpolicy-crd.yaml
+++ b/chart/templates/deploymentpolicy-crd.yaml
@@ -13,7 +13,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: skyhook-operator-webhook-service
+          name: {{ include "chart.webhookServiceName" . }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/chart/templates/leader-election-rbac.yaml
+++ b/chart/templates/leader-election-rbac.yaml
@@ -1,12 +1,12 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: skyhook-operator-leader-election-role
+  name: {{ include "chart.fullname" . }}-leader-election-role
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -44,17 +44,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: skyhook-operator-leader-election-rolebinding
+  name: {{ include "chart.fullname" . }}-leader-election-rolebinding
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: skyhook-operator-leader-election-role
+  name: {{ include "chart.fullname" . }}-leader-election-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "chart.fullname" . }}-controller-manager

--- a/chart/templates/manager-rbac.yaml
+++ b/chart/templates/manager-rbac.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: skyhook-operator-manager-role
+  name: {{ include "chart.fullname" . }}-manager-role
   annotations:
     checkov.io/skip1: CKV_K8S_155=Operator must manage webhook configs for cert rotation
   labels:
@@ -25,11 +25,22 @@ rules:
   - mutatingwebhookconfigurations
   - validatingwebhookconfigurations
   resourceNames:
+  - {{ include "chart.validatingWebhookName" . }}
+  - {{ include "chart.mutatingWebhookName" . }}
+  {{- /* MIGRATION-SHIM (skyhook-operator -> nodewright resource rename, #440):
+         during the upgrade that crosses the rename both the pre-rename webhook
+         configurations and a not-yet-terminated old operator replica are still
+         around, and the pre-delete cleanup job deletes the legacy names as a
+         belt-and-braces. Drop these two entries once the rename window closes. */}}
   - skyhook-operator-validating-webhook
   - skyhook-operator-mutating-webhook
   verbs:
   - get
   - update
+  {{- /* delete is what the pre-delete cleanup job needs; without it that job's
+         `kubectl delete ...webhookconfiguration` was silently RBAC-denied and
+         the `|| true` swallowed the error. */}}
+  - delete
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -188,16 +199,16 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: skyhook-operator-manager-rolebinding
+  name: {{ include "chart.fullname" . }}-manager-rolebinding
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: skyhook-operator-manager-role
+  name: {{ include "chart.fullname" . }}-manager-role
 subjects:
 - kind: ServiceAccount
   name: {{ include "chart.fullname" . }}-controller-manager

--- a/chart/templates/metrics-reader-rbac.yaml
+++ b/chart/templates/metrics-reader-rbac.yaml
@@ -1,31 +1,31 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: skyhook-operator-metrics-reader
+  name: {{ include "chart.fullname" . }}-metrics-reader
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
 rules:
 - nonResourceURLs:
   - /metrics
   verbs:
   - get
----
 {{- if .Values.metrics.addServiceAccountBinding }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   labels:
   {{- include "chart.labels" . | nindent 4 }}
     app.kubernetes.io/component: metrics-reader
-    app.kubernetes.io/created-by: skyhook-operator
-  name: skyhook-operator-metrics-reader-rolebinding
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+  name: {{ include "chart.fullname" . }}-metrics-reader-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: skyhook-operator-metrics-reader
+  name: {{ include "chart.fullname" . }}-metrics-reader
 subjects:
 - kind: ServiceAccount
   name: {{ .Values.metrics.serviceAccountName }}

--- a/chart/templates/metrics-service.yaml
+++ b/chart/templates/metrics-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: skyhook-operator-controller-manager-metrics-service
+  name: {{ include "chart.fullname" . }}-controller-manager-metrics-service
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
     control-plane: controller-manager
   {{- if .Values.metricsService.annotations }}
   annotations:

--- a/chart/templates/mutating-webhook.yaml
+++ b/chart/templates/mutating-webhook.yaml
@@ -2,13 +2,18 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: skyhook-operator-mutating-webhook
+  name: {{ include "chart.mutatingWebhookName" . }}
+  labels:
+    ## The operator finds this object by this label, not by name, so renaming it
+    ## in the chart does not strand a running operator. Do not remove.
+    nodewright.nvidia.com/webhook-config: "true"
+  {{- include "chart.labels" . | nindent 4 }}
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-skyhook-nvidia-com-v1alpha1-skyhook
       port: 443
@@ -36,7 +41,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-skyhook-nvidia-com-v1alpha1-deploymentpolicy
       port: 443
@@ -64,7 +69,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-nodewright-nvidia-com-v1alpha1-nodewright
       port: 443
@@ -91,7 +96,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /mutate-nodewright-nvidia-com-v1alpha1-deploymentpolicy
       port: 443

--- a/chart/templates/nodewright-crd.yaml
+++ b/chart/templates/nodewright-crd.yaml
@@ -4,6 +4,15 @@ metadata:
   name: nodewrights.nodewright.nvidia.com
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+    ## The CRDs live in templates/ (not crds/) because they interpolate the
+    ## conversion-webhook Service name, so helm manages them as release resources
+    ## and would DELETE this one on any release operation that drops it from the
+    ## rendered manifest. `helm rollback` to a pre-rename revision does exactly
+    ## that, and the CRD delete cascades to every NodeWright object (#464).
+    ## `keep` only suppresses deletion; helm still creates and patches this CRD on
+    ## upgrade, so schema changes are unaffected. The cost is that uninstall
+    ## orphans it, which is the right trade against silent data loss.
+    "helm.sh/resource-policy": keep
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/nodewright-deploymentpolicy-crd.yaml
+++ b/chart/templates/nodewright-deploymentpolicy-crd.yaml
@@ -4,6 +4,11 @@ metadata:
   name: deploymentpolicies.nodewright.nvidia.com
   annotations:
     controller-gen.kubebuilder.io/version: v0.21.0
+    ## See nodewright-crd.yaml: helm manages these CRDs as release resources, so a
+    ## rollback to a pre-rename revision deletes them and cascade-deletes every
+    ## object they define (#464). `keep` suppresses deletion only; create and
+    ## patch on upgrade are unaffected.
+    "helm.sh/resource-policy": keep
   labels:
   {{- include "chart.labels" . | nindent 4 }}
 spec:

--- a/chart/templates/selector-migration-job.yaml
+++ b/chart/templates/selector-migration-job.yaml
@@ -137,10 +137,31 @@ spec:
           fi
           {{- end }}
 
+          {{/* MIGRATION-SHIM (skyhook-operator -> nodewright resource rename, #440).
+               An operator from before that change looks its webhook configurations up by
+               NAME. This upgrade renames them, so that running operator hard-errors on
+               "skyhook-operator-validating-webhook not found", never goes Ready, never
+               releases the webhook bootstrap lease (docs/designs/webhook-bootstrap-lease.md),
+               and therefore never gets terminated by the rolling update: helm upgrade wedges
+               on "Pending termination". The new operator finds them by label instead, so this
+               is a one-time rollover, not a recurring cost.
+
+               WEBHOOK_SERVICE_NAME is the marker: no chart before #440 set it, so its absence
+               on the live Deployment means the running operator predates label discovery.
+               Deleting the Deployment here costs a short operator gap and lets helm recreate
+               it; the alternative is a stuck release that needs a manual kubectl delete pod.
+               Drop this block once the rename window closes. */}}
+          if ! kubectl get deployment "$DEPLOY" -n "$NS" \
+               -o jsonpath='{.spec.template.spec.containers[?(@.name=="manager")].env[*].name}' \
+               2>/dev/null | tr ' ' '\n' | grep -qx 'WEBHOOK_SERVICE_NAME'; then
+            echo "live operator predates label-based webhook discovery (no WEBHOOK_SERVICE_NAME); it cannot survive the webhook rename"
+            mismatch=1
+          fi
+
           if [ "$mismatch" -eq 1 ]; then
-            echo "Deployment selector does not match desired; deleting so helm upgrade can recreate it"
+            echo "deleting Deployment $DEPLOY so helm upgrade can recreate it"
             kubectl delete deployment "$DEPLOY" -n "$NS" --ignore-not-found
           else
-            echo "Deployment selector already matches desired; nothing to do"
+            echo "Deployment selector matches desired and the live operator understands label-based webhook discovery; nothing to do"
           fi
 {{- end }}

--- a/chart/templates/serviceaccount.yaml
+++ b/chart/templates/serviceaccount.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
   annotations:
     {{- toYaml .Values.controllerManager.serviceAccount.annotations | nindent 4 }}

--- a/chart/templates/skyhook-crd.yaml
+++ b/chart/templates/skyhook-crd.yaml
@@ -13,7 +13,7 @@ spec:
     webhook:
       clientConfig:
         service:
-          name: skyhook-operator-webhook-service
+          name: {{ include "chart.webhookServiceName" . }}
           namespace: '{{ .Release.Namespace }}'
           path: /convert
       conversionReviewVersions:

--- a/chart/templates/skyhook_editor_role.yaml
+++ b/chart/templates/skyhook_editor_role.yaml
@@ -7,8 +7,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
   name: skyhook-editor-role
 rules:

--- a/chart/templates/skyhook_viewer_role.yaml
+++ b/chart/templates/skyhook_viewer_role.yaml
@@ -7,8 +7,8 @@ kind: ClusterRole
 metadata:
   labels:
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
   name: skyhook-viewer-role
 rules:

--- a/chart/templates/validating-webhook.yaml
+++ b/chart/templates/validating-webhook.yaml
@@ -2,13 +2,18 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: skyhook-operator-validating-webhook
+  name: {{ include "chart.validatingWebhookName" . }}
+  labels:
+    ## The operator finds this object by this label, not by name, so renaming it
+    ## in the chart does not strand a running operator. Do not remove.
+    nodewright.nvidia.com/webhook-config: "true"
+  {{- include "chart.labels" . | nindent 4 }}
 webhooks:
 - admissionReviewVersions:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-skyhook-nvidia-com-v1alpha1-skyhook
       port: 443
@@ -35,7 +40,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-skyhook-nvidia-com-v1alpha1-deploymentpolicy
       port: 443
@@ -63,7 +68,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-nodewright-nvidia-com-v1alpha1-nodewright
       port: 443
@@ -89,7 +94,7 @@ webhooks:
   - v1
   clientConfig:
     service:
-      name: skyhook-operator-webhook-service
+      name: {{ include "chart.webhookServiceName" . }}
       namespace: {{ .Release.Namespace }}
       path: /validate-nodewright-nvidia-com-v1alpha1-deploymentpolicy
       port: 443

--- a/chart/templates/webhook-service.yaml
+++ b/chart/templates/webhook-service.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ .Values.webhook.serviceName }}
+  name: {{ include "chart.webhookServiceName" . }}
   namespace: "{{ .Release.Namespace }}"
   labels:
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: {{ include "chart.name" . }}
+    app.kubernetes.io/part-of: {{ include "chart.name" . }}
   {{- include "chart.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.webhookService.type }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -139,8 +139,11 @@ estimatedNodeCount: 1
 webhook:
   ## secretName: name of the secret to store the webhook certificate
   secretName: webhook-cert
-  ## serviceName: name of the service to expose the webhook
-  serviceName: skyhook-operator-webhook-service
+  ## serviceName: name of the service to expose the webhook.
+  ## Empty derives it from the chart fullname (`<fullname>-webhook-service`). The
+  ## operator is handed this name as WEBHOOK_SERVICE_NAME so its self-signed
+  ## serving cert carries the matching SAN; overriding it renames both together.
+  serviceName: ""
   ## enable: "true" will enable the webhook setup in the operator controller.
   ## Default is "true" and is required for production.
   enable: true
@@ -162,11 +165,15 @@ cleanup:
   ## The job will be killed if it exceeds this time.
   jobTimeoutSeconds: 120
 
-## selectorMigration: pre-upgrade hook that repairs an immutable Deployment
-## selector left over from an older chart (e.g. the skyhook-operator ->
-## nodewright rename). It deletes the controller-manager Deployment ONLY when
-## its live selector does not match the chart's desired selector, so helm can
-## recreate it. It is a no-op on normal upgrades.
+## selectorMigration: pre-upgrade hook for the upgrade states helm cannot patch
+## in place. It deletes the controller-manager Deployment, so helm recreates it,
+## and ONLY when one of these holds:
+##   - the live Deployment's selector does not match the chart's desired selector
+##     (spec.selector is immutable, e.g. across the skyhook-operator -> nodewright
+##     chart rename), or
+##   - the live operator predates label-based webhook discovery, which would
+##     otherwise deadlock the rollout when the webhook configurations are renamed.
+## It is a no-op on normal upgrades.
 selectorMigration:
   ## enabled: When true, run the selector-migration pre-upgrade hook. Safe to
   ## leave on; disable if your GitOps tooling manages the Deployment directly.

--- a/docs/ci-test-pools.md
+++ b/docs/ci-test-pools.md
@@ -39,6 +39,13 @@ need ctlptl's local image registry to serve the operator image under test. The
 three cluster-setup steps key off a shared list, so adding another registry-needing
 suite means adding its name to that list in all three places.
 
+Both also need **full history with tags** (`fetch-depth: 0`, `fetch-tags: true`,
+already set for the whole `tests` job): each materializes a released chart with
+`git archive chart/v0.17.1` to get a pre-rename baseline — `migration` for the API
+group rename, `helm-tests`' `helm-upgrade-rename-test` for the in-cluster resource
+name rename. Both fail early with an explicit message rather than a bare git error
+when the tag is missing.
+
 ### `migration`
 
 Runs `k8s-tests/migration/run.sh`: installs the last pre-rename release

--- a/docs/designs/webhook-bootstrap-lease.md
+++ b/docs/designs/webhook-bootstrap-lease.md
@@ -95,6 +95,34 @@ the dedicated bootstrap lease: a new pod can win
 who holds the main reconcile lease. Readiness flips green, Service endpoints
 rotate, the rollout completes.
 
+### Corollary: never look the webhook configurations up by name
+
+The dedicated lease only helps when a new pod can *win* it. It cannot help when the
+old pod is alive, holding the bootstrap lease, and stuck — which is exactly what a
+name-based lookup of the webhook configurations produces the moment those objects are
+renamed:
+
+1. The chart renames `{Validating,Mutating}WebhookConfiguration`.
+2. The old pod's `WebhookController` hard-errors on `... not found`, so its readiness
+   probe never goes green.
+3. The rolling update will not terminate an un-Ready old pod, so the old pod keeps
+   renewing the bootstrap lease.
+4. The new pod stays a follower, never mints the cert, never patches the caBundle.
+   `helm upgrade` fails with `Pending termination`, and the release stays wedged.
+
+The operator therefore selects these objects by the
+`nodewright.nvidia.com/webhook-config` label (filtered to configurations whose
+`clientConfig` dials its own webhook Service, since the caBundle it injects only
+signs that Service's certificate) and patches every match, so a rename is
+invisible to it. **Do not reintroduce a name-based lookup.** The chart must keep
+applying that label.
+
+This makes *future* renames safe. It could not save the one upgrade that introduced it
+(the operator already running was the name-based one), so the chart's
+`selectorMigration` pre-upgrade hook detects a pre-label-discovery operator — the live
+Deployment has no `WEBHOOK_SERVICE_NAME` env var — and deletes the Deployment so Helm
+recreates it.
+
 ### What this does NOT fix
 
 This design **cannot** retroactively fix the v0.7.x → v0.15.x upgrade
@@ -113,6 +141,10 @@ kubectl -n "$NS" delete pod <old-pod-1> <old-pod-2>                         # fr
 kubectl -n "$NS" delete lease 3c22c1ae.nvidia.com
 
 # Verify recovery:
+# The object names below are the pre-rename ones, which is what a v0.7.x-era install has.
+# On a chart from the resource-name rename onward they are nodewright-*; select the webhook
+# configuration by label instead of by name there:
+#   kubectl get mutatingwebhookconfiguration -l nodewright.nvidia.com/webhook-config
 kubectl -n "$NS" get secret webhook-cert -w
 kubectl get mutatingwebhookconfiguration skyhook-operator-mutating-webhook \
   -o jsonpath='{.webhooks[0].clientConfig.caBundle}' | wc -c                # must be > 0

--- a/docs/metrics/README.md
+++ b/docs/metrics/README.md
@@ -114,15 +114,17 @@ See the script [metrics_test.py](../../k8s-tests/chainsaw/metrics_test.py) that 
 ```bash
 kubectl -n nodewright create serviceaccount metrics-reader
 kubectl create clusterrolebinding metrics-reader-access \
-  --clusterrole=skyhook-operator-metrics-reader \
+  --clusterrole=nodewright-metrics-reader \
   --serviceaccount=nodewright:metrics-reader
 ```
+
+This ClusterRole was named `skyhook-operator-metrics-reader` before the resource-name rename. If you created a ClusterRoleBinding against the old name, re-point it at `nodewright-metrics-reader`; the rule is identical (`get` on the `/metrics` non-resource URL), so nothing else changes. A binding left on the old name fails as an empty scrape rather than a visible error, so make the swap when you upgrade.
 
 Then port-forward the HTTPS Service and scrape it with a short-lived token. TLS verification must be skipped because controller-runtime generates an in-memory self-signed certificate for each operator pod and does not publish a stable CA:
 
 ```bash
 kubectl -n nodewright port-forward \
-  svc/skyhook-operator-controller-manager-metrics-service 8443:8443 &
+  svc/nodewright-controller-manager-metrics-service 8443:8443 &
 METRICS_TOKEN="$(kubectl -n nodewright create token metrics-reader)"
 curl --insecure --header "Authorization: Bearer ${METRICS_TOKEN}" \
   https://127.0.0.1:8443/metrics
@@ -262,7 +264,7 @@ discovery job does not send a bearer token or disable certificate verification,
 so annotations would continuously advertise a target that fails with a 401 or
 x509 error. Use the explicit `role: endpoints` job in
 [prometheus_values.yaml](prometheus_values.yaml), and bind the Prometheus
-ServiceAccount to `skyhook-operator-metrics-reader`, as shown in the local
+ServiceAccount to `nodewright-metrics-reader`, as shown in the local
 dashboard setup above. Endpoint discovery scrapes each operator pod separately;
 this preserves the leader's reconcile metrics without intermittently routing a
 single Service target to an idle standby replica.

--- a/docs/metrics/prometheus_values.yaml
+++ b/docs/metrics/prometheus_values.yaml
@@ -15,7 +15,9 @@
 # limitations under the License.
 
 # Example of scraping each authenticated HTTPS pod endpoint. The Prometheus
-# ServiceAccount must be bound to skyhook-operator-metrics-reader.
+# ServiceAccount must be bound to nodewright-metrics-reader (named
+# skyhook-operator-metrics-reader before the resource-name rename, so re-point an
+# existing binding). See docs/metrics/README.md.
 extraScrapeConfigs: |
   - job_name: 'nodewright'
     metrics_path: /metrics
@@ -29,11 +31,23 @@ extraScrapeConfigs: |
       - role: endpoints
         namespaces:
           names:
+            # New installs default to `nodewright`; installs predating that change
+            # stay in `skyhook` forever, since a namespace cannot be renamed in place.
+            - nodewright
             - skyhook
     relabel_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: keep
-        regex: skyhook-operator-controller-manager-metrics-service
+        # The metrics Service is named off the chart fullname. The alternation below
+        # covers the default (`nodewright-`) and the pre-rename name, so this example
+        # works against an operator that has not been upgraded yet.
+        # IF YOU SET fullnameOverride OR nameOverride, EDIT THIS REGEX: the Service is
+        # then `<your-override>-controller-manager-metrics-service` and this job will
+        # silently match zero targets. Confirm with:
+        #   kubectl -n <namespace> get svc -l control-plane=controller-manager
+        # e.g. for `fullnameOverride: skyhook-operator` the regex is already covered;
+        # for `fullnameOverride: acme` use `acme-controller-manager-metrics-service`.
+        regex: (nodewright|skyhook-operator)-controller-manager-metrics-service
       - source_labels: [__meta_kubernetes_endpoint_port_name]
         action: keep
         regex: metrics

--- a/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
@@ -801,3 +801,262 @@ spec:
                 containers:
                 - name: cleanup
           EXPECTED
+
+  ## ── Resource names templated off chart.fullname (#440) ──────────────
+
+  - name: resource-names-follow-fullname
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Nothing in the rendered chart may hardcode the pre-rename
+          ## `skyhook-operator-` prefix, with one intentional exception: the legacy
+          ## webhook configuration names the manager RBAC and the webhook cleanup job
+          ## still sweep during the rename window. Anything else is a name that
+          ## escaped templating.
+          helm template test-release ${CHART} -n nodewright \
+            | grep -n 'skyhook-operator' \
+            | grep -v 'skyhook-operator-validating-webhook' \
+            | grep -v 'skyhook-operator-mutating-webhook' \
+            > /tmp/leaked.txt || true
+          if [ -s /tmp/leaked.txt ]; then
+            echo "hardcoded skyhook-operator names leaked into the render:"
+            cat /tmp/leaked.txt
+            exit 1
+          fi
+
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Every renamed object, by exact rendered name. Asserted with grep rather
+          ## than `chainsaw assert` because these templates emit several resources per
+          ## file and a file-scoped assert requires every resource in the file to match
+          ## the single expectation.
+          helm template test-release ${CHART} -n nodewright \
+            | grep -E '^  name: ' | sed 's/^  name: //' | tr -d '"' | sort -u > /tmp/names.txt
+          missing=0
+          for want in \
+            nodewright-controller-manager \
+            nodewright-leader-election-role \
+            nodewright-leader-election-rolebinding \
+            nodewright-manager-role \
+            nodewright-manager-rolebinding \
+            nodewright-metrics-reader \
+            nodewright-controller-manager-metrics-service \
+            nodewright-webhook-service \
+            nodewright-validating-webhook \
+            nodewright-mutating-webhook ; do
+            if ! grep -qx "$want" /tmp/names.txt; then
+              echo "missing expected resource name: $want"
+              missing=1
+            fi
+          done
+          [ "$missing" -eq 0 ]
+
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## roleRef is immutable, so a renamed binding that still points at the old
+          ## role name would fail to apply rather than fail quietly.
+          helm template test-release ${CHART} -n nodewright \
+            -s templates/metrics-service.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: nodewright-controller-manager-metrics-service
+          EXPECTED
+
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          helm template test-release ${CHART} -n nodewright \
+            -s templates/webhook-service.yaml > /tmp/rendered.yaml
+          cat <<'EXPECTED' | ${CHAINSAW_BIN} assert \
+            --resource /tmp/rendered.yaml --file - --no-color --timeout 5s
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: nodewright-webhook-service
+          EXPECTED
+
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Both bindings must point at the renamed roles. roleRef is immutable, so a
+          ## binding left pointing at the old role name is rejected on apply.
+          rendered=$(helm template test-release ${CHART} -n nodewright \
+            -s templates/leader-election-rbac.yaml -s templates/manager-rbac.yaml)
+          echo "$rendered" | grep -A4 '^roleRef:' | grep -q 'name: nodewright-leader-election-role'
+          echo "$rendered" | grep -A4 '^roleRef:' | grep -q 'name: nodewright-manager-role'
+
+  - name: no-duplicate-resource-names-under-override
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## `fullnameOverride: skyhook-operator` is what chart/RELEASE_NOTES.md offers to
+          ## avoid the one-time admission gap, and it makes chart.fullname render the same
+          ## string the deprecated metrics-reader alias hardcodes. Two objects of the same
+          ## kind and name in one release is a silent overwrite, not an error, so assert
+          ## the rendered (kind, name) pairs are unique for the default AND the override.
+          ## Only metadata.name counts: roleRef.name and subjects[].name sit at the same
+          ## indent, so a naive `^  name:` match reports every RoleBinding as a duplicate.
+          for args in "" "--set fullnameOverride=skyhook-operator" "--set nameOverride=skyhook-operator"; do
+            dupes=$(helm template test-release ${CHART} -n nodewright $args \
+              | awk '
+                  /^kind: / { kind=$2; inmeta=0; next }
+                  /^metadata:/ { inmeta=1; next }
+                  /^[^ ]/ { inmeta=0 }
+                  inmeta && /^  name: / { gsub(/"/,"",$2); print kind"/"$2; inmeta=0 }
+                ' | sort | uniq -d)
+            if [ -n "$dupes" ]; then
+              echo "duplicate rendered resources with args '$args':"
+              echo "$dupes"
+              exit 1
+            fi
+          done
+
+  - name: metrics-reader-renders-once-under-its-new-name
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Users bind their own Prometheus ServiceAccount to this ClusterRole by name
+          ## (docs/metrics/README.md), so it is the one renamed object the chart cannot
+          ## fix up for them. Exactly one ClusterRole, under the new name.
+          rendered=$(helm template test-release ${CHART} -n nodewright \
+            -s templates/metrics-reader-rbac.yaml)
+          echo "$rendered" | grep -q 'name: nodewright-metrics-reader'
+          if echo "$rendered" | grep -q 'name: skyhook-operator-metrics-reader'; then
+            echo "the pre-rename metrics-reader name is still being rendered"
+            exit 1
+          fi
+          if [ "$(echo "$rendered" | grep -c '^kind: ClusterRole$')" -ne 1 ]; then
+            echo "expected exactly one metrics-reader ClusterRole"
+            echo "$rendered"
+            exit 1
+          fi
+
+  - name: operator-env-matches-rendered-webhook-service
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## The operator mints the webhook serving cert with WEBHOOK_SERVICE_NAME in
+          ## the SAN, so drift between this env value and the rendered Service fails
+          ## admission closed rather than erroring at startup. Asserted against the
+          ## whole render, so the Service and the env value are compared as shipped.
+          rendered=$(helm template test-release ${CHART} -n nodewright)
+          echo "$rendered" | grep -A1 'name: WEBHOOK_SERVICE_NAME' \
+            | grep -q 'value: "nodewright-webhook-service"'
+          echo "$rendered" | grep -A1 'name: WEBHOOK_SECRET_NAME' \
+            | grep -q 'value: "webhook-cert"'
+          ## and the Service the operator was told about actually exists in the render
+          echo "$rendered" | grep -q '^  name: nodewright-webhook-service$'
+
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## An override has to move the Service and the env value together, or the
+          ## cert SAN stops matching the DNS name the API server dials.
+          rendered=$(helm template test-release ${CHART} -n nodewright \
+            --set webhook.serviceName=pinned-svc)
+          echo "$rendered" | grep -A1 'name: WEBHOOK_SERVICE_NAME' \
+            | grep -q 'value: "pinned-svc"'
+          echo "$rendered" | grep -q '^  name: pinned-svc$'
+
+  - name: manager-rbac-covers-the-rendered-webhook-config-names
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## Label-based discovery removes the name coupling from the operator's LOOKUP,
+          ## but not from its RBAC: the manager ClusterRole scopes `update` by
+          ## resourceNames. A configuration the operator discovers by label but cannot
+          ## update 403s in a requeue loop, so the rendered names must always be a subset
+          ## of the rendered resourceNames. Both come from the same helpers; this asserts
+          ## they have not drifted.
+          rendered=$(helm template test-release ${CHART} -n nodewright)
+          allowed=$(helm template test-release ${CHART} -n nodewright \
+            -s templates/manager-rbac.yaml \
+            | grep -E '^  - .*-(validating|mutating)-webhook$' | sed 's/^  - //')
+          names=$(echo "$rendered" \
+            | grep -E '^  name: .*-(validating|mutating)-webhook$' | sed 's/^  name: //')
+          ## Guard the guard: an empty list would make the loop below vacuously green.
+          if [ "$(echo "$names" | grep -c .)" -ne 2 ]; then
+            echo "expected 2 rendered webhook configurations, got: $names"
+            exit 1
+          fi
+          for want in $names; do
+            if ! echo "$allowed" | grep -qx "$want"; then
+              echo "webhook configuration '$want' is not in the manager ClusterRole resourceNames:"
+              echo "$allowed"
+              exit 1
+            fi
+          done
+
+  - name: webhook-configs-carry-the-discovery-label
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        - name: CHAINSAW_BIN
+          value: ($CHAINSAW_BIN)
+        content: |
+          ## The operator selects the webhook configurations on this label instead of
+          ## by name, which is what makes renaming them survivable: a name-based
+          ## lookup turns a rename into a hard error on the running old leader, which
+          ## then never releases the webhook bootstrap lease and wedges the rollout.
+          ## Dropping this label breaks caBundle injection entirely.
+          for tpl in validating-webhook mutating-webhook; do
+            helm template test-release ${CHART} -n nodewright \
+              -s templates/${tpl}.yaml \
+              | grep -q 'nodewright.nvidia.com/webhook-config: "true"' || {
+                echo "templates/${tpl}.yaml lost the webhook-config discovery label"
+                exit 1
+              }
+          done
+
+  - name: webhook-service-name-override-threads-through
+    try:
+    - script:
+        env:
+        - name: CHART
+          value: ($CHART)
+        content: |
+          ## An override has to reach the Service, both webhook configurations,
+          ## the legacy CRD conversion clientConfigs, and the operator env in
+          ## lockstep. 1 Service + 8 webhook clientConfigs + 2 CRDs + 1 env = 12.
+          count=$(helm template test-release ${CHART} -n nodewright \
+            --set webhook.serviceName=custom-webhook-svc | grep -c 'custom-webhook-svc')
+          if [ "$count" -ne 12 ]; then
+            echo "expected 12 references to the overridden webhook service name, got $count"
+            exit 1
+          fi

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/assert-legacy-names.yaml
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/assert-legacy-names.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Baseline: the published chart really does create the pre-rename names. If
+## these ever stop existing the upgrade step below is asserting nothing, so this
+## is a guard on the test itself, not on the product.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: skyhook-operator-validating-webhook
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: skyhook-operator-mutating-webhook
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: skyhook-operator-webhook-service
+  namespace: nodewright
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: skyhook-operator-manager-role
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodewright-controller-manager
+  namespace: nodewright
+status:
+  (readyReplicas > `0`): true

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/assert-renamed.yaml
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/assert-renamed.yaml
@@ -1,0 +1,91 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nodewright-controller-manager
+  namespace: nodewright
+status:
+  (readyReplicas > `0`): true
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodewright-webhook-service
+  namespace: nodewright
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nodewright-controller-manager-metrics-service
+  namespace: nodewright
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nodewright-manager-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: nodewright-manager-rolebinding
+roleRef:
+  kind: ClusterRole
+  name: nodewright-manager-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: nodewright-leader-election-role
+  namespace: nodewright
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nodewright-leader-election-rolebinding
+  namespace: nodewright
+roleRef:
+  kind: Role
+  name: nodewright-leader-election-role
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nodewright-metrics-reader
+---
+## The operator has to find the RENAMED configurations and inject its CA into
+## them. An empty caBundle here means the operator is still looking for the old
+## names and every matching API call is being rejected.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: nodewright-validating-webhook
+(length(webhooks[?clientConfig.caBundle == null]) == `0`): true
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: nodewright-mutating-webhook
+(length(webhooks[?clientConfig.caBundle == null]) == `0`): true
+---
+## The renamed Service is what the webhook clientConfigs and the operator's cert
+## SAN must both point at.
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: nodewright-validating-webhook
+(length(webhooks[?clientConfig.service.name != 'nodewright-webhook-service']) == `0`): true

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/chainsaw-test.yaml
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# yaml-language-server: $schema=https://raw.githubusercontent.com/kyverno/chainsaw/main/.schemas/json/test-chainsaw-v1alpha1.json
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: helm-upgrade-rename
+spec:
+  ## Installs a real released chart and upgrades over it, so it owns the cluster
+  ## for its duration.
+  concurrent: false
+  timeouts:
+    assert: 300s
+    exec: 300s
+  steps:
+
+  - name: install-previous-released-chart
+    try:
+    - script:
+        content: |
+          ## The last chart released before the resource-name rename (#440). Its
+          ## in-cluster names are all `skyhook-operator-*`, which is exactly the
+          ## starting state this test exists to upgrade away from. Bump this only
+          ## when the pre-rename baseline itself needs to move; advancing it to a
+          ## post-rename chart makes the test assert nothing. Same tag the
+          ## k8s-tests/migration suite pins.
+          ./install-previous-chart.sh chart/v0.17.1
+    - assert:
+        file: assert-legacy-names.yaml
+
+  - name: upgrade-to-branch-chart
+    try:
+    - script:
+        content: |
+          ../install-helm-chart.sh nodewright
+    - assert:
+        file: assert-renamed.yaml
+
+  - name: legacy-names-are-gone
+    try:
+    - error:
+        resource:
+          apiVersion: admissionregistration.k8s.io/v1
+          kind: ValidatingWebhookConfiguration
+          metadata:
+            name: skyhook-operator-validating-webhook
+    - error:
+        resource:
+          apiVersion: admissionregistration.k8s.io/v1
+          kind: MutatingWebhookConfiguration
+          metadata:
+            name: skyhook-operator-mutating-webhook
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: skyhook-operator-manager-role
+    ## The upgrade must remove the pre-rename ClusterRole, so a binding left pointing at
+    ## it stops working outright rather than silently half-working.
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: skyhook-operator-metrics-reader
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            name: skyhook-operator-manager-rolebinding
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: Role
+          metadata:
+            name: skyhook-operator-leader-election-role
+            namespace: nodewright
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: RoleBinding
+          metadata:
+            name: skyhook-operator-leader-election-rolebinding
+            namespace: nodewright
+    - error:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: skyhook-operator-webhook-service
+            namespace: nodewright
+    - error:
+        resource:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: skyhook-operator-controller-manager-metrics-service
+            namespace: nodewright
+
+  - name: admission-works-after-upgrade
+    try:
+    - script:
+        content: |
+          ## The caBundle the operator injects has to land on the RENAMED
+          ## configurations, and the serving cert's SAN has to match the RENAMED
+          ## Service, or this apply fails with a TLS error rather than the
+          ## admission rejection the webhook is supposed to produce.
+          kubectl apply -f invalid-nodewright.yaml 2>err.txt
+          ec=$?
+          cat err.txt
+          if [ $ec -eq 0 ]; then
+            echo "ERROR: invalid CR was accepted; the validating webhook is not being reached"
+            kubectl delete nodewright upgrade-rename-reject --ignore-not-found
+            exit 1
+          fi
+          if grep -qi "x509\|tls\|certificate" err.txt; then
+            echo "ERROR: webhook failed on TLS, not validation; cert SAN does not match the renamed Service"
+            exit 1
+          fi
+          if ! grep -q "admission webhook \"validate-nodewright.nvidia.com\" denied the request" err.txt; then
+            echo "ERROR: rejected for the wrong reason"
+            exit 1
+          fi
+          echo "✓ admission reached the renamed webhook configuration"
+
+  - name: rollback-does-not-destroy-the-nodewright-crds
+    try:
+    - script:
+        content: |
+          ## #464: the CRDs live in templates/ (they interpolate the conversion-webhook
+          ## Service name), so helm manages them as release resources. Rolling back to the
+          ## pre-rename revision drops them from the rendered manifest, and without
+          ## helm.sh/resource-policy: keep helm DELETES them -- cascade-deleting every
+          ## NodeWright object. No --wait: the pre-rename operator this rolls back to
+          ## cannot reach the renamed webhook configurations, so the rollout does not
+          ## settle. Survival of the CRDs is the claim under test, not the rollout.
+          helm rollback nodewright 1 -n nodewright --timeout 2m || true
+    ## Short timeout on purpose: helm has already returned, so the CRD either survived
+    ## the rollback or it did not. The suite-wide 300s would turn a real regression into
+    ## a five-minute wait for a verdict that is already decided.
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: nodewrights.nodewright.nvidia.com
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: apiextensions.k8s.io/v1
+          kind: CustomResourceDefinition
+          metadata:
+            name: deploymentpolicies.nodewright.nvidia.com
+    - script:
+        content: |
+          ## Roll forward again so the remaining steps run against the chart under test.
+          ## The pre-upgrade hook clears the wedged pre-rename operator. #464 also saw the
+          ## first roll-forward fail on a CRD-establishment race; `keep` removes that too,
+          ## because the CRD never went away.
+          ../install-helm-chart.sh nodewright
+    - assert:
+        file: assert-renamed.yaml
+
+  - name: uninstall-leaves-nothing-behind
+    try:
+    - script:
+        content: |
+          ../uninstall-helm-chart.sh nodewright
+    - error:
+        resource:
+          apiVersion: admissionregistration.k8s.io/v1
+          kind: ValidatingWebhookConfiguration
+          metadata:
+            name: nodewright-validating-webhook
+    - error:
+        resource:
+          apiVersion: admissionregistration.k8s.io/v1
+          kind: MutatingWebhookConfiguration
+          metadata:
+            name: nodewright-mutating-webhook
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: nodewright-manager-role
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: nodewright-metrics-reader
+    - error:
+        resource:
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            name: skyhook-operator-metrics-reader
+    - error:
+        resource:
+          apiVersion: v1
+          kind: Secret
+          metadata:
+            name: webhook-cert
+            namespace: nodewright
+    finally:
+    - script:
+        content: |
+          ../uninstall-helm-chart.sh nodewright || true

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/install-previous-chart.sh
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/install-previous-chart.sh
@@ -1,0 +1,55 @@
+#!/bin/bash -xe
+
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## Installs a RELEASED chart as the baseline for the upgrade test. The point is to
+## start from in-cluster objects the current templates can no longer produce, which
+## a local render cannot reproduce.
+##
+## The chart is extracted from its git tag rather than pulled from the registry:
+## no network dependency, and the baseline is pinned by something already in the
+## repo. Same mechanism as k8s-tests/migration/lib.sh:materialize_old_chart, and
+## it needs the same thing from CI: full history with tags (actions/checkout with
+## fetch-depth: 0 and fetch-tags: true), which the tests job already sets.
+##
+## The baseline brings its own operator image (its appVersion), so the upgrade
+## exercises the real operator-and-chart rollover, not just a template diff.
+
+CHART_TAG=$1
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+if [ -n "$GITLAB_CI" ]; then
+    HELM=/workspace/bin/helm
+else
+    HELM=$(which helm)
+fi
+
+if ! git -C "$REPO_ROOT" rev-parse --verify --quiet "${CHART_TAG}^{commit}" >/dev/null; then
+    echo "tag ${CHART_TAG} is not present in this checkout; fetch tags with full history"
+    exit 1
+fi
+
+WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
+git -C "$REPO_ROOT" archive "$CHART_TAG" chart/ | tar -x -C "$WORKDIR"
+[ -f "$WORKDIR/chart/Chart.yaml" ] || { echo "no Chart.yaml after extracting $CHART_TAG"; exit 1; }
+
+${HELM} upgrade --install nodewright "$WORKDIR/chart" \
+    -n nodewright --create-namespace \
+    --set controllerManager.replicas=1 \
+    --set controllerManager.podDisruptionBudget.minAvailable=0 \
+    --wait --timeout 5m

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/invalid-nodewright.yaml
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/invalid-nodewright.yaml
@@ -14,19 +14,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
+apiVersion: nodewright.nvidia.com/v1alpha1
+kind: NodeWright
 metadata:
-  labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: nodewright
-    app.kubernetes.io/part-of: nodewright
-    app.kubernetes.io/managed-by: kustomize
-  name: metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+  name: upgrade-rename-reject
+spec:
+  packages:
+    cookies:
+      version: "3.2.3"
+      image: ghcr.io/nvidia/skyhook/agentless
+      dependsOn:
+        milkshake: "1.2.3" ## invalid dependency
+    milk:
+      ## Semver, so the ONLY thing invalid about this CR is the missing dependency
+      ## below. The test asserts the rejection reason, which a second validation
+      ## failure could pre-empt.
+      version: "1.2.0"
+      image: ghcr.io/nvidia/skyhook/agentless

--- a/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/values.yaml
+++ b/k8s-tests/chainsaw/helm/helm-upgrade-rename-test/values.yaml
@@ -14,19 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  labels:
-    app.kubernetes.io/name: clusterrole
-    app.kubernetes.io/instance: metrics-reader
-    app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: nodewright
-    app.kubernetes.io/part-of: nodewright
-    app.kubernetes.io/managed-by: kustomize
-  name: metrics-reader
-rules:
-- nonResourceURLs:
-  - /metrics
-  verbs:
-  - get
+## This upgrade has to land the locally-built operator image alongside the chart:
+## the pre-#440 operator looks its webhook configurations up by name, so it cannot
+## reach the renamed ones, while the new operator finds them by the
+## nodewright.nvidia.com/webhook-config label.
+## install-helm-chart.sh overrides the image from LOCAL_OPERATOR_IMG.
+controllerManager:
+  ## One replica keeps the post-upgrade rollout deterministic; the rename gap
+  ## this test measures is about object names, not replica count.
+  replicas: 1
+  podDisruptionBudget:
+    minAvailable: 0
+webhook:
+  enable: true

--- a/k8s-tests/chainsaw/helm/helm-webhook-test/assert-webhook.yaml
+++ b/k8s-tests/chainsaw/helm/helm-webhook-test/assert-webhook.yaml
@@ -24,7 +24,7 @@ metadata:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  name: skyhook-operator-validating-webhook
+  name: nodewright-validating-webhook
 ## Wait until the operator has injected the CA into every webhook's caBundle.
 ## The chart ships no caBundle; the operator self-manages certs and patches it
 ## in. Asserting presence here (chainsaw polls) closes the race where the test
@@ -35,5 +35,5 @@ metadata:
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: skyhook-operator-mutating-webhook
+  name: nodewright-mutating-webhook
 (length(webhooks[?clientConfig.caBundle == null]) == `0`): true

--- a/k8s-tests/chainsaw/helm/helm-webhook-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-webhook-test/chainsaw-test.yaml
@@ -232,12 +232,12 @@ spec:
         resource:
           apiVersion: admissionregistration.k8s.io/v1
           kind: ValidatingWebhookConfiguration
-          name: skyhook-operator-validating-webhook
+          name: nodewright-validating-webhook
     - error:
         resource:
           apiVersion: admissionregistration.k8s.io/v1
           kind: MutatingWebhookConfiguration
-          name: skyhook-operator-mutating-webhook
+          name: nodewright-mutating-webhook
     finally:
     - script:
         content: |

--- a/k8s-tests/chainsaw/helm/readme.md
+++ b/k8s-tests/chainsaw/helm/readme.md
@@ -1,6 +1,8 @@
 ## Helm Tests
 
-This directory holds all the tests for the nodewright operator's helm chart. Right now this mainly ensures that tolerations set in the helm chart actually work and that the operator can be deployed successfully under another deployment name than skyhook-operator.
+This directory holds all the tests for the nodewright operator's helm chart. It covers template rendering, that tolerations and node affinity set in the chart actually take effect, that the admission webhooks reject invalid resources, and that the operator deploys successfully under an overridden name.
+
+`helm-upgrade-rename-test` is the odd one out: it installs the last pre-rename chart release (extracted from its git tag, the same way `k8s-tests/migration` does) and upgrades the working tree's chart over it. It exists because in-cluster resource names can only be renamed safely once, and a local render cannot reproduce the pre-rename objects that the upgrade has to clean up. It needs the checkout to have full history with tags (`fetch-depth: 0`, `fetch-tags: true`), which the CI `tests` job already sets.
 
 ## Test Image
 

--- a/k8s-tests/chainsaw/helm/uninstall-helm-chart.sh
+++ b/k8s-tests/chainsaw/helm/uninstall-helm-chart.sh
@@ -29,3 +29,12 @@ fi
 
 ## remove operator
 ${HELM} delete $OPERATOR_NAME -n nodewright
+
+## The nodewright CRDs carry helm.sh/resource-policy: keep so a `helm rollback` cannot
+## cascade-delete every NodeWright (#464), which means `helm delete` deliberately leaves
+## them behind still stamped meta.helm.sh/release-name=$OPERATOR_NAME. Tests in this
+## directory share one namespace but install under DIFFERENT release names, so the next
+## test's install would fail with "invalid ownership metadata". Drop them here: keeping
+## them is a production guarantee, not a test-fixture one.
+kubectl delete crd nodewrights.nodewright.nvidia.com \
+    deploymentpolicies.nodewright.nvidia.com --ignore-not-found --timeout=120s

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -336,8 +336,11 @@ push-local-image: docker-build ## Tag and push the locally-built operator image 
 
 .PHONY: rollout-local
 rollout-local: push-local-image ## push locally-built operator and restart the deployment
-	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager
-	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout status deployment -l app.kubernetes.io/name=skyhook-operator,control-plane=controller-manager --timeout=60s
+	@# control-plane=controller-manager is the only label both install paths agree on:
+	@# the chart renders app.kubernetes.io/name=nodewright while the kustomize overlay
+	@# renders app.kubernetes.io/name=deployment (namePrefix renames resources, not labels).
+	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout restart deployment -l control-plane=controller-manager
+	$(KUBECTL) -n $(SKYHOOK_NAMESPACE) rollout status deployment -l control-plane=controller-manager --timeout=60s
 
 
 .PHONY: delete-kind-cluster

--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -7,6 +7,35 @@ For the full commit-level log see CHANGELOG.md.
 
 ### Other Changes
 
+- **The operator finds its webhook configurations by label, not by name.** It now
+  selects `Validating`/`MutatingWebhookConfiguration` objects carrying
+  `nodewright.nvidia.com/webhook-config` whose `clientConfig` dials its own webhook
+  Service, and injects the caBundle into every webhook of every match. Scoping on the
+  Service rather than just the label matters because the configurations are
+  cluster-scoped: the caBundle only signs that one Service's certificate, so writing it
+  into a configuration belonging to another install would break that install's admission. Previously the two names
+  were compiled-in constants, which made renaming them in the chart a hard error on
+  the running operator: it stayed un-Ready, kept the webhook bootstrap lease, and
+  wedged the rolling update (see
+  [docs/designs/webhook-bootstrap-lease.md](../docs/designs/webhook-bootstrap-lease.md)).
+  The chart applies the label; a chart that does not is unsupported. The
+  now-vestigial `webhookValidatingWebhookConfiguration` /
+  `webhookMutatingWebhookConfiguration` builders were removed with the constants,
+  since the chart has owned creation of these objects for several releases and the
+  operator only ever patched their caBundle.
+
+- **`WEBHOOK_SERVICE_NAME` and `WEBHOOK_SECRET_NAME` are now set by the chart.**
+  Both env vars already existed but nothing passed them, so the operator always fell
+  back to its built-in defaults and silently ignored `webhook.serviceName` /
+  `webhook.secretName` in `values.yaml`.
+
+- **The webhook serving certificate is reminted when the webhook Service is renamed.**
+  `Secret/webhook-cert` is operator-owned, so it survives a chart upgrade. The
+  operator reminted only on expiry or a cert-on-disk mismatch, so a renamed Service
+  left a year-valid certificate carrying the old SAN and admission failed closed with
+  `x509: certificate is valid for <old>..., not <new>`. It now also remints when the
+  Service recorded on the Secret differs from the configured `WEBHOOK_SERVICE_NAME`.
+
 - **The documented install namespace for new deployments is now `nodewright`, not
   `skyhook`.** The kustomize overlay moved from `skyhook-operator-system` to
   `nodewright-operator-system`, and the operator's `NAMESPACE` env default (used only

--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -20,12 +20,9 @@ namespace: nodewright-operator-system
 # Value of this field is prepended to the
 # names of all resources, e.g. a deployment named
 # "wordpress" becomes "alices-wordpress".
-# The kubebuilder convention is for this to match the prefix of the namespace field
-# above; it deliberately does not right now. Renaming the in-cluster resource names is
-# a separate, riskier change than renaming the namespace (see #285: the last one broke
-# `helm upgrade` on the immutable Deployment selector), so the namespace moved to
-# nodewright first and the resource names still lag.
-namePrefix: skyhook-operator-
+# Kept in sync with the Helm chart, where the same names come from
+# `chart.fullname` and render `nodewright-*` by default (#440).
+namePrefix: nodewright-
 
 # Labels to add to all resources and selectors.
 #labels:

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/name: namespace
     app.kubernetes.io/instance: system
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: system
 ---
@@ -37,8 +37,8 @@ metadata:
     app.kubernetes.io/name: deployment
     app.kubernetes.io/instance: controller-manager
     app.kubernetes.io/component: manager
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
 spec:
   selector:
@@ -95,6 +95,12 @@ spec:
             value: info
           - name: ENABLE_WEBHOOKS
             value: "true"
+          # Must match the Service the overlay renders (config/default namePrefix +
+          # config/webhook/service.yaml). The operator puts WEBHOOK_SERVICE_NAME in
+          # the SAN of the serving cert it mints, so a mismatch fails admission
+          # closed rather than erroring at startup.
+          - name: WEBHOOK_SERVICE_NAME
+            value: nodewright-webhook-service
           - name: NAMESPACE
             value: nodewright-operator-system
           - name: IMAGE_PULL_SECRET

--- a/operator/config/prometheus/monitor.yaml
+++ b/operator/config/prometheus/monitor.yaml
@@ -23,8 +23,8 @@ metadata:
     app.kubernetes.io/name: servicemonitor
     app.kubernetes.io/instance: controller-manager-metrics-monitor
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-monitor
   namespace: system

--- a/operator/config/rbac/leader_election_role.yaml
+++ b/operator/config/rbac/leader_election_role.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/name: role
     app.kubernetes.io/instance: leader-election-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-role
 rules:

--- a/operator/config/rbac/leader_election_role_binding.yaml
+++ b/operator/config/rbac/leader_election_role_binding.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: rolebinding
     app.kubernetes.io/instance: leader-election-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: leader-election-rolebinding
 roleRef:

--- a/operator/config/rbac/metrics_service.yaml
+++ b/operator/config/rbac/metrics_service.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: controller-manager-metrics-service
     app.kubernetes.io/component: metrics
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager-metrics-service
   namespace: system

--- a/operator/config/rbac/role_binding.yaml
+++ b/operator/config/rbac/role_binding.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: clusterrolebinding
     app.kubernetes.io/instance: manager-rolebinding
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: manager-rolebinding
 roleRef:

--- a/operator/config/rbac/service_account.yaml
+++ b/operator/config/rbac/service_account.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: serviceaccount
     app.kubernetes.io/instance: controller-manager-sa
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: controller-manager
   namespace: system

--- a/operator/config/rbac/skyhook_editor_role.yaml
+++ b/operator/config/rbac/skyhook_editor_role.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: skyhook-editor-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: skyhook-editor-role
 rules:

--- a/operator/config/rbac/skyhook_viewer_role.yaml
+++ b/operator/config/rbac/skyhook_viewer_role.yaml
@@ -22,8 +22,8 @@ metadata:
     app.kubernetes.io/name: clusterrole
     app.kubernetes.io/instance: skyhook-viewer-role
     app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: skyhook-viewer-role
 rules:

--- a/operator/config/samples/skyhook_v1alpha1_skyhook.yaml
+++ b/operator/config/samples/skyhook_v1alpha1_skyhook.yaml
@@ -20,9 +20,9 @@ metadata:
   labels:
     app.kubernetes.io/name: skyhook
     app.kubernetes.io/instance: skyhook-sample
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
-    app.kubernetes.io/created-by: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
   name: skyhook-sample
 spec:
   additionalTolerations:

--- a/operator/config/webhook/service.yaml
+++ b/operator/config/webhook/service.yaml
@@ -21,8 +21,8 @@ metadata:
     app.kubernetes.io/name: service
     app.kubernetes.io/instance: webhook-service
     app.kubernetes.io/component: webhook
-    app.kubernetes.io/created-by: skyhook-operator
-    app.kubernetes.io/part-of: skyhook-operator
+    app.kubernetes.io/created-by: nodewright
+    app.kubernetes.io/part-of: nodewright
     app.kubernetes.io/managed-by: kustomize
   name: webhook-service
   namespace: system

--- a/operator/internal/controller/webhook_controller.go
+++ b/operator/internal/controller/webhook_controller.go
@@ -21,6 +21,7 @@ package controller
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"reflect"
@@ -30,11 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
+	nwv1 "github.com/NVIDIA/nodewright/operator/api/nodewright/v1alpha1"
 	"github.com/NVIDIA/nodewright/operator/api/v1alpha1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
@@ -44,36 +45,54 @@ import (
 )
 
 const (
-	// Webhook configuration names
-	validatingWebhookConfigName = "skyhook-operator-validating-webhook"
-	mutatingWebhookConfigName   = "skyhook-operator-mutating-webhook"
-
 	// Webhook names
 	// MIGRATION-SHIM: the skyhook* names/rules below (and their getMutating/
-	// getValidatingWebhookRules cases + webhook*Configuration entries) manage the
-	// legacy skyhook.nvidia.com webhooks. Drop the skyhook* cases when the legacy
-	// group is removed; the nodewright webhooks are chart-owned (operator only
-	// injects their caBundle).
+	// getValidatingWebhookRules cases) manage the legacy skyhook.nvidia.com webhooks.
+	// Drop the skyhook* cases when the legacy group is removed; the nodewright webhooks
+	// are chart-owned (operator only injects their caBundle).
 	skyhookValidatingWebhookName          = "validate-skyhook.nvidia.com"
 	deploymentPolicyValidatingWebhookName = "validate-deploymentpolicy.nvidia.com"
 	skyhookMutatingWebhookName            = "mutate-skyhook.nvidia.com"
 	deploymentPolicyMutatingWebhookName   = "mutate-deploymentpolicy.nvidia.com"
 
-	// Webhook paths
-	skyhookValidatingPath          = "/validate-skyhook-nvidia-com-v1alpha1-skyhook"
-	deploymentPolicyValidatingPath = "/validate-skyhook-nvidia-com-v1alpha1-deploymentpolicy"
-	skyhookMutatingPath            = "/mutate-skyhook-nvidia-com-v1alpha1-skyhook"
-	deploymentPolicyMutatingPath   = "/mutate-skyhook-nvidia-com-v1alpha1-deploymentpolicy"
+	// webhookConfigLabelKey marks the chart-owned webhook configurations this operator
+	// injects a caBundle into. They are looked up by this label rather than by name so
+	// that renaming them in the chart does not break the operator binary: a name-based
+	// lookup turns a rename into a hard error on the running (old) leader, which then
+	// never goes Ready, never releases the bootstrap lease, and wedges the rolling
+	// update. See docs/designs/webhook-bootstrap-lease.md.
+	//
+	// This buys name-independence for the *lookup* only. The manager ClusterRole still
+	// scopes `update` to these objects by resourceNames (deliberate least privilege --
+	// see the CKV_K8S_155 skip on chart/templates/manager-rbac.yaml), so the chart must
+	// keep that list and the object names in lockstep. Both render from the same
+	// chart.{validating,mutating}WebhookName helpers, and helm-template-test asserts they
+	// agree. If they ever diverge, the symptom is a Forbidden on Update, which
+	// updateWebhookConfigurationsErr below annotates rather than leaving opaque.
+	webhookConfigLabelKey = nwv1.METADATA_PREFIX + "/webhook-config"
 
 	// Certificate management
 	certRotationThreshold    = 168 * time.Hour      // 7 days
 	certValidityDurationYear = 365 * 24 * time.Hour // 1 year
-	expirationAnnotationKey  = v1alpha1.METADATA_PREFIX + "/expiration"
+
+	// Both of these stay on the LEGACY prefix, unlike webhookConfigLabelKey above, because
+	// they are not ours to choose: webhookCert.ToSecret (cert_utils.go) has written both
+	// keys under v1alpha1.METADATA_PREFIX since cert-manager was dropped, and every
+	// webhook-cert Secret in the field already carries them. Reading under the nodewright
+	// prefix would miss on every existing Secret and leave the writer and the reader
+	// disagreeing. Move them together with ToSecret when the legacy group is removed.
+	expirationAnnotationKey = v1alpha1.METADATA_PREFIX + "/expiration"
+	serviceAnnotationKey    = v1alpha1.METADATA_PREFIX + "/service"
 )
 
 // This project used to use cert-manager to generate the webhook certificates.
 // This removes the dependency on cert-manager and simplifies the deployment.
 // This also removes the need to have a specific issuer, and just uses a self-signed cert.
+//
+// ServiceName is chart-supplied rather than a constant because the chart templates the
+// Service name off its fullname; it goes in the serving cert's SAN, so a mismatch fails
+// admission closed. The webhook configurations are deliberately absent here: they are
+// found by label (see webhookConfigLabelKey), not by a configured name.
 type WebhookControllerOptions struct { // prefix these with WEBHOOK_
 	SecretName  string `env:"WEBHOOK_SECRET_NAME, default=webhook-cert"`
 	ServiceName string `env:"WEBHOOK_SERVICE_NAME, default=skyhook-operator-webhook-service"`
@@ -113,7 +132,7 @@ func (r *WebhookController) Start(ctx context.Context) error {
 	// starts the reconcile process off
 	_, err := r.GetOrCreateWebhookCertSecret(ctx, r.opts.SecretName, r.namespace)
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if apierrors.IsAlreadyExists(err) {
 			return nil // ignore this special case, it just needs to exist
 		}
 		return err
@@ -143,14 +162,10 @@ func (r *WebhookController) SetupWithManager(mgr ctrl.Manager) error {
 		// resetting caBundle) and fixes them immediately instead of waiting for the 24h requeue.
 		Watches(&admissionregistrationv1.ValidatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.webhookConfigToSecret),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return obj.GetName() == validatingWebhookConfigName
-			}))).
+			builder.WithPredicates(predicate.NewPredicateFuncs(hasWebhookConfigLabel))).
 		Watches(&admissionregistrationv1.MutatingWebhookConfiguration{},
 			handler.EnqueueRequestsFromMapFunc(r.webhookConfigToSecret),
-			builder.WithPredicates(predicate.NewPredicateFuncs(func(obj client.Object) bool {
-				return obj.GetName() == mutatingWebhookConfigName
-			}))).
+			builder.WithPredicates(predicate.NewPredicateFuncs(hasWebhookConfigLabel))).
 		Complete(r)
 }
 
@@ -214,7 +229,7 @@ func (r *WebhookController) GetOrCreateWebhookCertSecret(ctx context.Context, se
 	secret := &corev1.Secret{}
 	err := r.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
 	if err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			// not found, create it
 			webhookCert, err := generateCert(r.opts.ServiceName, r.namespace, certValidityDurationYear)
 			if err != nil {
@@ -241,16 +256,24 @@ func (r *WebhookController) GetOrCreateWebhookCertSecret(ctx context.Context, se
 	return secret, nil
 }
 
-// CheckOrUpdateWebhookCertSecret checks if the webhook secret is going to expire in the next 7 days or if the cert on disk is different from the secret
-// if it is, it will generate a new cert and update the secret
+// CheckOrUpdateWebhookCertSecret checks if the webhook secret is going to expire in the next 7 days,
+// if the cert on disk is different from the secret, or if the cert was minted for a different Service
+// than the one currently configured. If any of those hold, it generates a new cert and updates the secret.
 func (r *WebhookController) CheckOrUpdateWebhookCertSecret(ctx context.Context, secret *corev1.Secret) (bool, error) {
 	equal, err := compareCertOnDiskToSecret(r.certDir, secret)
 	if err != nil {
-		return false, err
+		return false, fmt.Errorf("comparing cert on disk to secret %s/%s: %w", r.namespace, secret.Name, err)
 	}
 
+	// The Secret outlives the chart objects: helm does not own it, so renaming the webhook
+	// Service leaves a perfectly valid, unexpired cert whose SAN no longer matches the DNS
+	// name the API server dials, and admission fails closed with an x509 error until the
+	// cert expires (a year). Treat a missing annotation as a mismatch: it can only come from
+	// a cert minted before the annotation existed, and reminting is cheap.
+	serviceChanged := secret.Annotations[serviceAnnotationKey] != r.opts.ServiceName
+
 	// check if the secret is going to expire in the next 7 days or if the cert on disk is different from the secret
-	if !equal || secret.Annotations[expirationAnnotationKey] < time.Now().Add(certRotationThreshold).Format(time.RFC3339) {
+	if !equal || serviceChanged || secret.Annotations[expirationAnnotationKey] < time.Now().Add(certRotationThreshold).Format(time.RFC3339) {
 		// expired, generate a new cert
 		webhookCert, err := generateCert(r.opts.ServiceName, r.namespace, certValidityDurationYear)
 		if err != nil {
@@ -265,7 +288,11 @@ func (r *WebhookController) CheckOrUpdateWebhookCertSecret(ctx context.Context, 
 		secret.Data["ca.crt"] = webhookCert.CABytes
 		secret.Data["tls.crt"] = []byte(webhookCert.TLSCert)
 		secret.Data["tls.key"] = []byte(webhookCert.TLSKey)
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
+		}
 		secret.Annotations[expirationAnnotationKey] = webhookCert.Expiration.Format(time.RFC3339)
+		secret.Annotations[serviceAnnotationKey] = r.opts.ServiceName
 
 		return true, r.Update(ctx, secret)
 	}
@@ -291,70 +318,172 @@ func (r *WebhookController) CheckOrUpdateWebhookConfigurations(ctx context.Conte
 	return validatingChanged || mutatingChanged, nil
 }
 
-// updateValidatingWebhookConfiguration updates the ValidatingWebhookConfiguration with the provided CABundle
-func (r *WebhookController) updateValidatingWebhookConfiguration(ctx context.Context, caBundle []byte) (bool, error) {
-	existingValidating := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-	if err := r.Get(ctx, types.NamespacedName{Name: validatingWebhookConfigName}, existingValidating); err != nil {
-		if errors.IsNotFound(err) {
-			return false, fmt.Errorf("ValidatingWebhookConfiguration %q not found; creation is handled by the Helm chart. Ensure the chart is installed and webhooks are enabled: %w", validatingWebhookConfigName, err)
-		}
-		return false, fmt.Errorf("failed to get ValidatingWebhookConfiguration %q: %w", validatingWebhookConfigName, err)
-	}
-
-	needUpdate := false
-	for i := range existingValidating.Webhooks {
-		// Every webhook in this config points at the operator's service, so all
-		// need the CA injected. getValidatingWebhookRules returns nil for
-		// webhooks the operator does not own (e.g. the chart-defined
-		// nodewright mirror webhooks); those keep their chart rules and only
-		// have their caBundle reconciled.
-		expectedRules := r.getValidatingWebhookRules(existingValidating.Webhooks[i].Name)
-		if validatingWebhookNeedsUpdate(&existingValidating.Webhooks[i], caBundle, expectedRules) {
-			needUpdate = true
-		}
-	}
-
-	if needUpdate {
-		if err := r.Update(ctx, existingValidating); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
-
-	return false, nil
+// hasWebhookConfigLabel reports whether an object carries the chart's webhook-config marker.
+func hasWebhookConfigLabel(obj client.Object) bool {
+	_, ok := obj.GetLabels()[webhookConfigLabelKey]
+	return ok
 }
 
-// updateMutatingWebhookConfiguration updates the MutatingWebhookConfiguration with the provided CABundle
+// dialsThisOperator reports whether a single webhook's clientConfig points at the Service
+// this operator issues its serving certificate for.
+//
+// This is THE ownership rule, deliberately in one place: it decides both which
+// configurations are ours and which individual webhooks inside them we may write. Those two
+// must agree — the caBundle only signs the cert for r.opts.ServiceName, so injecting it into
+// a webhook that dials some other Service actively breaks that Service's admission rather
+// than merely being untidy. Keeping the predicate single-sourced is also why the validating
+// and mutating paths, which are otherwise near-identical, cannot drift apart on the part
+// that matters.
+func (r *WebhookController) dialsThisOperator(svc *admissionregistrationv1.ServiceReference) bool {
+	return svc != nil && svc.Name == r.opts.ServiceName && svc.Namespace == r.namespace
+}
+
+// ownedValidatingWebhookConfigurations returns the chart-owned ValidatingWebhookConfigurations
+// that point at this operator's namespace.
+func (r *WebhookController) ownedValidatingWebhookConfigurations(ctx context.Context) ([]admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+	list := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+	if err := r.List(ctx, list, client.HasLabels{webhookConfigLabelKey}); err != nil {
+		return nil, fmt.Errorf("listing ValidatingWebhookConfigurations labelled %s: %w", webhookConfigLabelKey, err)
+	}
+
+	owned := make([]admissionregistrationv1.ValidatingWebhookConfiguration, 0, len(list.Items))
+	for _, conf := range list.Items {
+		for i := range conf.Webhooks {
+			if r.dialsThisOperator(conf.Webhooks[i].ClientConfig.Service) {
+				owned = append(owned, conf)
+				break
+			}
+		}
+	}
+
+	if len(owned) == 0 {
+		return nil, fmt.Errorf("no ValidatingWebhookConfiguration labelled %s targets namespace %q; creation is handled by the Helm chart. Ensure the chart is installed and webhooks are enabled", webhookConfigLabelKey, r.namespace)
+	}
+	return owned, nil
+}
+
+// ownedMutatingWebhookConfigurations returns the chart-owned MutatingWebhookConfigurations
+// that point at this operator's namespace.
+func (r *WebhookController) ownedMutatingWebhookConfigurations(ctx context.Context) ([]admissionregistrationv1.MutatingWebhookConfiguration, error) {
+	list := &admissionregistrationv1.MutatingWebhookConfigurationList{}
+	if err := r.List(ctx, list, client.HasLabels{webhookConfigLabelKey}); err != nil {
+		return nil, fmt.Errorf("listing MutatingWebhookConfigurations labelled %s: %w", webhookConfigLabelKey, err)
+	}
+
+	owned := make([]admissionregistrationv1.MutatingWebhookConfiguration, 0, len(list.Items))
+	for _, conf := range list.Items {
+		for i := range conf.Webhooks {
+			if r.dialsThisOperator(conf.Webhooks[i].ClientConfig.Service) {
+				owned = append(owned, conf)
+				break
+			}
+		}
+	}
+
+	if len(owned) == 0 {
+		return nil, fmt.Errorf("no MutatingWebhookConfiguration labelled %s targets namespace %q; creation is handled by the Helm chart. Ensure the chart is installed and webhooks are enabled", webhookConfigLabelKey, r.namespace)
+	}
+	return owned, nil
+}
+
+// updateValidatingWebhookConfiguration updates every owned ValidatingWebhookConfiguration with the provided CABundle
+func (r *WebhookController) updateValidatingWebhookConfiguration(ctx context.Context, caBundle []byte) (bool, error) {
+	owned, err := r.ownedValidatingWebhookConfigurations(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	changed := false
+	var errs []error
+	for c := range owned {
+		existingValidating := &owned[c]
+
+		needUpdate := false
+		for i := range existingValidating.Webhooks {
+			// Ownership is per-webhook, matching how it was decided: a configuration is
+			// claimed because AT LEAST ONE webhook dials our Service, so skip any that
+			// does not. The chart points all of them at one Service and this is a no-op,
+			// but injecting a CA that does not sign a foreign Service's cert is the exact
+			// breakage dialsThisOperator exists to prevent.
+			if !r.dialsThisOperator(existingValidating.Webhooks[i].ClientConfig.Service) {
+				continue
+			}
+			// getValidatingWebhookRules returns nil for webhooks the operator does not
+			// own (e.g. the chart-defined nodewright mirror webhooks); those keep their
+			// chart rules and only have their caBundle reconciled.
+			expectedRules := r.getValidatingWebhookRules(existingValidating.Webhooks[i].Name)
+			if validatingWebhookNeedsUpdate(&existingValidating.Webhooks[i], caBundle, expectedRules) {
+				needUpdate = true
+			}
+		}
+
+		if needUpdate {
+			// Keep going rather than returning: during a rename window two owned
+			// configurations legitimately coexist, and bailing on the first would
+			// silently defer the second to a later requeue with no admission in
+			// between. Errors are joined so every failure still reaches the queue.
+			if err := r.Update(ctx, existingValidating); err != nil {
+				errs = append(errs, updateWebhookConfigurationsErr("ValidatingWebhookConfiguration", existingValidating.Name, err))
+				continue
+			}
+			changed = true
+		}
+	}
+
+	return changed, errors.Join(errs...)
+}
+
+// updateMutatingWebhookConfiguration updates every owned MutatingWebhookConfiguration with the provided CABundle
 func (r *WebhookController) updateMutatingWebhookConfiguration(ctx context.Context, caBundle []byte) (bool, error) {
-	existingMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
-	if err := r.Get(ctx, types.NamespacedName{Name: mutatingWebhookConfigName}, existingMutating); err != nil {
-		if errors.IsNotFound(err) {
-			return false, fmt.Errorf("MutatingWebhookConfiguration %q not found; creation is handled by the Helm chart. Ensure the chart is installed and webhooks are enabled: %w", mutatingWebhookConfigName, err)
-		}
-		return false, fmt.Errorf("failed to get MutatingWebhookConfiguration %q: %w", mutatingWebhookConfigName, err)
+	owned, err := r.ownedMutatingWebhookConfigurations(ctx)
+	if err != nil {
+		return false, err
 	}
 
-	needUpdate := false
-	for i := range existingMutating.Webhooks {
-		// Every webhook in this config points at the operator's service, so all
-		// need the CA injected. getMutatingWebhookRules returns nil for webhooks
-		// the operator does not own (e.g. the chart-defined nodewright mirror
-		// webhooks); those keep their chart rules and only have their caBundle
-		// reconciled.
-		expectedRules := r.getMutatingWebhookRules(existingMutating.Webhooks[i].Name)
-		if mutatingWebhookNeedsUpdate(&existingMutating.Webhooks[i], caBundle, expectedRules) {
-			needUpdate = true
+	changed := false
+	var errs []error
+	for c := range owned {
+		existingMutating := &owned[c]
+
+		needUpdate := false
+		for i := range existingMutating.Webhooks {
+			// See updateValidatingWebhookConfiguration: skip webhooks that dial a
+			// different Service than the one this operator's caBundle signs for.
+			if !r.dialsThisOperator(existingMutating.Webhooks[i].ClientConfig.Service) {
+				continue
+			}
+			// getMutatingWebhookRules returns nil for webhooks the operator does not own
+			// (e.g. the chart-defined nodewright mirror webhooks); those keep their chart
+			// rules and only have their caBundle reconciled.
+			expectedRules := r.getMutatingWebhookRules(existingMutating.Webhooks[i].Name)
+			if mutatingWebhookNeedsUpdate(&existingMutating.Webhooks[i], caBundle, expectedRules) {
+				needUpdate = true
+			}
+		}
+
+		if needUpdate {
+			// See updateValidatingWebhookConfiguration: continue rather than return so a
+			// failure on one owned configuration does not defer the others.
+			if err := r.Update(ctx, existingMutating); err != nil {
+				errs = append(errs, updateWebhookConfigurationsErr("MutatingWebhookConfiguration", existingMutating.Name, err))
+				continue
+			}
+			changed = true
 		}
 	}
 
-	if needUpdate {
-		if err := r.Update(ctx, existingMutating); err != nil {
-			return false, err
-		}
-		return true, nil
-	}
+	return changed, errors.Join(errs...)
+}
 
-	return false, nil
+// updateWebhookConfigurationsErr annotates a failed caBundle write. A Forbidden here is
+// almost always the one coupling label-based discovery does not remove: the operator finds
+// a configuration by label that the manager ClusterRole's resourceNames does not cover, so
+// say that outright instead of surfacing a bare RBAC error in a requeue loop.
+func updateWebhookConfigurationsErr(kind, name string, err error) error {
+	if apierrors.IsForbidden(err) {
+		return fmt.Errorf("updating %s %s: not permitted; the manager ClusterRole scopes update by resourceNames and %q is not in that list, so the chart's webhook configuration names and its RBAC have drifted: %w", kind, name, name, err)
+	}
+	return fmt.Errorf("updating %s %s: %w", kind, name, err)
 }
 
 // getValidatingWebhookRules returns the expected rules for a validating webhook by name
@@ -381,64 +510,6 @@ func (r *WebhookController) getMutatingWebhookRules(webhookName string) []admiss
 	}
 }
 
-// webhookValidatingWebhookConfiguration returns a new validating webhook configuration.
-func webhookValidatingWebhookConfiguration(namespace, serviceName string, secret *corev1.Secret) *admissionregistrationv1.ValidatingWebhookConfiguration {
-	conf := admissionregistrationv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: validatingWebhookConfigName,
-		},
-		Webhooks: []admissionregistrationv1.ValidatingWebhook{
-			{
-				Name:                    skyhookValidatingWebhookName,
-				ClientConfig:            webhookClient(serviceName, namespace, skyhookValidatingPath, secret),
-				FailurePolicy:           ptr(admissionregistrationv1.Fail),
-				Rules:                   skyhookRules(),
-				SideEffects:             ptr(admissionregistrationv1.SideEffectClassNone),
-				AdmissionReviewVersions: []string{"v1"},
-			},
-			{
-				Name:                    deploymentPolicyValidatingWebhookName,
-				ClientConfig:            webhookClient(serviceName, namespace, deploymentPolicyValidatingPath, secret),
-				FailurePolicy:           ptr(admissionregistrationv1.Fail),
-				Rules:                   deploymentPolicyValidatingRules(),
-				SideEffects:             ptr(admissionregistrationv1.SideEffectClassNone),
-				AdmissionReviewVersions: []string{"v1"},
-			},
-		},
-	}
-
-	return &conf
-}
-
-// webhookMutatingWebhookConfiguration returns a new mutating webhook configuration.
-func webhookMutatingWebhookConfiguration(namespace, serviceName string, secret *corev1.Secret) *admissionregistrationv1.MutatingWebhookConfiguration {
-	conf := admissionregistrationv1.MutatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: mutatingWebhookConfigName,
-		},
-		Webhooks: []admissionregistrationv1.MutatingWebhook{
-			{
-				Name:                    skyhookMutatingWebhookName,
-				ClientConfig:            webhookClient(serviceName, namespace, skyhookMutatingPath, secret),
-				FailurePolicy:           ptr(admissionregistrationv1.Fail),
-				Rules:                   skyhookRules(),
-				SideEffects:             ptr(admissionregistrationv1.SideEffectClassNone),
-				AdmissionReviewVersions: []string{"v1"},
-			},
-			{
-				Name:                    deploymentPolicyMutatingWebhookName,
-				ClientConfig:            webhookClient(serviceName, namespace, deploymentPolicyMutatingPath, secret),
-				FailurePolicy:           ptr(admissionregistrationv1.Fail),
-				Rules:                   deploymentPolicyMutatingRules(),
-				SideEffects:             ptr(admissionregistrationv1.SideEffectClassNone),
-				AdmissionReviewVersions: []string{"v1"},
-			},
-		},
-	}
-
-	return &conf
-}
-
 func compareMutatingWebhookConfigurations(a, b *admissionregistrationv1.MutatingWebhookConfiguration) bool {
 	if len(a.Webhooks) != len(b.Webhooks) {
 		return true
@@ -461,17 +532,6 @@ func compareValidatingWebhookConfigurations(a, b *admissionregistrationv1.Valida
 		}
 	}
 	return false
-}
-
-func webhookClient(serviceName, namespace, path string, secret *corev1.Secret) admissionregistrationv1.WebhookClientConfig {
-	return admissionregistrationv1.WebhookClientConfig{
-		Service: &admissionregistrationv1.ServiceReference{
-			Name:      serviceName,
-			Namespace: namespace,
-			Path:      ptr(path),
-		},
-		CABundle: secret.Data["ca.crt"],
-	}
 }
 
 func skyhookRules() []admissionregistrationv1.RuleWithOperations {
@@ -555,9 +615,17 @@ func mutatingWebhookNeedsUpdate(webhook *admissionregistrationv1.MutatingWebhook
 // WebhookSecretReadyzCheck is a readyz check for the webhook secret, if it does not exist, it will return an error
 // if it exists, it will wait for the secret to be ready, this makes sure that we don't start the operator
 // if the webhook secret is not ready
-func (r *WebhookController) WebhookSecretReadyzCheck(_ *http.Request) error {
+func (r *WebhookController) WebhookSecretReadyzCheck(req *http.Request) error {
+	// Inherit the probe's deadline so these reads are cancelled when kubelet gives up on
+	// the request, rather than outliving it. controller-runtime always passes a request
+	// here; the nil guard is for direct calls in tests.
+	ctx := context.Background()
+	if req != nil {
+		ctx = req.Context()
+	}
+
 	secret := &corev1.Secret{}
-	err := r.Client.Get(context.Background(), types.NamespacedName{
+	err := r.Client.Get(ctx, types.NamespacedName{
 		Name:      r.opts.SecretName,
 		Namespace: r.namespace,
 	}, secret)
@@ -575,32 +643,42 @@ func (r *WebhookController) WebhookSecretReadyzCheck(_ *http.Request) error {
 		return fmt.Errorf("webhook secret is not ready")
 	}
 
-	// check for the webhook configurations
-	validatingWebhookName := webhookValidatingWebhookConfiguration(r.namespace, r.opts.ServiceName, secret).GetName()
-	validatingWebhookConfiguration := &admissionregistrationv1.ValidatingWebhookConfiguration{}
-	err = r.Get(context.Background(), types.NamespacedName{Name: validatingWebhookName}, validatingWebhookConfiguration)
+	// Check EVERY webhook, not just the first. The update path injects the caBundle into
+	// all of them, and each is dialled independently by the API server, so a stale bundle
+	// on webhook[1] fails those admission requests while a first-entry-only check reports
+	// the pod ready.
+	validating, err := r.ownedValidatingWebhookConfigurations(ctx)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return fmt.Errorf("ValidatingWebhookConfiguration %q not found. Either disable webhooks (not recommended) or reinstall the operator via the Helm chart to provision webhooks", validatingWebhookName)
-		}
 		return err
 	}
-
-	if !bytes.Equal(validatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle, secret.Data["ca.crt"]) {
-		return fmt.Errorf("webhook secret is not ready, ca bundle is not equal to the validating webhook configuration")
+	for i := range validating {
+		for j := range validating[i].Webhooks {
+			// Same per-webhook ownership rule the update path uses: readiness must not
+			// gate on a webhook this operator deliberately does not write.
+			if !r.dialsThisOperator(validating[i].Webhooks[j].ClientConfig.Service) {
+				continue
+			}
+			if !bytes.Equal(validating[i].Webhooks[j].ClientConfig.CABundle, secret.Data["ca.crt"]) {
+				return fmt.Errorf("webhook secret is not ready, ca bundle is not equal to webhook %s of ValidatingWebhookConfiguration %s",
+					validating[i].Webhooks[j].Name, validating[i].Name)
+			}
+		}
 	}
 
-	mutatingWebhookConfiguration := webhookMutatingWebhookConfiguration(r.namespace, r.opts.ServiceName, secret)
-	err = r.Get(context.Background(), types.NamespacedName{Name: mutatingWebhookConfiguration.Name}, mutatingWebhookConfiguration)
+	mutating, err := r.ownedMutatingWebhookConfigurations(ctx)
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return fmt.Errorf("MutatingWebhookConfiguration %q not found. Either disable webhooks (not recommended) or reinstall the operator via the Helm chart to provision webhooks", mutatingWebhookConfiguration.Name)
-		}
 		return err
 	}
-
-	if !bytes.Equal(mutatingWebhookConfiguration.Webhooks[0].ClientConfig.CABundle, secret.Data["ca.crt"]) {
-		return fmt.Errorf("webhook secret is not ready, ca bundle is not equal to the mutating webhook configuration")
+	for i := range mutating {
+		for j := range mutating[i].Webhooks {
+			if !r.dialsThisOperator(mutating[i].Webhooks[j].ClientConfig.Service) {
+				continue
+			}
+			if !bytes.Equal(mutating[i].Webhooks[j].ClientConfig.CABundle, secret.Data["ca.crt"]) {
+				return fmt.Errorf("webhook secret is not ready, ca bundle is not equal to webhook %s of MutatingWebhookConfiguration %s",
+					mutating[i].Webhooks[j].Name, mutating[i].Name)
+			}
+		}
 	}
 
 	return nil

--- a/operator/internal/controller/webhook_controller_test.go
+++ b/operator/internal/controller/webhook_controller_test.go
@@ -20,6 +20,8 @@ package controller
 
 import (
 	"context"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -30,17 +32,22 @@ import (
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("WebhookController", Ordered, func() {
 	var (
-		secretName  string
-		namespace   string
-		serviceName string
-		tmpDir      string
-		cachedCert  *webhookCert
+		secretName           string
+		namespace            string
+		serviceName          string
+		validatingConfigName string
+		mutatingConfigName   string
+		tmpDir               string
+		cachedCert           *webhookCert
 	)
 
 	BeforeAll(func() {
@@ -62,6 +69,8 @@ var _ = Describe("WebhookController", Ordered, func() {
 		secretName = "test-webhook-secret"
 		namespace = "test-namespace"
 		serviceName = "test-service"
+		validatingConfigName = "test-validating-webhook"
+		mutatingConfigName = "test-mutating-webhook"
 	})
 
 	Describe("generateCert", func() {
@@ -101,31 +110,143 @@ var _ = Describe("WebhookController", Ordered, func() {
 		})
 	})
 
-	Describe("webhookValidatingWebhookConfiguration", func() {
-		It("should create a ValidatingWebhookConfiguration with the correct CABundle", func() {
-			secret := &corev1.Secret{
-				Data: map[string][]byte{
-					"ca.crt": cachedCert.CABytes,
-				},
-			}
-			conf := webhookValidatingWebhookConfiguration(namespace, serviceName, secret)
-			Expect(conf).ToNot(BeNil())
-			Expect(conf.Webhooks).ToNot(BeEmpty())
-			Expect(conf.Webhooks[0].ClientConfig.CABundle).To(Equal(cachedCert.CABytes))
-		})
-	})
+	Describe("owned webhook configuration discovery", func() {
+		var controller *WebhookController
 
-	Describe("webhookMutatingWebhookConfiguration", func() {
-		It("should create a MutatingWebhookConfiguration with the correct CABundle", func() {
-			secret := &corev1.Secret{
-				Data: map[string][]byte{
-					"ca.crt": cachedCert.CABytes,
+		BeforeEach(func() {
+			controller = &WebhookController{namespace: namespace, opts: WebhookControllerOptions{SecretName: secretName, ServiceName: serviceName}}
+		})
+
+		It("finds configurations by label regardless of their name", func() {
+			controller.Client = fake.NewClientBuilder().WithObjects(
+				validatingWebhookConfig("any-name-at-all", namespace, serviceName, nil),
+				mutatingWebhookConfig("some-other-name", namespace, serviceName, nil),
+			).Build()
+
+			validating, err := controller.ownedValidatingWebhookConfigurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validating).To(HaveLen(1))
+			Expect(validating[0].Name).To(Equal("any-name-at-all"))
+
+			mutating, err := controller.ownedMutatingWebhookConfigurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mutating).To(HaveLen(1))
+			Expect(mutating[0].Name).To(Equal("some-other-name"))
+		})
+
+		It("ignores configurations that target another namespace", func() {
+			// The webhook configurations are cluster-scoped, so a second install elsewhere
+			// matches the same label; without the namespace filter the two operators would
+			// overwrite each other's caBundle.
+			controller.Client = fake.NewClientBuilder().WithObjects(
+				validatingWebhookConfig("ours", namespace, serviceName, nil),
+				validatingWebhookConfig("theirs", "other-namespace", serviceName, nil),
+			).Build()
+
+			validating, err := controller.ownedValidatingWebhookConfigurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validating).To(HaveLen(1))
+			Expect(validating[0].Name).To(Equal("ours"))
+		})
+
+		It("ignores configurations that dial a different Service in the same namespace", func() {
+			// Two installs can share a namespace. The caBundle only signs the cert for
+			// r.opts.ServiceName, so injecting it into a configuration that dials another
+			// Service would break that Service's admission rather than just being untidy.
+			controller.Client = fake.NewClientBuilder().WithObjects(
+				validatingWebhookConfig("ours", namespace, serviceName, nil),
+				validatingWebhookConfig("theirs", namespace, "someone-elses-webhook-service", nil),
+			).Build()
+
+			validating, err := controller.ownedValidatingWebhookConfigurations(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validating).To(HaveLen(1))
+			Expect(validating[0].Name).To(Equal("ours"))
+
+			changed, err := controller.updateValidatingWebhookConfiguration(context.Background(), cachedCert.CABytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			theirs := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			Expect(controller.Get(context.Background(), types.NamespacedName{Name: "theirs"}, theirs)).To(Succeed())
+			Expect(theirs.Webhooks[0].ClientConfig.CABundle).To(BeEmpty())
+		})
+
+		It("ignores configurations without the marker label", func() {
+			unlabelled := validatingWebhookConfig("unlabelled", namespace, serviceName, nil)
+			unlabelled.Labels = nil
+			controller.Client = fake.NewClientBuilder().WithObjects(unlabelled).Build()
+
+			_, err := controller.ownedValidatingWebhookConfigurations(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("creation is handled by the Helm chart"))
+		})
+
+		It("leaves a foreign webhook inside an owned configuration alone", func() {
+			// Ownership is claimed per configuration when ANY webhook dials our Service,
+			// but the caBundle only signs that one Service's cert, so a sibling webhook
+			// pointing elsewhere must not be written. Mutation scope has to match the
+			// scope that decided ownership.
+			conf := validatingWebhookConfig("mixed", namespace, serviceName, nil)
+			conf.Webhooks = append(conf.Webhooks, admissionregistrationv1.ValidatingWebhook{
+				Name: "foreign.example.com",
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service: &admissionregistrationv1.ServiceReference{Name: "someone-elses-svc", Namespace: namespace},
 				},
+			})
+			controller.Client = fake.NewClientBuilder().WithObjects(conf).Build()
+
+			_, err := controller.updateValidatingWebhookConfiguration(context.Background(), cachedCert.CABytes)
+			Expect(err).NotTo(HaveOccurred())
+
+			got := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+			Expect(controller.Get(context.Background(), types.NamespacedName{Name: "mixed"}, got)).To(Succeed())
+			Expect(got.Webhooks[0].ClientConfig.CABundle).To(Equal(cachedCert.CABytes), "our webhook gets the CA")
+			Expect(got.Webhooks[1].ClientConfig.CABundle).To(BeEmpty(), "the foreign webhook must be untouched")
+		})
+
+		It("annotates a Forbidden update with the RBAC coupling that causes it", func() {
+			// Label discovery removes the name coupling from the lookup but not from the
+			// manager ClusterRole's resourceNames, so this is the one drift that can still
+			// happen. The bare apierror says nothing about why.
+			forbidden := apierrors.NewForbidden(
+				schema.GroupResource{Group: "admissionregistration.k8s.io", Resource: "validatingwebhookconfigurations"},
+				"renamed-config", fmt.Errorf("not allowed"))
+
+			err := updateWebhookConfigurationsErr("ValidatingWebhookConfiguration", "renamed-config", forbidden)
+			Expect(err.Error()).To(ContainSubstring("resourceNames"))
+			Expect(err.Error()).To(ContainSubstring("renamed-config"))
+			Expect(apierrors.IsForbidden(err)).To(BeTrue(), "the apierror must stay unwrapped-detectable")
+		})
+
+		It("injects the CA into every owned configuration, not just the first", func() {
+			// A chart upgrade that renames a configuration leaves both the old and the new
+			// object present for a moment; patching only one leaves the other failing closed.
+			controller.Client = fake.NewClientBuilder().WithObjects(
+				validatingWebhookConfig("old-name", namespace, serviceName, nil),
+				validatingWebhookConfig("new-name", namespace, serviceName, nil),
+				mutatingWebhookConfig("mutating", namespace, serviceName, nil),
+			).Build()
+
+			changed, err := controller.updateValidatingWebhookConfiguration(context.Background(), cachedCert.CABytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			for _, name := range []string{"old-name", "new-name"} {
+				conf := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+				Expect(controller.Get(context.Background(), types.NamespacedName{Name: name}, conf)).To(Succeed())
+				Expect(conf.Webhooks[0].ClientConfig.CABundle).To(Equal(cachedCert.CABytes))
 			}
-			conf := webhookMutatingWebhookConfiguration(namespace, serviceName, secret)
-			Expect(conf).ToNot(BeNil())
-			Expect(conf.Webhooks).ToNot(BeEmpty())
-			Expect(conf.Webhooks[0].ClientConfig.CABundle).To(Equal(cachedCert.CABytes))
+
+			// The mutating path carries the same loop, so cover it here rather than
+			// leaving the fixture's mutating configuration asserted-on-by-nobody.
+			changed, err = controller.updateMutatingWebhookConfiguration(context.Background(), cachedCert.CABytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(changed).To(BeTrue())
+
+			mut := &admissionregistrationv1.MutatingWebhookConfiguration{}
+			Expect(controller.Get(context.Background(), types.NamespacedName{Name: "mutating"}, mut)).To(Succeed())
+			Expect(mut.Webhooks[0].ClientConfig.CABundle).To(Equal(cachedCert.CABytes))
 		})
 	})
 
@@ -440,8 +561,8 @@ var _ = Describe("WebhookController", Ordered, func() {
 
 		It("should return nil when all checks pass", func() {
 			// Create webhook configurations
-			validatingWebhook := webhookValidatingWebhookConfiguration(namespace, serviceName, secret)
-			mutatingWebhook := webhookMutatingWebhookConfiguration(namespace, serviceName, secret)
+			validatingWebhook := validatingWebhookConfig(validatingConfigName, namespace, serviceName, secret.Data["ca.crt"])
+			mutatingWebhook := mutatingWebhookConfig(mutatingConfigName, namespace, serviceName, secret.Data["ca.crt"])
 
 			// Add webhook configurations to the fake client
 			controller.Client = fake.NewClientBuilder().
@@ -477,10 +598,39 @@ var _ = Describe("WebhookController", Ordered, func() {
 			Expect(err.Error()).To(ContainSubstring("not ready"))
 		})
 
+		It("should return error when a NON-FIRST webhook has a stale CA bundle", func() {
+			// The API server dials each webhook independently, so a first-entry-only
+			// readiness check reports the pod ready while later webhooks reject everything.
+			stale, err := generateCert("stale-service", namespace, 24*time.Hour)
+			Expect(err).NotTo(HaveOccurred())
+
+			validatingWebhook := validatingWebhookConfig(validatingConfigName, namespace, serviceName, secret.Data["ca.crt"])
+			validatingWebhook.Webhooks = append(validatingWebhook.Webhooks, admissionregistrationv1.ValidatingWebhook{
+				Name: deploymentPolicyValidatingWebhookName,
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
+					Service:  &admissionregistrationv1.ServiceReference{Name: serviceName, Namespace: namespace},
+					CABundle: stale.CABytes,
+				},
+			})
+			mutatingWebhook := mutatingWebhookConfig(mutatingConfigName, namespace, serviceName, secret.Data["ca.crt"])
+
+			controller.Client = fake.NewClientBuilder().
+				WithObjects(secret, validatingWebhook, mutatingWebhook).
+				Build()
+
+			err = writeCertAndKey(secret.Data["tls.crt"], secret.Data["tls.key"], tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = controller.WebhookSecretReadyzCheck(nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(deploymentPolicyValidatingWebhookName))
+		})
+
 		It("should return error when webhook configurations are missing", func() {
 			err := controller.WebhookSecretReadyzCheck(nil)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not found"))
+			Expect(err.Error()).To(ContainSubstring("no ValidatingWebhookConfiguration labelled"))
+			Expect(err.Error()).To(ContainSubstring("creation is handled by the Helm chart"))
 		})
 
 		It("should return error when webhook configuration CA bundle doesn't match", func() {
@@ -491,8 +641,8 @@ var _ = Describe("WebhookController", Ordered, func() {
 			secretWithDifferentCA := secret.DeepCopy()
 			secretWithDifferentCA.Data["ca.crt"] = differentCert.CABytes
 
-			validatingWebhook := webhookValidatingWebhookConfiguration(namespace, serviceName, secretWithDifferentCA)
-			mutatingWebhook := webhookMutatingWebhookConfiguration(namespace, serviceName, secretWithDifferentCA)
+			validatingWebhook := validatingWebhookConfig(validatingConfigName, namespace, serviceName, secretWithDifferentCA.Data["ca.crt"])
+			mutatingWebhook := mutatingWebhookConfig(mutatingConfigName, namespace, serviceName, secretWithDifferentCA.Data["ca.crt"])
 
 			controller.Client = fake.NewClientBuilder().
 				WithObjects(secret, validatingWebhook, mutatingWebhook).
@@ -563,5 +713,87 @@ var _ = Describe("WebhookController", Ordered, func() {
 			Expect(updated).To(BeTrue())
 
 		})
+
+		It("should remint the certificate when the webhook Service has been renamed", func() {
+			// The cert Secret is operator-owned, not chart-owned, so it survives a chart
+			// upgrade that renames the webhook Service. A long-lived cert carrying the old
+			// SAN would then be reused and the API server would reject the webhook call with
+			// an x509 error until the cert expired.
+			cert, err := generateCert("old-webhook-service", namespace, certValidityDurationYear)
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := cert.ToSecret(secretName, namespace, "old-webhook-service")
+			controller.Client = fake.NewClientBuilder().WithObjects(secret).Build()
+
+			err = writeCertAndKey([]byte(cert.TLSCert), []byte(cert.TLSKey), tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := controller.CheckOrUpdateWebhookCertSecret(context.Background(), secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeTrue())
+			Expect(secret.Annotations[serviceAnnotationKey]).To(Equal(serviceName))
+
+			block, _ := pem.Decode(secret.Data["tls.crt"])
+			Expect(block).NotTo(BeNil())
+			parsed, err := x509.ParseCertificate(block.Bytes)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(parsed.DNSNames).To(ConsistOf(
+				fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, namespace),
+				fmt.Sprintf("%s.%s.svc", serviceName, namespace),
+			))
+		})
+
+		It("should not remint the certificate when nothing has changed", func() {
+			cert, err := generateCert(serviceName, namespace, certValidityDurationYear)
+			Expect(err).NotTo(HaveOccurred())
+
+			secret := cert.ToSecret(secretName, namespace, serviceName)
+			controller.Client = fake.NewClientBuilder().WithObjects(secret).Build()
+
+			err = writeCertAndKey([]byte(cert.TLSCert), []byte(cert.TLSKey), tmpDir)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated, err := controller.CheckOrUpdateWebhookCertSecret(context.Background(), secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).To(BeFalse())
+		})
 	})
 })
+
+// validatingWebhookConfig builds a chart-shaped ValidatingWebhookConfiguration: carrying the
+// marker label the operator selects on, and pointing its clientConfig at a Service in
+// namespace. The name is a free parameter precisely because the operator must not care
+// about it.
+func validatingWebhookConfig(name, namespace, serviceName string, caBundle []byte) *admissionregistrationv1.ValidatingWebhookConfiguration {
+	return &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{webhookConfigLabelKey: "true"},
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name: skyhookValidatingWebhookName,
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				Service:  &admissionregistrationv1.ServiceReference{Name: serviceName, Namespace: namespace},
+				CABundle: caBundle,
+			},
+			Rules: skyhookRules(),
+		}},
+	}
+}
+
+func mutatingWebhookConfig(name, namespace, serviceName string, caBundle []byte) *admissionregistrationv1.MutatingWebhookConfiguration {
+	return &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: map[string]string{webhookConfigLabelKey: "true"},
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			Name: skyhookMutatingWebhookName,
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{
+				Service:  &admissionregistrationv1.ServiceReference{Name: serviceName, Namespace: namespace},
+				CABundle: caBundle,
+			},
+			Rules: skyhookRules(),
+		}},
+	}
+}

--- a/scripts/scale_test.sh
+++ b/scripts/scale_test.sh
@@ -209,7 +209,7 @@ prepare_metrics_access() {
   kubectl -n "$NAMESPACE" create serviceaccount "$METRICS_SERVICE_ACCOUNT" \
     --dry-run=client -o yaml | kubectl apply -f - >/dev/null
   kubectl create clusterrolebinding scale-test-metrics-reader-access \
-    --clusterrole=skyhook-operator-metrics-reader \
+    --clusterrole=nodewright-metrics-reader \
     --serviceaccount="${NAMESPACE}:${METRICS_SERVICE_ACCOUNT}" \
     --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 }


### PR DESCRIPTION
Closes #440.

## What

Every in-cluster resource name that was still hardcoded to `skyhook-operator-*` now templates off `chart.fullname`, and `operator/config/` is mirrored (`namePrefix: nodewright-`) so kustomize and Helm render identical names.

| Before | After |
| --- | --- |
| `skyhook-operator-manager-role` / `-manager-rolebinding` | `nodewright-manager-role` / `-manager-rolebinding` |
| `skyhook-operator-leader-election-role` / `-rolebinding` | `nodewright-leader-election-role` / `-rolebinding` |
| `skyhook-operator-metrics-reader` / `-metrics-reader-rolebinding` | `nodewright-metrics-reader` / `-metrics-reader-rolebinding` |
| `skyhook-operator-controller-manager-metrics-service` | `nodewright-controller-manager-metrics-service` |
| `skyhook-operator-webhook-service` | `nodewright-webhook-service` |
| `skyhook-operator-validating-webhook` / `-mutating-webhook` | `nodewright-validating-webhook` / `-mutating-webhook` |

`app.kubernetes.io/created-by` and `part-of` move from `skyhook-operator` to `nodewright`. The controller-manager Deployment name and `spec.selector` are **unchanged**, so #285 does not recur; every renamed object is created new and the old one removed, and none has an immutable field a rename would trip.

## Why this isn't chart-only

Renaming the webhook Service and the two webhook configurations required three operator-side changes. All three were found by actually running `chart/v0.17.1 → this branch` on kind, not by reading.

**1. The rollout deadlocks.** The pre-#440 operator looks its webhook configurations up by name. Renaming them makes it hard-error, so it never goes Ready, so the rolling update never terminates it, so it never releases the webhook bootstrap lease. `helm upgrade` wedges on `Pending termination` and the release stays stuck:

```
Error: UPGRADE FAILED: resource Deployment/nodewright/nodewright-controller-manager
not ready. status: InProgress, message: Pending termination: 1
```

The operator now finds them by the `nodewright.nvidia.com/webhook-config` label (filtered to configurations whose `clientConfig` targets its own namespace) and patches every match, so future renames are invisible to it. `docs/designs/webhook-bootstrap-lease.md` gains a section on why a name-based lookup is specifically forbidden here.

Label discovery cannot save the upgrade that introduces it, because the pod holding the lease is the pre-rename one. The existing `selectorMigration` pre-upgrade hook now also detects a pre-label-discovery operator — the live Deployment has no `WEBHOOK_SERVICE_NAME` env var — and deletes the Deployment so Helm recreates it. Verified to stay a no-op on normal upgrades.

**2. The serving cert kept the old SAN.** `Secret/webhook-cert` is operator-owned, not chart-owned, so it survives the upgrade, and the operator only reminted on expiry or a cert-on-disk mismatch. A renamed Service left a year-valid certificate carrying the old DNS name and admission failed closed:

```
x509: certificate is valid for skyhook-operator-webhook-service.nodewright.svc,
not nodewright-webhook-service.nodewright.svc
```

It now also remints when the Service recorded on the Secret no longer matches the configured `WEBHOOK_SERVICE_NAME`.

**3. The chart never passed the env vars.** `WEBHOOK_SERVICE_NAME` and `WEBHOOK_SECRET_NAME` already existed on the operator but nothing set them, so `webhook.serviceName` and `webhook.secretName` in `values.yaml` were silently ignored.

## Also fixed in passing

The manager ClusterRole granted only `get`/`update` on the webhook configurations, so the pre-delete cleanup job's `kubectl delete ...webhookconfiguration` was RBAC-denied and the trailing `|| true` swallowed the error. `delete` is now granted, and the job also sweeps the pre-rename names — an orphaned `failurePolicy: Fail` configuration with no operator behind it rejects every matching API call cluster-wide.

## Also fixes #464: `helm rollback` destroyed every NodeWright

The CRDs live under `templates/` (they interpolate the conversion-webhook Service name), so Helm manages them as release resources. Rolling back to a pre-rename revision dropped `nodewrights.nodewright.nvidia.com` from the rendered manifest and Helm deleted it, cascade-deleting every `NodeWright` object. Both nodewright CRDs now carry `helm.sh/resource-policy: keep`.

`keep` suppresses **deletion only** — Helm still creates and patches these CRDs on install and upgrade, so schema changes apply exactly as before. Two consequences, both in `chart/RELEASE_NOTES.md`:

- `helm uninstall` now leaves the two CRDs behind. Delete them explicitly for a full teardown.
- A kept CRD keeps its `meta.helm.sh/release-name`. Reinstalling under the **same** release name adopts it; under a **different** name Helm fails with `invalid ownership metadata`. Verified both on kind.

That second consequence bites our own helm chainsaw suite, which shares one namespace across five release names (`events-rbac`, `foobar`, `node-affinity-test`, `nodewright`, `webhooks`), so the first uninstall would have broken every later install. `uninstall-helm-chart.sh` now drops the CRDs on teardown — keeping them is a production guarantee, not a test-fixture one. All seven helm tests pass in a single run against one cluster.

The new `helm-upgrade-rename-test` round-trips a `helm rollback` and asserts both CRDs survive. With the annotation reverted that step fails with `actual resource not found`, so it is not a vacuous guard.

Also caught while rebasing: `docs/metrics/prometheus_values.yaml` relabels on the metrics Service name, which this PR renames, so the shipped example scrape job would have silently matched zero targets. Its regex now accepts both names, and its namespace list covers `nodewright` as well as `skyhook`.

## Deprecation, not removal

`skyhook-operator-metrics-reader` ships as a duplicate ClusterRole for a deprecation window. Unlike every other renamed object it is a name users bind to themselves: `docs/metrics/README.md` tells them to create a ClusterRoleBinding against it for their Prometheus service account, so renaming it alone would break their scrape with no error anywhere else. Removal is a follow-up.

## New patterns introduced

Per `CLAUDE.md`, calling these out explicitly:

- **Label-based discovery of cluster-scoped objects the operator does not create.** The operator previously addressed these two objects by compiled-in name. If this is the wrong direction, the alternative is keeping the webhook trio pinned to the legacy names and closing #440 partially.
- **Removal of `webhookValidatingWebhookConfiguration` / `webhookMutatingWebhookConfiguration` / `webhookClient`.** These became dead once the name constants went away. The chart has owned creation of these objects for several releases; the operator only ever patched their caBundle, and the error messages already said so.
- **A chainsaw test that installs a released chart.** `helm-upgrade-rename-test` materializes `chart/v0.17.1` with `git archive`, the same mechanism `k8s-tests/migration/lib.sh` uses, so there is no registry dependency — but `helm-tests` now needs full history with tags, which the CI `tests` job already sets. Noted in `docs/ci-test-pools.md`.

## CLI contract: unaffected

`CLAUDE.md` asks for an explicit justification when a change touches a contract surface, so stating it rather than leaving it implied: **this rename does not cross the CLI contract.**

The CLI discovers the operator by label, not by name — `operator/internal/cli/utils/utils.go` uses `LabelSelector: "control-plane=controller-manager"`, and its own comment notes that label is the one "which both the chart and the kustomize overlay label". Nothing under `operator/cmd/cli/` or `operator/internal/cli/` references any of the renamed objects (`grep` for `skyhook-operator`, `metrics-reader`, `*-webhook-service`, `*-manager-role` returns no non-test hits). The annotation keys, status fields, and finalizer names the CLI depends on are untouched.

No CLI change, no version gate, and no `docs/cli.md` compatibility-matrix entry is needed.

## Verification

- `make unit-tests` — 13 suites green. `make lint` — 0 issues. No CRD/deepcopy drift from `make manifests generate`.
- **Real upgrade on kind**, `chart/v0.17.1` → this branch: upgrade completes hands-off, cert reminted, caBundle lands on the renamed configurations, an invalid CR is rejected by `validate-nodewright.nvidia.com` (i.e. admission is reached, not failing on TLS), only the intentional metrics-reader alias survives, and `helm uninstall` leaves zero orphans.
- **Idempotence**: re-running the upgrade against itself does not restart the operator pod, confirming the pre-upgrade hook stays a no-op.
- New `helm-upgrade-rename-test` covers all of the above; `helm-template-test` gains coverage for the rendered names, the discovery label, and the env-to-Service contract.
- Existing suites re-run green against the new operator: `helm-chart`, `helm-webhook`, `helm-node-affinity`, `events-rbac`, `helm-template`, and `k8s-tests/migration` phases 1–6 (the suite most at risk, since it performs the same old-chart → working-tree upgrade).

## Upgrade impact

Written up in `chart/RELEASE_NOTES.md`: this chart requires an operator built from this PR or later, the controller-manager Deployment is deleted and recreated on the one upgrade that crosses the rename, there is a brief admission gap while the operator injects the caBundle into the newly created configurations, and `skyhook-operator-metrics-reader` is deprecated. Releases that pin `fullnameOverride` / `nameOverride` keep their own prefix on everything and are unaffected.
