### PR TITLE
fix(operator): rename skyhook -> nodewright in operator error and log text

### DIFF
--- a/operator/cmd/manager/main.go
+++ b/operator/cmd/manager/main.go
@@ -163,14 +163,14 @@ func main() {
 	cont, err := controller.NewSkyhookReconciler(
 		mgr.GetScheme(),
 		mgr.GetClient(),
-		mgr.GetEventRecorder("skyhook-controller"),
+		mgr.GetEventRecorder("nodewright-controller"),
 		options.SkyhookOperatorOptions)
 	if err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Skyhook")
+		setupLog.Error(err, "unable to create controller", "controller", "NodeWright")
 		os.Exit(1)
 	}
 	if err = cont.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Skyhook")
+		setupLog.Error(err, "unable to create controller", "controller", "NodeWright")
 		os.Exit(1)
 	}
 

--- a/operator/internal/controller/cluster_state_v2.go
+++ b/operator/internal/controller/cluster_state_v2.go
@@ -1563,7 +1563,7 @@ func (skyhook *skyhookNodes) Migrate(logger logr.Logger) error {
 	}
 
 	if err := skyhook.skyhook.Migrate(logger); err != nil {
-		return fmt.Errorf("error migrating skyhook [%s]: %w", skyhook.skyhook.Name, err)
+		return fmt.Errorf("error migrating nodewright [%s]: %w", skyhook.skyhook.Name, err)
 	}
 
 	if from == "" { // before this was a thing v0.4.0 and before
@@ -1587,7 +1587,7 @@ func (skyhook *skyhookNodes) AddCompartment(name string, compartment *wrapper.Co
 func (skyhook *skyhookNodes) AddCompartmentNode(name string, node wrapper.SkyhookNode) error {
 	compartment, ok := skyhook.compartments[name]
 	if !ok {
-		return fmt.Errorf("compartment %q not found for skyhook %q - missing deployment policy", name, skyhook.skyhook.Name)
+		return fmt.Errorf("compartment %q not found for nodewright %q - missing deployment policy", name, skyhook.skyhook.Name)
 	}
 	compartment.AddNode(node)
 	return nil

--- a/operator/internal/controller/cluster_state_v2.go
+++ b/operator/internal/controller/cluster_state_v2.go
@@ -909,9 +909,9 @@ func (s *skyhookNodes) UpdateCondition(logger logr.Logger) bool {
 	byStatus := wrapper.SkyhookReadyConditionStatusGroups(nodeStatuses, nodeNames)
 
 	if wrapper.SkyhookReadyConditionMessageTruncated(byStatus) {
-		logger.WithName("skyhook-ready-condition").Info(
+		logger.WithName("nodewright-ready-condition").Info(
 			"Ready condition message truncated; full per-status node lists",
-			"skyhook", s.skyhook.Name,
+			"nodewright", s.skyhook.Name,
 			"complete", byStatus[v1alpha1.StatusComplete],
 			"inProgress", byStatus[v1alpha1.StatusInProgress],
 			"blocked", byStatus[v1alpha1.StatusBlocked],
@@ -1112,7 +1112,7 @@ func (np *NodePicker) updateTaintToleranceCondition(s SkyhookNodes, nodesWithTai
 	if len(nodesWithTaintTolerationIssue) > 0 {
 		message := fmt.Sprintf("Node [%s] has taints that are not tolerable. Skipping.", strings.Join(nodesWithTaintTolerationIssue, ", "))
 		if len(nodesWithTaintTolerationIssue) > wrapper.ReadyConditionNodeListLimit {
-			np.logger.Info("Condition message truncated for nodes with taint toleration issues", "skyhook", s.GetSkyhook().Name, "nodes", nodesWithTaintTolerationIssue)
+			np.logger.Info("Condition message truncated for nodes with taint toleration issues", "nodewright", s.GetSkyhook().Name, "nodes", nodesWithTaintTolerationIssue)
 			message = fmt.Sprintf("%d nodes have taints that are not tolerable. Skipping.", len(nodesWithTaintTolerationIssue))
 		}
 
@@ -1141,7 +1141,7 @@ func (np *NodePicker) updateIgnoredNodesCondition(s SkyhookNodes, ignoredNodes [
 	if len(ignoredNodes) > 0 {
 		message := fmt.Sprintf("Node [%s] has ignore label set. Skipping.", strings.Join(ignoredNodes, ", "))
 		if len(ignoredNodes) > wrapper.ReadyConditionNodeListLimit {
-			np.logger.Info("Condition message truncated for ignored nodes", "skyhook", s.GetSkyhook().Name, "nodes", ignoredNodes)
+			np.logger.Info("Condition message truncated for ignored nodes", "nodewright", s.GetSkyhook().Name, "nodes", ignoredNodes)
 			message = fmt.Sprintf("%d nodes have ignore label set. Skipping.", len(ignoredNodes))
 		}
 

--- a/operator/internal/controller/event_handler.go
+++ b/operator/internal/controller/event_handler.go
@@ -112,7 +112,7 @@ func (h *globalDelayHandler) relevant(ctx context.Context, object client.Object)
 	case *corev1.Node:
 		list, err := h.dal.GetSkyhooks(ctx)
 		if err != nil {
-			return false, fmt.Errorf("listing skyhooks for node relevance check: %w", err)
+			return false, fmt.Errorf("listing nodewrights for node relevance check: %w", err)
 		}
 		if list == nil {
 			return false, nil

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -257,7 +257,7 @@ func NewSkyhookReconciler(schema *runtime.Scheme, c client.Client, recorder even
 
 	err := opts.Validate()
 	if err != nil {
-		return nil, fmt.Errorf("invalid skyhook operator options: %w", err)
+		return nil, fmt.Errorf("invalid nodewright operator options: %w", err)
 	}
 
 	return &SkyhookReconciler{
@@ -555,7 +555,7 @@ func (r *SkyhookReconciler) processSkyhooksPerNode(ctx context.Context, clusterS
 		}
 		hasWork, err := skyhook.HasUninstallWork()
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error checking uninstall work for skyhook %s: %w", skyhook.GetSkyhook().Name, err))
+			errs = append(errs, fmt.Errorf("error checking uninstall work for nodewright %s: %w", skyhook.GetSkyhook().Name, err))
 			continue
 		}
 		if skyhook.IsComplete() && !hasWork {
@@ -565,7 +565,7 @@ func (r *SkyhookReconciler) processSkyhooksPerNode(ctx context.Context, clusterS
 		// Check if any nodes are ready for this skyhook
 		ready, err := hasReadyNodesForSkyhook(skyhook, clusterState.skyhooks)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("error checking ready nodes for skyhook %s: %w", skyhook.GetSkyhook().Name, err))
+			errs = append(errs, fmt.Errorf("error checking ready nodes for nodewright %s: %w", skyhook.GetSkyhook().Name, err))
 			continue
 		}
 		if !ready {
@@ -631,11 +631,11 @@ func (r *SkyhookReconciler) HandleMigrations(ctx context.Context, clusterState *
 
 		err := skyhook.Migrate(logger)
 		if err != nil {
-			return false, fmt.Errorf("error migrating skyhook [%s]: %w", skyhook.GetSkyhook().Name, err)
+			return false, fmt.Errorf("error migrating nodewright [%s]: %w", skyhook.GetSkyhook().Name, err)
 		}
 
 		if err := skyhook.GetSkyhook().NodeWright.Validate(); err != nil {
-			return false, fmt.Errorf("error validating skyhook [%s]: %w", skyhook.GetSkyhook().Name, err)
+			return false, fmt.Errorf("error validating nodewright [%s]: %w", skyhook.GetSkyhook().Name, err)
 		}
 
 		// MIGRATION-SHIM: rollback-safe legacy cleanup. skyhook.Migrate above adopts
@@ -672,7 +672,7 @@ func (r *SkyhookReconciler) HandleMigrations(ctx context.Context, clusterState *
 		// the legacy skyhook.nvidia.com labels.
 		hadLegacyWorkloads, workloadsChanged, err := r.reconcileLegacyLabeledWorkloads(ctx, nw, prune)
 		if err != nil {
-			return false, fmt.Errorf("error reconciling legacy-labeled workloads for skyhook [%s]: %w", skyhook.GetSkyhook().Name, err)
+			return false, fmt.Errorf("error reconciling legacy-labeled workloads for nodewright [%s]: %w", skyhook.GetSkyhook().Name, err)
 		}
 		if workloadsChanged {
 			updates = true
@@ -683,7 +683,7 @@ func (r *SkyhookReconciler) HandleMigrations(ctx context.Context, clusterState *
 			// additionally it needs to be an update, a patch nils out the annotations for some reason, which the save function does a patch
 
 			if err = r.Status().Update(ctx, skyhook.GetSkyhook().NodeWright); err != nil {
-				return false, fmt.Errorf("error updating during migration skyhook status [%s]: %w", skyhook.GetSkyhook().Name, err)
+				return false, fmt.Errorf("error updating during migration nodewright status [%s]: %w", skyhook.GetSkyhook().Name, err)
 			}
 
 			// because of conflict issues (409) we need to do things a bit differently here.
@@ -695,7 +695,7 @@ func (r *SkyhookReconciler) HandleMigrations(ctx context.Context, clusterState *
 
 			newskyhook, err := r.dal.GetSkyhook(ctx, skyhook.GetSkyhook().Name)
 			if err != nil {
-				return false, fmt.Errorf("error getting skyhook to migrate [%s]: %w", skyhook.GetSkyhook().Name, err)
+				return false, fmt.Errorf("error getting nodewright to migrate [%s]: %w", skyhook.GetSkyhook().Name, err)
 			}
 			newPatch := client.MergeFrom(newskyhook.DeepCopy())
 
@@ -703,7 +703,7 @@ func (r *SkyhookReconciler) HandleMigrations(ctx context.Context, clusterState *
 			wrapper.NewSkyhookWrapper(newskyhook).SetVersion()
 
 			if err = r.Patch(ctx, newskyhook, newPatch); err != nil {
-				return false, fmt.Errorf("error updating during migration skyhook [%s]: %w", skyhook.GetSkyhook().Name, err)
+				return false, fmt.Errorf("error updating during migration nodewright [%s]: %w", skyhook.GetSkyhook().Name, err)
 			}
 
 			updates = true
@@ -789,7 +789,7 @@ func (r *SkyhookReconciler) reconcileLegacyLabeledWorkloads(ctx context.Context,
 	pods := &corev1.PodList{}
 	if err := r.List(ctx, pods, client.InNamespace(r.opts.Namespace),
 		client.MatchingLabels{legacyNameLabel: skyhookName}); err != nil {
-		return false, false, fmt.Errorf("listing legacy-labeled pods for skyhook [%s]: %w", skyhookName, err)
+		return false, false, fmt.Errorf("listing legacy-labeled pods for nodewright [%s]: %w", skyhookName, err)
 	}
 	if len(pods.Items) > 0 {
 		hadLegacy = true
@@ -826,7 +826,7 @@ func (r *SkyhookReconciler) reconcileLegacyLabeledWorkloads(ctx context.Context,
 		cms := &corev1.ConfigMapList{}
 		if err := r.List(ctx, cms, client.InNamespace(r.opts.Namespace),
 			client.MatchingLabels{labelKey: skyhookName}); err != nil {
-			return false, false, fmt.Errorf("listing legacy-labeled configmaps by [%s] for skyhook [%s]: %w", labelKey, skyhookName, err)
+			return false, false, fmt.Errorf("listing legacy-labeled configmaps by [%s] for nodewright [%s]: %w", labelKey, skyhookName, err)
 		}
 		for i := range cms.Items {
 			cm := &cms.Items[i]
@@ -1112,7 +1112,7 @@ func (r *SkyhookReconciler) TrackReboots(ctx context.Context, clusterState *clus
 			updates = true
 			err := r.Status().Update(ctx, skyhook.GetSkyhook().NodeWright)
 			if err != nil {
-				errs = append(errs, fmt.Errorf("error updating skyhook status after reboot [%s]: %w", skyhook.GetSkyhook().Name, err))
+				errs = append(errs, fmt.Errorf("error updating nodewright status after reboot [%s]: %w", skyhook.GetSkyhook().Name, err))
 			}
 		}
 	}
@@ -1904,7 +1904,7 @@ func (r *SkyhookReconciler) HandleFinalizer(ctx context.Context, skyhook Skyhook
 			controllerutil.AddFinalizer(skyhook.GetSkyhook().NodeWright, SkyhookFinalizer)
 
 			if err := r.Update(ctx, skyhook.GetSkyhook().NodeWright); err != nil {
-				return false, fmt.Errorf("error updating skyhook to add finalizer: %w", err)
+				return false, fmt.Errorf("error updating nodewright to add finalizer: %w", err)
 			}
 		}
 	} else { // being deleted
@@ -2076,12 +2076,12 @@ func (r *SkyhookReconciler) HandleFinalizer(ctx context.Context, skyhook Skyhook
 			// re-triggering add-finalizer logic.)
 			skyhook.GetSkyhook().Status.ObservedGeneration = skyhook.GetSkyhook().Status.ObservedGeneration + 1
 			if err := r.Status().Update(ctx, skyhook.GetSkyhook().NodeWright); err != nil {
-				return false, fmt.Errorf("error updating skyhook status: %w", err)
+				return false, fmt.Errorf("error updating nodewright status: %w", err)
 			}
 
 			controllerutil.RemoveFinalizer(skyhook.GetSkyhook().NodeWright, SkyhookFinalizer)
 			if err := r.Update(ctx, skyhook.GetSkyhook().NodeWright); err != nil {
-				return false, fmt.Errorf("error updating skyhook removing finalizer: %w", err)
+				return false, fmt.Errorf("error updating nodewright removing finalizer: %w", err)
 			}
 
 			return true, nil
@@ -2409,7 +2409,7 @@ func (r *SkyhookReconciler) ValidateNodeConfigmaps(ctx context.Context, skyhookN
 	// Ensure packages.json is present and up-to-date for expected configmaps
 	skyhookCR, err := r.dal.GetSkyhook(ctx, skyhookName)
 	if err != nil {
-		return update, fmt.Errorf("error getting skyhook for metadata validation: %w", err)
+		return update, fmt.Errorf("error getting nodewright for metadata validation: %w", err)
 	}
 	skyhookWrapper := wrapper.NewSkyhookWrapper(skyhookCR)
 	metadata := NewSkyhookMetadata(r.opts, skyhookWrapper)

--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -373,7 +373,7 @@ func (r *SkyhookReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	skyhooks, err := r.dal.GetSkyhooks(ctx)
 	if err != nil {
 		// error, going to requeue and backoff
-		logger.Error(err, "error getting skyhooks")
+		logger.Error(err, "error getting nodewrights")
 		return ctrl.Result{}, err
 	}
 
@@ -574,7 +574,7 @@ func (r *SkyhookReconciler) processSkyhooksPerNode(ctx context.Context, clusterS
 
 		res, err := r.RunSkyhookPackages(ctx, clusterState, nodePicker, skyhook)
 		if err != nil {
-			logger.Error(err, "error processing skyhook", "skyhook", skyhook.GetSkyhook().Name)
+			logger.Error(err, "error processing nodewright", "nodewright", skyhook.GetSkyhook().Name)
 			errs = append(errs, err)
 		}
 		if res != nil {

--- a/operator/internal/controller/suite_test.go
+++ b/operator/internal/controller/suite_test.go
@@ -118,7 +118,7 @@ var _ = BeforeSuite(func() {
 	operator, err = NewSkyhookReconciler(
 		k8sManager.GetScheme(),
 		k8sManager.GetClient(),
-		k8sManager.GetEventRecorder("skyhook-controller"),
+		k8sManager.GetEventRecorder("nodewright-controller"),
 		opts,
 	)
 	Expect(err).ToNot(HaveOccurred())

--- a/operator/internal/dal/dal.go
+++ b/operator/internal/dal/dal.go
@@ -59,7 +59,7 @@ func (e *dal) GetSkyhook(ctx context.Context, name string, opts ...client.ListOp
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("error getting skyhook [%s]: %w", name, err)
+		return nil, fmt.Errorf("error getting nodewright [%s]: %w", name, err)
 	}
 
 	return &skyhook, nil
@@ -72,7 +72,7 @@ func (e *dal) GetSkyhooks(ctx context.Context, opts ...client.ListOption) (*skyh
 		if apierrors.IsNotFound(err) {
 			return nil, nil
 		}
-		return nil, fmt.Errorf("error getting skyhooks: %w", err)
+		return nil, fmt.Errorf("error getting nodewrights: %w", err)
 	}
 
 	if len(skyhook.Items) == 0 {


### PR DESCRIPTION
Closes #403. Supersedes #414.

Finishes the operator's user-visible text rename. #410 landed part 1 (event and condition text); this PR carries part 2 (`fmt.Errorf` text) and part 3 (log messages and keys).

## Credit

The part 2 commit is **@mohityadav8's**, authored by them and preserved as such. I re-applied their original commit (`f88c4079`, from before the merge-ups) onto current `main` rather than patching their merged-up branch, because that is what makes the defect below go away by construction. Part 3 is mine.

## What #414 hit, and why this branch is not affected

@ayuskauskas found in https://github.com/NVIDIA/nodewright/pull/414#discussion_r3759417593 that #414's `reconcileLegacyLabeledWorkloads` was a partial revert of #380, not a rename. The `f49c695a` merge of `main`@`84df6448` resolved a conflict in favour of the branch's pre-#380 side and dropped three things: the two-key legacy ConfigMap sweep, the `reparentToNodeWright` call, and `changed = true` after a successful `Update`.

Cherry-picking the pre-merge commit means that resolution never enters this history. The one conflict that did arise (the same function) was resolved by keeping `main`'s code and re-applying only the string edit on top, so `git diff origin/main -- operator/internal/controller/skyhook_controller.go` is text-only. All three dropped pieces are present.

## Two observability breaks, deliberate

Renaming the structured-log key and the event source component is not cosmetic, so calling them out rather than letting them surprise someone:

- A log query matching `skyhook=<name>` needs to become `nodewright=<name>`.
- `kubectl get events --field-selector source=skyhook-controller` needs `source=nodewright-controller`.

Nothing else about the event surface changed; #410 already renamed the messages themselves.

## Out of scope, unchanged on purpose

Go identifiers (`SkyhookReconciler`, `wrapper.SkyhookNode`, filenames), the agent contract surfaces (`SKYHOOK_RESOURCE_ID`, `/skyhook-package/*`, `/var/lib/skyhook`), the legacy migration shims and the legacy Skyhook webhook, whose text genuinely refers to `skyhook.nvidia.com` resources, the deprecated `skyhook_*` metrics (owned by #462), and the CLI.

A sweep over `operator/` confirms every surviving `skyhook` literal falls into one of those buckets.

## Testing

`make unit-tests`: 13 suites, 851 specs, 0 failures. `make manifests generate` produces no drift. No test or chainsaw file asserts on any renamed string.

## Note for whoever merges

#459 touches 5 of the 7 files here. Whichever lands second needs a re-resolve, and the resolution is the exact trap that broke #414, so it is worth taking `main`'s side and re-applying the string edits rather than accepting either side wholesale.
