### PR TITLE
chore(ci): drop priority labels in favor of the native issue field

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -289,6 +289,14 @@ When choosing between approaches, prioritize:
 - Observability is mandatory — structured `logr` messages, metrics via `controller/metrics.go`, events via the event recorder.
 - Boring first — prefer proven controller-runtime idioms over clever abstractions.
 
+## Issue and PR metadata (labels, type, priority)
+
+- **`.github/labels.yml` is the desired, closed set of labels.** It is the only source of truth, synced to GitHub with `make labels`. Because that sync creates and updates but never deletes, GitHub may currently carry undeclared extras; treat any label not defined in the file as one that should not exist, never as precedent for adding more.
+- **Never create a label.** No `gh label create`, no `gh issue create --label <something-new>`, no label creation through `gh api`. `make labels` does not prune, so a label invented once lingers on the repo forever until someone deletes it by hand. If a label you want is genuinely missing, add it to `.github/labels.yml` in a PR and stop there; do not create it on GitHub and backfill the file later.
+- **Priority is not a label.** It is a native GitHub issue Field (Urgent / High / Medium / Low) in the issue sidebar. **Maintainers set it during triage; agents and issue reporters do not set it at all.** Never apply `priority/*`, `P0` / `P1` / `P2`, or any severity label, and never write the Priority field from automation. If you think something is urgent, say so in the issue body and let a maintainer decide.
+- **Type is not a label either.** Bug / Enhancement / Documentation / Task / Epic / Initiative are native GitHub Issue Types, assigned by the issue forms via their `type:` key. `doc` is the one exception, and only because the PR path labeler applies it to docs-only PRs.
+- **When filing an issue, apply no labels yourself.** `.github/workflows/triage.yaml` adds `needs-triage` and infers `component/*` from the title and body; `.github/labeler.yml` handles PR path labels. Let that automation run rather than pre-labeling.
+
 ## Conventions and gotchas
 
 - **Vendoring**: Go deps are vendored. `make build`/`make test` pass `-mod=vendor` via `GOFLAGS`; `go get` is still fine but follow with `go mod vendor`.

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -39,18 +39,6 @@ body:
       required: true
 
   - type: dropdown
-    id: criticality
-    attributes:
-      label: How would you describe the priority of this feature request?
-      options:
-        - Critical (currently preventing usage)
-        - High
-        - Medium
-        - Low (would be nice)
-    validations:
-      required: true
-
-  - type: dropdown
     id: component
     attributes:
       label: Component

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -17,9 +17,16 @@
 # GitHub label definitions for Skyhook (NodeWright).
 # Sync to GitHub with: make labels
 #
+# This file is the desired set of labels for this repo: a label that is not
+# defined here should not exist on GitHub. Note that `make labels` creates and
+# updates, but never deletes, so a label created by hand lingers until someone
+# removes it and GitHub may currently carry undeclared extras. If you need a new
+# label, add it here in a PR rather than creating it with `gh label create`.
+#
 # Label categories:
 #   Type:      issue Type (Bug/Enhancement/Documentation/Task/Epic/Initiative) is
 #              a native GitHub Issue Type set by the org, not a label
+#   Priority:  a native GitHub issue Field set by maintainers, not a label
 #   Triage:    needs-triage, cleared once a maintainer triages
 #   Component: which part of the project is affected
 #   Lifecycle: stale automation and freeze exemptions
@@ -34,6 +41,13 @@
 - name: "doc"
   color: "0075ca"
   description: "Documentation change (PR path label; doc issues use the Documentation type)"
+
+# ── Priority ─────────────────────────────────────────────────────────────────
+# Priority is a native GitHub issue Field (Urgent / High / Medium / Low), set
+# from the Fields section of the issue sidebar. It is deliberately NOT modelled
+# as a label and is NOT collected by the issue forms: prioritization is a
+# maintainer call made during triage, not something a reporter self-declares.
+# Do not add priority/*, P0/P1/P2, or severity labels here.
 
 # ── Triage ───────────────────────────────────────────────────────────────────
 # Applied automatically to new issues; removed once a maintainer triages.


### PR DESCRIPTION
## Description

The `priority/p1` and `priority/p2` labels were never defined in `.github/labels.yml`. They were created directly on the repo by coding agents, and because `scripts/sync_labels.py` only creates and updates labels and never prunes, a label invented once survives every subsequent `make labels` run.

Priority already has a home: the native GitHub issue **Field** (Urgent / High / Medium / Low) in the issue sidebar, set by maintainers during triage. Modeling it a second time as a label gave us two sources of truth that disagreed with each other.

The root cause is that the agent guide said nothing at all about issue and PR metadata, so agents filled the gap with an invented taxonomy. This PR closes that gap.

### Changes

- **`.claude/CLAUDE.md`** (canonical agent guide, symlinked as `AGENTS.md`): new "Issue and PR metadata" section establishing that `.github/labels.yml` is a closed set, that agents must never create a label under any circumstance, that Priority and Type are native fields rather than labels, and that neither agents nor reporters set priority.
- **`.github/labels.yml`**: documents Priority as a native field, in the same style the file already documents native issue Type, with an explicit "do not add `priority/*`, `P0`/`P1`/`P2`, or severity labels here."
- **`.github/ISSUE_TEMPLATE/feature_request_form.yml`**: removes the required "How would you describe the priority of this feature request?" dropdown. Prioritization is a maintainer call, not something a reporter self-declares. Nothing else in the repo referenced that field id (`criticality`).

### Already applied outside this PR

Both labels have been deleted from the repo, and the 19 issues that carried them were migrated to the native Priority field (`priority/p1` → Medium, `priority/p2` → Low). 8 issues needed a write; the other 11 already held the target value.

### Note for follow-up

Two related gaps are deliberately left out of scope here:

1. `scripts/sync_labels.py` still never prunes, so this PR's rule is instruction-level only. A `--prune` mode would enforce it mechanically.
2. Three more labels exist on GitHub but not in `labels.yml`: `question`, `go`, and a description-less `needs-rebase` that has drifted from its definition in the file.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes. <!-- N/A: docs and GitHub config only; the three YAML files were parse-validated. -->
- [x] The documentation is up to date with these changes. <!-- The agent guide and labels.yml are the documentation being changed. -->