### PR TITLE
docs: record the Jobs upgrade contract and validation (#305)

### DIFF
--- a/chart/RELEASE_NOTES.md
+++ b/chart/RELEASE_NOTES.md
@@ -53,6 +53,16 @@ For the full commit-level log see CHANGELOG.md.
 
 ### Upgrade notes
 
+- **Run `helm upgrade` only when no package work is in flight.** The operator
+  that precedes this chart executes packages as raw pods, and the two execution
+  models are never allowed to overlap: the new operator withholds all
+  reconciliation while any pre-rename `Skyhook` is still rolling out. Upgrading
+  mid-rollout therefore leaves that node **cordoned and stalled** until you
+  `helm rollback` and let the rollout finish, or delete the legacy `Skyhook`.
+  Confirm every `Skyhook` reads `complete` first, and do not unpause or enable a
+  migrated `NodeWright` until its pre-upgrade package pods are gone. See the
+  operator release notes and
+  [docs/nodewright-migration.md](../docs/nodewright-migration.md).
 - **A crash-looping package now gives up after ~70 seconds instead of retrying
   for up to an hour.** `jobBackoffLimit` bounds retries per stage; if you rely on
   a package self-healing through transient environment problems, raise it before

--- a/docs/designs/2026-07-10-package-execution-as-jobs.md
+++ b/docs/designs/2026-07-10-package-execution-as-jobs.md
@@ -201,7 +201,7 @@ Today the `skyhook.nvidia.com/pause` annotation (the CLI's **Emergency Stop**) o
 - **Resume has an explicit owner and ordering.** Because the pause path only runs for paused Skyhooks and paused Skyhooks skip validation, un-suspension is a separate step for *non-paused* Skyhooks, ordered after validation: invalidate suspended Jobs whose spec changed while paused, *then* clear `suspend` on the survivors. Clearing first would let one stale-spec attempt launch before validation catches it.
 - **Everything else is indifferent**: existence gating counts the suspended Job, completion ignores it (Suspended is not terminal), and node state stays `in_progress` (guard (c) of the erroring evidence makes that hold).
 - **Interrupts already fired**: suspension can't un-ring a reboot; on resume the replacement pod skips the interrupt via the resource-id flag and completes.
-- **Legacy pods can't suspend** — for them pause keeps today's let-finish semantics until the upgrade window closes, so pause's stop-strength is operator-version-dependent (a CLI-docs note).
+- **Legacy pods can't suspend** — a pre-rename raw pod has no Job, so pause cannot stop one. It never has to: the migration hold keeps the two execution models from running side by side (see [Upgrade and compatibility](#upgrade-and-compatibility)). What stays version-dependent is pause's stop-strength *across operator versions* — a pre-Jobs operator lets an in-flight stage finish — which is the CLI-docs note.
 
 `disable` is unchanged: it skips a Skyhook from processing but has never claimed to halt in-flight work.
 
@@ -311,6 +311,63 @@ Locking the write does not fix this: the value is computed long before the write
 **Pruner accounting safety.** The archive pruner deletes the middle attempts by normal deletion only, never force-delete: the Job-tracking finalizer is what guarantees a failure is counted and policy-classified before the pod is removed. The archives it keeps — the first and most recent genuine failures — exclude `DisruptionTarget` casualties so an ignored disruption can neither shadow a real failure nor suppress the deadline snapshot.
 
 **Replacement-policy gate off.** `podReplacementPolicy` is beta and on by default across the supported range; if a cluster disables the gate, operator-initiated recreates stay safe (foreground deletion frees the name only after children are gone), and only Job-controller replacements can then briefly overlap a terminating predecessor — accepted for that non-default configuration, since the agent's flag files keep re-execution idempotent.
+
+## Validation
+
+Chainsaw and envtest assert fixed shapes; this section records the hand-run pass over the flows a
+user actually drives, which #305 gated the merge to `main` on. Run against
+`feature/package-as-jobs` on kind v1.36.1 (podman), three nodes, with the operator built from the
+branch and run against the cluster — the same shape `make e2e-tests` uses, since the branch
+published no image. Every case reset first (all CRs, Jobs, pods, ConfigMaps, and per-CR node
+annotations/labels/taints/cordons) with a baseline assertion before starting, and captured evidence
+mid-flight as well as at the end. Two full passes were run and agreed case for case.
+
+**16 cases, 15 pass, 1 fail.**
+
+| Case | Result |
+| --- | --- |
+| single package | pass — apply then config Jobs `Complete 1/1`, child pods retained and logs still readable, `state-recorded` set at completion |
+| multiple packages + `dependsOn` | pass — one Job per (package, stage); the dependency completed before its dependents started |
+| erroring, retries exhausted | pass — `failed=4` at `backoffLimit: 3`, `BackoffLimitExceeded`, exactly two archive pods (middle attempts pruned), no churn; editing the package cleared the terminal Job and the stage re-ran |
+| stage timeout | pass — attempt killed at its own deadline, pod `Failed`/`DeadlineExceeded`, archive logs readable, per-attempt bound only |
+| multiple CRs on one node | pass — no tick ever held unfinished Jobs from both CRs; separate `nodeState_` keys |
+| interrupt grouping | pass — one merged interrupt Job for two packages, node cordoned during and uncordoned after, `skipped` sibling promoted to `complete` |
+| explicit uninstall | **fail** — entry removed correctly, but the successful uninstall Job and its pod were deleted immediately, losing the logs (#443) |
+| CR deletion with `uninstall.enabled` | pass — finalizer ran an uninstall Job during deletion; no `nodewright.nvidia.com/*` metadata left behind, node uncordoned |
+| TTL by outcome | pass — succeeded collected first while the failed one remained, node state survived collection, sub-minute TTL rejected at startup |
+| kubelet-refused attempts | pass — spent budget, never marked `erroring`, self-healed via sweep and recreate |
+| pause / disable | pass — pause set `spec.suspend` and killed the running pod, resume started a fresh one; adding disable while clearing pause left the Job suspended |
+| config update mid-flight | pass — ConfigMap not swapped mid-stage; the config stage re-ran afterwards with a new `resource-id` |
+| two nodes + interruption budget | pass — never more than one node cordoned, one interrupt Job per node |
+| node deleted mid-run | pass — orphaned-node Job foreground-deleted within seconds; the surviving node completed |
+| disruption casualty | pass — evicted attempt spent no retry budget and never marked `erroring` |
+| upgrade → downgrade | pass — upgrade removed the superseded entry; downgrade kept both, as `uninstall.md` intends |
+| unpullable image | pass — bounded by `stageTimeout` rather than hanging indefinitely; the baseline #306 improves on |
+
+**CLI.** `package logs`, `package status`, `node status` and `package rerun` were exercised inside
+the cases above against a Jobs operator and needed no code change: child pods inherit the full label
+set, so the CLI's label queries resolve identically, and post-completion `package logs` gets better
+because the Job is retained. The version-dependent stop-strength of `pause` is recorded in
+[`docs/cli.md`](../cli.md)'s compatibility matrix.
+
+**Upgrade.** The hold is what makes the upgrade safe, and it was validated separately, on the rename
+pass: an upgrade started mid-rollout held without taking over the node (requeuing roughly every 20s,
+writing no `nodewright.nvidia.com/*` annotations) and released when the in-flight legacy `Skyhook`
+was deleted. The same pass confirmed the unsupported case — upgrading with an interrupt executing
+leaves a **cordoned, stalled node** rather than corrupting state or double-executing.
+
+### Not covered
+
+- **The hold and the Jobs executor were never exercised in one build.** The hold was validated on
+  pre-Jobs `main` (rename, raw pods) and the cases above on `feature/package-as-jobs`.
+  `migration_hold.go` was byte-identical across the two, so the composition is argued rather than
+  observed.
+- **Operator restart across a completion** — the exactly-once crash window in
+  [Edge cases](#edge-cases-and-correctness-arguments); the gap #433 exists for and the one most worth
+  covering next.
+- **Scale** — two nodes, one package at a time. Nothing here speaks to fleet behavior (#382).
+- **Webhook validation** — disabled under the local-run setup, so rejection paths were not exercised.
+- **Real reboots** — the test image does not reboot, so interrupt was exercised structurally only.
 
 ## References
 

--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -146,6 +146,12 @@ For the full commit-level log see CHANGELOG.md.
   `JOB_TTL_SUCCEEDED` (default 1h) and `JOB_TTL_FAILED` (default 24h) — failure
   logs outlive success logs. Both have a hard minimum of one minute; the
   operator refuses to start below it, so `"0"` is not a way to disable retention.
+  - **A successful `uninstall` stage is the one exception and keeps no logs.**
+    A successful no-interrupt uninstall's completion *is* the removal of the
+    package's node-state entry, so its Job is eligible for rerun cleanup the
+    moment it finishes and never serves out `JOB_TTL_SUCCEEDED`. Starting an
+    uninstall also clears that package's retained apply/config Jobs. Failed
+    uninstalls are retained normally (#443).
 - Editing `stageTimeout`, `JOB_STAGE_TIMEOUT` or `JOB_BACKOFF_LIMIT` applies to
   the *next* stage Job, not one already running (a Job's pod template is
   immutable). To apply a new value to work already under way, clear that Job
@@ -165,6 +171,33 @@ For the full commit-level log see CHANGELOG.md.
   tolerations use Kubernetes `ToleratesTaint` matching, and DaemonSet pods are
   identified from the controller owner reference instead of the previous owner
   reference count heuristic.
+
+### Upgrade notes
+
+- **Upgrade with no package work in flight.** Jobs and the pre-rename raw-pod
+  executor are never allowed to run side by side, so there is no dual path and
+  nothing is converted: because this release also carries the rename, every
+  operator that precedes it is a pre-rename one, and `legacyMigrationHold`
+  withholds all `NodeWright` reconciliation while any legacy `Skyhook` is still
+  rolling out. The new operator therefore cannot start a Job on a node the
+  pre-rename operator may still be mutating. Pre-upgrade package pods run to
+  completion as pods and are removed by the prune once `LEGACY_CLEANUP_DELAY`
+  elapses. This is the same quiet-window prerequisite the rename carries above —
+  see [docs/nodewright-migration.md](../docs/nodewright-migration.md).
+  - **If you upgrade anyway with a rollout in flight**, the failure mode is a
+    **stuck, cordoned node** rather than corruption or double execution: the hold
+    protects the node, the legacy `Skyhook` stays frozen at its stage, and
+    nothing progresses until you either roll back and let the rollout finish or
+    delete the legacy `Skyhook`.
+  - **Do not unpause or enable a migrated `NodeWright` until its pre-upgrade
+    package pods are gone.** The hold treats a paused or disabled `Skyhook` as
+    not-in-flight, deliberately, so migrating never forces you to unpause one —
+    but neither pre-Jobs pause nor disable stopped a *running* pod, so one of
+    those objects can cross the upgrade with a live raw pod. Unpausing or
+    enabling it before that pod exits puts a Job alongside it on the same host
+    `copyDir`; the agent's flag files make re-execution idempotent but are not a
+    lock, so that sequence is documented as unsupported rather than guarded.
+    Leaving the object paused or disabled is safe indefinitely.
 
 ## operator/v0.16.1 - 2026-05-22
 

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -1081,8 +1081,10 @@ func (r *SkyhookReconciler) UpdatePauseStatus(ctx context.Context, clusterState 
 // unfinished Jobs is set spec.suspend=true, so the Job controller SIGTERMs the running pod (honoring
 // terminationGracePeriodSeconds) and starts nothing until resume. Idempotent; already-suspended Jobs
 // and invalid ones (mid-reap) are skipped. The killed pod carries a DeletionTimestamp, so
-// erroring-evidence guard (c) keeps node state at in_progress. Legacy raw pods have no Job to suspend
-// and keep today's let-finish semantics until the migration window closes.
+// erroring-evidence guard (c) keeps node state at in_progress. A pre-rename raw pod has no Job and
+// so cannot be suspended, but pause never has one of its own to stop: this change ships with the
+// nodewright rename, so legacyMigrationHold keeps the two execution models from running side by
+// side. See the design doc's Upgrade section.
 func (r *SkyhookReconciler) suspendUnfinishedJobs(ctx context.Context, skyhook SkyhookNodes) error {
 	return r.setSuspendOnUnfinishedJobs(ctx, skyhook, true)
 }


### PR DESCRIPTION
## Description

Closes #305. Final PR of the Jobs migration epic (#223) — docs only, no behavior change.

### The correction this PR makes

#305 scoped an upgrade note reading *"in-flight legacy pods finish under the old path; the dual path is removed the following minor."* That is not what the code does. Those four accommodations were **deliberately dropped** in favour of `legacyMigrationHold`, which prevents the two execution models from overlapping at all. The design doc's Upgrade section already records this (and #423 exists to reconcile the docs with it); the release notes were the last place still implying a dual path.

So the note documents the real contract instead:

- **The hold.** This release also carries the rename, so every preceding operator is a pre-rename one, and `legacyMigrationHold` withholds all `NodeWright` reconciliation while any legacy `Skyhook` is still rolling out. Pre-upgrade package pods run to completion as pods and are removed by the prune.
- **The quiet-window prerequisite**, cross-referenced to the rename's existing statement rather than duplicated.
- **What ignoring it actually looks like:** a *stuck, cordoned node* — not corruption, not double execution. This is what M15 of the rename validation observed.
- **The one sequence the hold does not cover:** unpausing or enabling a migrated `NodeWright` while a pre-upgrade raw pod is still live. The hold treats paused/disabled objects as not-in-flight by design, but pre-Jobs pause never stopped a running pod. Documented as unsupported rather than guarded, matching the design doc.

### Also in this PR

- **Uninstall retention carve-out** noted directly under the retention bullet it contradicts: a successful no-interrupt uninstall's completion *is* the node-state entry removal, so its Job never serves out `JOB_TTL_SUCCEEDED` (#443). Failed uninstalls are retained normally.
- **Chart notes** carry the prerequisite too, since `helm upgrade` is what the user actually runs.
- **Two stale comments corrected** — `suspendUnfinishedJobs` and the design doc's pause section — which described pause's legacy behavior as a closing migration window rather than a difference across operator versions.
- **A `## Validation` section in the design doc.** `docs/plans/` is gitignored, so the hand-run pass behind #305 had no committed home and the repo's "document the verification" rule was unmet.

### Verification

Per #305's checklist, verification was run ahead of this PR rather than in it:

- **Jobs manual pass — 16 cases, 15 pass, 1 fail.** The failure is #443 (already filed). Two full passes agreed case for case.
- **CLI** — `package logs` / `status` / `rerun` and `node status` exercised inside those cases against a Jobs operator. No CLI code change needed: child pods inherit the full label set, so label queries resolve identically. Documented per the repo rule.
- **Upgrade** — the hold was exercised by the rename validation pass, including the unsupported mid-interrupt upgrade.
- **This PR:** `make lint` (0 issues) and `make unit-tests` (14 suites, Test Suite Passed).

**Stated honestly in the doc rather than papered over:** the hold and the Jobs executor were never exercised in one build — the hold on pre-Jobs `main`, the Jobs cases on this branch. `migration_hold.go` was byte-identical across both, so that composition is argued, not observed. The full not-covered list (operator restart across a completion #433, scale #382, webhook validation, real reboots) is in the doc.

### Out of scope

#464 (`helm rollback` deletes the NodeWright CRD) surfaced in the rename validation evidence and is already filed against the rename epic.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes. — docs + one comment; no behavior change, so no new specs. `make unit-tests` passes.
- [x] The documentation is up to date with these changes. — this PR *is* the documentation.