### PR TITLE
test(operator): close webhook-cache race in DeploymentPolicy webhook specs

### DIFF
--- a/operator/api/nodewright/v1alpha1/deployment_policy_webhook_test.go
+++ b/operator/api/nodewright/v1alpha1/deployment_policy_webhook_test.go
@@ -304,6 +304,7 @@ var _ = Describe("DeploymentPolicy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			waitForPolicyInWebhookCache(policy.Name)
 
 			// Create a NodeWright that references the policy
 			nodewright := &NodeWright{
@@ -361,6 +362,7 @@ var _ = Describe("DeploymentPolicy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			waitForPolicyInWebhookCache(policy.Name)
 
 			// Create a NodeWright that references the policy
 			nodewright := &NodeWright{

--- a/operator/api/nodewright/v1alpha1/webhook_suite_test.go
+++ b/operator/api/nodewright/v1alpha1/webhook_suite_test.go
@@ -34,6 +34,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,6 +50,7 @@ import (
 
 var cfg *rest.Config
 var k8sClient client.Client
+var cachedClient client.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
@@ -122,6 +124,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	cachedClient = mgr.GetClient()
+
 	err = (&NodeWright{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -155,3 +159,15 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// waitForPolicyInWebhookCache blocks until the manager's cache has observed the named
+// DeploymentPolicy. The NodeWright validating webhook reads through that cache, while
+// k8sClient reads straight from the apiserver, so a NodeWright created immediately
+// after its policy races the informer and is denied with "deploymentPolicy ... not
+// found". Waiting on the same client the webhook uses closes that window.
+func waitForPolicyInWebhookCache(name string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		return cachedClient.Get(ctx, types.NamespacedName{Name: name}, &DeploymentPolicy{})
+	}, "10s", "100ms").Should(Succeed())
+}

--- a/operator/api/v1alpha1/deployment_policy_webhook_test.go
+++ b/operator/api/v1alpha1/deployment_policy_webhook_test.go
@@ -324,6 +324,7 @@ var _ = Describe("DeploymentPolicy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			waitForPolicyInWebhookCache(policy.Name)
 
 			// Create a Skyhook that references the policy
 			skyhook := &Skyhook{
@@ -381,6 +382,7 @@ var _ = Describe("DeploymentPolicy", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, policy)).To(Succeed())
+			waitForPolicyInWebhookCache(policy.Name)
 
 			// Create a Skyhook that references the policy
 			skyhook := &Skyhook{

--- a/operator/api/v1alpha1/webhook_suite_test.go
+++ b/operator/api/v1alpha1/webhook_suite_test.go
@@ -33,6 +33,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	//+kubebuilder:scaffold:imports
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +49,7 @@ import (
 
 var cfg *rest.Config
 var k8sClient client.Client
+var cachedClient client.Client
 var testEnv *envtest.Environment
 var ctx context.Context
 var cancel context.CancelFunc
@@ -106,6 +108,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	cachedClient = mgr.GetClient()
+
 	err = (&Skyhook{}).SetupWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
@@ -139,3 +143,15 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// waitForPolicyInWebhookCache blocks until the manager's cache has observed the named
+// DeploymentPolicy. The Skyhook validating webhook reads through that cache, while
+// k8sClient reads straight from the apiserver, so a Skyhook created immediately after
+// its policy races the informer and is denied with "deploymentPolicy ... not found".
+// Waiting on the same client the webhook uses closes that window.
+func waitForPolicyInWebhookCache(name string) {
+	GinkgoHelper()
+	Eventually(func() error {
+		return cachedClient.Get(ctx, types.NamespacedName{Name: name}, &DeploymentPolicy{})
+	}, "10s", "100ms").Should(Succeed())
+}


### PR DESCRIPTION
Fixes #456

## Problem

`DeploymentPolicy > When deleting DeploymentPolicy under Validating Webhook > should allow deletion after NodeWrights no longer reference it` fails intermittently in `unit-tests`, on `main` and on unrelated PRs. It is a test bug, not a product bug.

Despite the spec name, the failure is not on the deletion. It is on the `NodeWright` create:

```
[FAILED] Expected success, but got an error:
    admission webhook "vnodewright.kb.io" denied the request:
    deploymentPolicy "policy-to-be-freed" not found
```

`NodeWrightWebhook.Client` is `mgr.GetClient()` (`nodewright_webhook.go:48`), so `validateDeploymentPolicyExists` reads through the manager's informer cache. The spec's `k8sClient` is a direct apiserver client. It creates the policy, then immediately creates a NodeWright referencing it; when the informer has not yet caught up, admission denies the create. A read-your-own-write race against an informer cache.

The spec already guards the delete-side version of this race. The create side was unguarded.

## Fix

Expose the manager's client as `cachedClient` in each webhook suite, and add `waitForPolicyInWebhookCache`, which waits for the policy to appear in that same cache before the referencing create. Because it is the exact informer the webhook reads, once the wait returns the webhook cannot miss the policy.

Waiting on the cache rather than `Eventually`-ing the create keeps a genuine validation error failing fast with its own message instead of spinning for the timeout.

## Scan for the same pattern

The issue asked for a scan of sibling specs. Four sites were racing, not one:

- `api/nodewright/v1alpha1/deployment_policy_webhook_test.go`: both the "reject deletion" and "allow deletion after..." specs.
- `api/v1alpha1/deployment_policy_webhook_test.go`: the identical pair in the legacy `skyhook.nvidia.com` package, where `SkyhookWebhook` is wired the same way (`skyhook_webhook.go:46`).

The remaining policy-referencing specs call the webhook struct directly, and those instances are constructed with `Client: k8sClient` in `BeforeEach`, so they read from the apiserver and do not race. Left alone.

## Verification

- Temporarily instrumented the helper with an attempt counter and ran the suite six times: the cache had not yet observed `policy-to-be-freed` on first read in two of the six runs, needing a second attempt. That is the window that produced the CI flake, and the guard is what closes it. Instrumentation removed before commit.
- Both webhook suites, five repeats each: 43/43 and 130/130 specs green every run.
- `make fmt` clean, `make lint` reports 0 issues, `make unit-tests` passes all 13 suites.

## Notes

- Test-only change. No `docs/` update: no user-visible behavior, CRD field, CLI surface, or lifecycle semantics changed.
- `cachedClient` and the helper are new to these two suite files. The pattern the suites already use (a package-level client set in `BeforeSuite`) is unchanged; this just adds the manager's cached client alongside the direct one, since the two views are what the race is about.
