### PR TITLE
chore: unblock the OSS scorecard Open Source Ready gate

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -152,6 +152,16 @@ Relevant env vars are documented in `agent/README.md`.
 
 kubectl plugin (`kubectl nodewright …`). Subcommands under `app/`: `node`, `package`, `deploymentpolicy`, plus `reset`, `lifecycle` (pause/resume/disable/enable), `version`, `migrate`. Commands go through `operator/internal/cli/client` rather than talking to the apiserver directly. Recent operators use annotations (`nodewright.nvidia.com/pause`, `nodewright.nvidia.com/disable`) for pause/disable — not spec fields (the legacy Skyhook uses the `skyhook.nvidia.com/*` equivalents).
 
+## Secrets and credentials
+
+Hard boundaries. These are not style preferences — violating one means a rotation, not a revert.
+
+- **Never commit credentials, API keys, tokens, passwords, kubeconfigs, or private keys.** Nothing secret belongs in a tracked file: not in Go or Python source, not in test fixtures, not in `chart/values.yaml`, not in chainsaw manifests under `k8s-tests/`, not in `.github/workflows/`, and not in a commit message. Examples use an obvious placeholder (`REPLACE_ME`, `<your-token>`), never a real value that "happens to be expired".
+- **Never read a real credential into your output.** `~/.kube/config`, `~/.docker/config.json`, `~/.ssh/`, `~/.aws/`, and any `.env` are off limits — refer to them by path, don't cat them into the transcript, a file, or a PR description.
+- **Secret-bearing environment variables stay out of tracked files.** CI reads them via `${{ secrets.* }}`; local runs read them from your shell. Don't add a `.env` with real values, and never give a secret-bearing variable a hardcoded fallback default.
+- **Cluster secrets are mounted at runtime, never baked in.** Packages receive them through the mechanism in `docs/providing_secrets_to_packages.md` — a Kubernetes Secret projected into the package pod. Never inline a secret into a package `configMap`, a `NodeWright` CR, or a container image layer.
+- **Found a committed secret? Stop and report it.** Do not quietly delete it in a follow-up commit — the value survives in git history and has to be rotated regardless. Report it through `SECURITY.md`; do not open a public issue.
+
 ## Code style (Go)
 
 ### Working rules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,14 @@ We use a single-owner model: an issue is assigned to at most one person. `/assig
 
 ## Pull Requests
 
+### Open an issue first
+
+Non-trivial changes start with an issue, not a pull request. Open one (or find an existing one), and wait for a maintainer to acknowledge it before you start writing code. The issue is where we confirm the change is wanted, agree on an approach, and tell you if something similar is already in flight — all of which are cheaper to sort out before you have a branch. A pull request that arrives with no linked, acknowledged issue may be closed and asked to start as one.
+
+Trivial changes are exempt: typo and formatting fixes, broken links, and comment corrections can go straight to a pull request.
+
+Reference the issue in your PR description (`closes #1234`) so it closes on merge.
+
 1. Fork the repository and create a branch from `main`.
 2. Make your changes and ensure tests pass (`make test` in the relevant component directory).
 3. Run `make fmt` to format code and add license headers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,10 @@ We use a single-owner model: an issue is assigned to at most one person. `/assig
 
 Non-trivial changes start with an issue, not a pull request. Open one (or find an existing one), and wait for a maintainer to acknowledge it before you start writing code. The issue is where we confirm the change is wanted, agree on an approach, and tell you if something similar is already in flight — all of which are cheaper to sort out before you have a branch. A pull request that arrives with no linked, acknowledged issue may be closed and asked to start as one.
 
-Trivial changes are exempt: typo and formatting fixes, broken links, and comment corrections can go straight to a pull request.
+Two exceptions:
+
+- **Trivial changes** — typo and formatting fixes, broken links, comment corrections — can go straight to a pull request.
+- **Security vulnerabilities never start with a public issue.** Report them through [SECURITY.md](SECURITY.md) instead. PSIRT owns triage and the disclosure date and will coordinate the fix with you, including the pull request itself, so that nothing reveals the issue before the embargo lifts.
 
 Reference the issue in your PR description (`closes #1234`) so it closes on merge.
 

--- a/containers/agentless/Dockerfile
+++ b/containers/agentless/Dockerfile
@@ -14,9 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BUSYBOX_TAG=1.36.1
-
-FROM busybox:${BUSYBOX_TAG}
+# The digest must stay the multi-arch index digest, not a per-platform one:
+# .github/workflows/agentless-container.yaml builds linux/amd64 + linux/arm64
+# from this file, and a platform-specific digest breaks the arm64 leg.
+# Dependabot (docker ecosystem, /containers/**) bumps tag and digest together.
+FROM docker.io/library/busybox:1.36.1@sha256:73aaf090f3d85aa34ee199857f03fa3a95c8ede2ffd4cc2cdb5b94e566b11662
 
 ## might need a better mock than empty folders existing
 RUN mkdir -p /skyhook_package/skyhook_dir /skyhook_package/root_dir


### PR DESCRIPTION
## Description

Clears three of the four signals blocking the **Open Source Ready** gate on the NVIDIA OSS Health Scorecard. The gate is pass/fail over 18 named signals (it ignores the 83.5 overall score), and we currently fail exactly four. This PR fixes the three that live in the repo; the fourth (`SIG-DOC-09`, README must link to `docs.nvidia.com`) needs a real docs.nvidia.com page and is tracked separately.

| Signal | Check | Change |
|---|---|---|
| `SIG-REL-28` | `dockerfile_from_upstream` | Registry-qualify + digest-pin the agentless base image |
| `SIG-CON-07` | `issue_first_workflow_documented` | Issue-first section in `CONTRIBUTING.md` |
| `SIG-AGT-15` | `security_boundaries_stated` | Secrets/credentials section in `AGENTS.md` |

Side effect: `SIG-CICD-24` (`container_base_images_pinned`) also flips to passing.

### Why the base-image change matters more than it looks

`SIG-REL-28` is the **only Level-2 check in the Release Process dimension**, and dimension score is `1.0 + L2 + L3 + L4` pass fractions — so failing this one check alone costs a full point and is what pins Release Process at 2.02. Fixing it takes that dimension to ~3.02.

The scorecard discovers Dockerfiles with `(^|/)dockerfile(\.[^/]*)?$`. That matches `containers/agentless/Dockerfile` but **not** `containers/agent.Dockerfile` or `containers/operator.Dockerfile`, so the only `FROM` it ever saw was the unqualified `busybox:${BUSYBOX_TAG}`. Our real base images (`nvcr.io/nvidia/distroless/*`) are already on its upstream-registry allowlist and were never read.

### Pattern note

The sibling Dockerfiles resolve their base digest at build time through a CI-populated `DISTROLESS_DIGEST_SUFFIX` ARG. I did **not** follow that pattern here: it exists because those images track a moving NVIDIA distroless release, whereas busybox is a fixed third-party pin that Dependabot already maintains (`/containers/**`, docker ecosystem, in `.github/dependabot.yml`). An inline `tag@digest` is the simpler thing Dependabot understands natively. Happy to converge on the ARG pattern instead if reviewers prefer consistency over Dependabot support.

The `BUSYBOX_TAG` ARG is dropped because nothing overrode it and, with a digest present, Docker resolves by digest and ignores the tag — leaving the ARG would have been a silent no-op trap.

## Verification

- `docker buildx build --platform linux/amd64` and `--platform linux/arm64` both build from the pinned digest, pulling their respective layers — confirms it is the multi-arch **index** digest, not a per-platform one (the workflow builds both legs).
- `make license-header-check` passes.
- `AGENTS.md` (symlink → `.claude/CLAUDE.md`) resolves and carries the new section.

No behavioral change to the operator, agent, chart, or CLI — nothing under `docs/` goes stale.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes. — n/a: two docs edits and a base-image reference; the agentless image build in `agentless-container.yaml` is the covering check and runs on this PR.
- [x] The documentation is up to date with these changes.
