### PR TITLE
test(operator): wait on the webhook cache when deleting a DeploymentPolicy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # NodeWright (formerly Skyhook)
 
-[![Pipeline Status](https://github.com/NVIDIA/skyhook/actions/workflows/operator-ci.yaml/badge.svg)](https://github.com/NVIDIA/skyhook/actions/workflows/operator-ci.yaml)
-[![Coverage Status](https://coveralls.io/repos/github/NVIDIA/skyhook/badge.svg)](https://coveralls.io/github/NVIDIA/skyhook)
-[![Go Report Card](https://goreportcard.com/badge/github.com/NVIDIA/nodewright/operator)](https://goreportcard.com/report/github.com/NVIDIA/nodewright/operator)
+[![Pipeline Status](https://github.com/NVIDIA/nodewright/actions/workflows/operator-ci.yaml/badge.svg)](https://github.com/NVIDIA/nodewright/actions/workflows/operator-ci.yaml)
+[![Coverage Status](https://coveralls.io/repos/github/NVIDIA/nodewright/badge.svg)](https://coveralls.io/github/NVIDIA/nodewright)
 
 **NodeWright** is a Kubernetes-aware package manager for cluster administrators to safely modify and maintain underlying host declaratively at scale.
 
@@ -333,7 +332,7 @@ Please report security vulnerabilities through [NVIDIA's Security Vulnerability 
 ## Support
 
 - **Support Level:** Maintained
-- **How to get help:** [GitHub Issues](https://github.com/NVIDIA/skyhook/issues) | [GitHub Discussions](https://github.com/NVIDIA/skyhook/discussions)
+- **How to get help:** [GitHub Issues](https://github.com/NVIDIA/nodewright/issues)
 - See [SUPPORT.md](SUPPORT.md) for more details.
 
 ## License

--- a/operator/api/nodewright/v1alpha1/deployment_policy_webhook_test.go
+++ b/operator/api/nodewright/v1alpha1/deployment_policy_webhook_test.go
@@ -21,9 +21,7 @@ package v1alpha1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -333,14 +331,11 @@ var _ = Describe("DeploymentPolicy", func() {
 			Expect(err.Error()).To(ContainSubstring("policy-in-use"))
 			Expect(err.Error()).To(ContainSubstring("test-nodewright-using-policy"))
 
-			// Cleanup. The validating webhook on policy deletion queries NodeWright
-			// references via the client; envtest deletes are async, so the NodeWright
-			// can still be visible to the webhook for a brief window after Delete
-			// returns. Wait for it to actually be gone before deleting the policy.
+			// Cleanup. The validating webhook on policy deletion lists NodeWrights through
+			// the manager's cache, so wait on that cache rather than on k8sClient: the
+			// apiserver reports the delete before the informer has observed it.
 			Expect(k8sClient.Delete(ctx, nodewright)).To(Succeed())
-			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: nodewright.Name}, &NodeWright{}))
-			}, "10s", "100ms").Should(BeTrue())
+			waitForNodeWrightGoneFromWebhookCache(nodewright.Name)
 			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
 		})
 
@@ -384,13 +379,12 @@ var _ = Describe("DeploymentPolicy", func() {
 			}
 			Expect(k8sClient.Create(ctx, nodewright)).To(Succeed())
 
-			// Delete the NodeWright and wait for it to actually be gone before
-			// validating the policy delete — envtest deletes are async, see
-			// the cleanup race in the previous It block.
+			// Wait on the cache the webhook reads, not on the apiserver. ValidateDelete
+			// below lists NodeWrights through the manager's client, so a delete that
+			// k8sClient already reports as gone can still be visible to the informer,
+			// and the policy delete is denied with "still referenced by 1 NodeWright(s)".
 			Expect(k8sClient.Delete(ctx, nodewright)).To(Succeed())
-			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: nodewright.Name}, &NodeWright{}))
-			}, "10s", "100ms").Should(BeTrue())
+			waitForNodeWrightGoneFromWebhookCache(nodewright.Name)
 
 			// Now deletion should succeed
 			_, err := deploymentPolicyWebhook.ValidateDelete(ctx, policy)

--- a/operator/api/nodewright/v1alpha1/webhook_suite_test.go
+++ b/operator/api/nodewright/v1alpha1/webhook_suite_test.go
@@ -33,6 +33,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	//+kubebuilder:scaffold:imports
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -170,4 +171,17 @@ func waitForPolicyInWebhookCache(name string) {
 	Eventually(func() error {
 		return cachedClient.Get(ctx, types.NamespacedName{Name: name}, &DeploymentPolicy{})
 	}, "10s", "100ms").Should(Succeed())
+}
+
+// waitForNodeWrightGoneFromWebhookCache blocks until the manager's cache has observed that
+// the named NodeWright is deleted. Same race as waitForPolicyInWebhookCache, in the removal
+// direction: the DeploymentPolicy validating webhook lists NodeWrights through the cache, so
+// confirming the delete against the apiserver with k8sClient is not enough. The informer can
+// still return the object, and the policy delete is denied with "still referenced by 1
+// NodeWright(s)".
+func waitForNodeWrightGoneFromWebhookCache(name string) {
+	GinkgoHelper()
+	Eventually(func() bool {
+		return apierrors.IsNotFound(cachedClient.Get(ctx, types.NamespacedName{Name: name}, &NodeWright{}))
+	}, "10s", "100ms").Should(BeTrue())
 }

--- a/operator/api/v1alpha1/deployment_policy_webhook_test.go
+++ b/operator/api/v1alpha1/deployment_policy_webhook_test.go
@@ -21,9 +21,7 @@ package v1alpha1
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 )
 
@@ -358,9 +356,7 @@ var _ = Describe("DeploymentPolicy", func() {
 			// can still be visible to the webhook for a brief window after Delete
 			// returns. Wait for it to actually be gone before deleting the policy.
 			Expect(k8sClient.Delete(ctx, skyhook)).To(Succeed())
-			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: skyhook.Name}, &Skyhook{}))
-			}, "10s", "100ms").Should(BeTrue())
+			waitForSkyhookGoneFromWebhookCache(skyhook.Name)
 			Expect(k8sClient.Delete(ctx, policy)).To(Succeed())
 		})
 
@@ -408,9 +404,7 @@ var _ = Describe("DeploymentPolicy", func() {
 			// validating the policy delete — envtest deletes are async, see
 			// the cleanup race in the previous It block.
 			Expect(k8sClient.Delete(ctx, skyhook)).To(Succeed())
-			Eventually(func() bool {
-				return errors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: skyhook.Name}, &Skyhook{}))
-			}, "10s", "100ms").Should(BeTrue())
+			waitForSkyhookGoneFromWebhookCache(skyhook.Name)
 
 			// Now deletion should succeed
 			_, err := deploymentPolicyWebhook.ValidateDelete(ctx, policy)

--- a/operator/api/v1alpha1/webhook_suite_test.go
+++ b/operator/api/v1alpha1/webhook_suite_test.go
@@ -32,6 +32,7 @@ import (
 
 	admissionv1 "k8s.io/api/admission/v1"
 	//+kubebuilder:scaffold:imports
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
@@ -154,4 +155,17 @@ func waitForPolicyInWebhookCache(name string) {
 	Eventually(func() error {
 		return cachedClient.Get(ctx, types.NamespacedName{Name: name}, &DeploymentPolicy{})
 	}, "10s", "100ms").Should(Succeed())
+}
+
+// waitForSkyhookGoneFromWebhookCache blocks until the manager's cache has observed that the
+// named Skyhook is deleted. Deleting a DeploymentPolicy through the apiserver runs the
+// REGISTERED validating webhook, which lists Skyhooks through the manager's cached client —
+// unlike the webhook the specs construct directly, which is handed k8sClient. So a delete
+// that k8sClient already reports as gone can still be visible to that informer, and the
+// policy delete is rejected with "still referenced by 1 Skyhook(s)".
+func waitForSkyhookGoneFromWebhookCache(name string) {
+	GinkgoHelper()
+	Eventually(func() bool {
+		return apierrors.IsNotFound(cachedClient.Get(ctx, types.NamespacedName{Name: name}, &Skyhook{}))
+	}, "10s", "100ms").Should(BeTrue())
 }


### PR DESCRIPTION
Fixes a flaky `unit-tests` job, seen on #463 and reproducible in principle on any PR.

## The failure

```
admission webhook "vdeploymentpolicy-nodewright.kb.io" denied the request:
cannot delete DeploymentPolicy "policy-to-be-freed": still referenced by
1 NodeWright(s): [test-nodewright-temp]
```

`DeploymentPolicy When deleting DeploymentPolicy under Validating Webhook should allow deletion after NodeWrights no longer reference it`, at the **cleanup** line — `Expect(k8sClient.Delete(ctx, policy)).To(Succeed())`.

## Why

The spec deletes its NodeWright, waits for the apiserver to report it gone through `k8sClient`, calls `ValidateDelete` directly, then deletes the policy for cleanup.

That existing wait is **correct for the direct call**: the `deploymentPolicyWebhook` the spec constructs is handed `k8sClient`, so polling `k8sClient` is polling exactly the client it reads.

It does not cover the line after. `k8sClient.Delete(ctx, policy)` goes through the apiserver and therefore through the **registered** webhook running inside the manager — a different instance, holding `mgr.GetClient()`, which reads the informer cache. The apiserver having applied the delete says nothing about whether that informer has observed it yet, so the policy delete is denied and the spec fails.

## The fix

`waitForNodeWrightGoneFromWebhookCache` / `waitForSkyhookGoneFromWebhookCache`, polling `cachedClient` until the object is `NotFound`. Same shape and rationale as `waitForPolicyInWebhookCache` from #467 — wait on the client the webhook actually reads — just in the removal direction, which #467 did not cover. Applied to both API groups, matching #467's scope.

Two call sites per group: the failing spec, and a cleanup in the preceding spec with the identical pattern.

## Verification

Both webhook suites, six consecutive runs (`--repeat=5`): 43/43 and 130/130 specs green each pass. `make lint` clean.

That it was a flake rather than a real regression was also confirmed independently on #463: the Go tree was byte-identical between a commit where `unit-tests` passed and one where it failed, the failing package has no dependency edge to anything that PR changed, and a plain CI re-run went green.

## Unrelated drive-by: README header

The badges still pointed at the pre-rename repository:

- Pipeline and coverage badges now target `NVIDIA/nodewright`.
- The **Go Report Card** badge is removed — the service returns nothing for this module.
- The support line points at this repo's issues, and the **GitHub Discussions** link is dropped since Discussions is not enabled here, so it advertised a channel that does not exist.

`NVIDIA/skyhook-packages` is a genuinely separate repository and is left as-is.
