### PR TITLE
test(e2e): decouple reap_old_logs from the stage retry budget

### DIFF
--- a/.github/workflows/agent-ci.yaml
+++ b/.github/workflows/agent-ci.yaml
@@ -22,6 +22,7 @@ on:
     paths:
       - agent/**
       - '!agent/go/**'
+      - k8s-tests/operator-agent/**
       - containers/agent.Dockerfile
       - .github/actions/**
       - operator/versions.yaml
@@ -36,6 +37,7 @@ on:
     paths:
       - agent/**
       - '!agent/go/**'
+      - k8s-tests/operator-agent/**
       - containers/agent.Dockerfile
       - .github/actions/**
       - operator/versions.yaml

--- a/k8s-tests/operator-agent/reap_old_logs/chainsaw-test.yaml
+++ b/k8s-tests/operator-agent/reap_old_logs/chainsaw-test.yaml
@@ -38,13 +38,34 @@ spec:
           ## clean up from prior runs
           ../check_node.sh kind-worker "rm -rf /var/log/skyhook/reap-old-logs-agent-operator || true" ".*" 2
           ../check_node.sh kind-worker "rm -rf /var/lib/skyhook/reap-old-logs-agent-operator || true" ".*" 2
+    - script:
+        content: |
+          ## Seed more logs than the agent keeps, so the package has something to reap on its
+          ## first attempt. Deliberately not driven by repeated failures: the operator gives a
+          ## stage only JOB_BACKOFF_LIMIT+1 attempts, so a test that needs N failed attempts to
+          ## produce N logs silently re-encodes that budget and breaks when it changes.
+          ## The seeds carry real timestamps rather than an obvious placeholder because the Go
+          ## agent parses the timestamp out of the name and skips any log it cannot parse, so a
+          ## placeholder would be reaped by the Python agent and ignored by the Go one (#221).
+          dir=/var/log/skyhook/reap-old-logs-agent-operator/shellscript/1.1.1
+          ../check_node.sh kind-worker "mkdir -p $dir && touch $dir/shellscript_run.sh-2020-01-0{1,2,3,4,5,6,7}-000000.log && ls $dir/*.log | wc -l" '^7$' 2
     - apply:
         file: nodewright.yaml
     - assert:
         file: assert.yaml
     - script:
         content: |
-          ../check_node.sh kind-worker "ls /var/log/skyhook/reap-old-logs-agent-operator/shellscript/1.1.1/*.log | wc -l" "5" 2
+          ## 7 seeds plus this attempt's own logs come back down to 5. Counting survivors rather
+          ## than naming them keeps this agnostic about which 5: the Python agent ranks by mtime,
+          ## where all 7 seeds tie, and the Go agent ranks by the timestamp in the name. ls -rt
+          ## lists oldest first, so a failure prints the surviving set rather than just a count.
+          dir=/var/log/skyhook/reap-old-logs-agent-operator/shellscript/1.1.1
+          ../check_node.sh kind-worker "ls -rt $dir/*.log | wc -l" '^5$' 5
+          ## One attempt writes 4 logs (apply and config, each with its check step) and only the
+          ## apply step echoes this, making it the oldest of the four. Finding it in a survivor
+          ## pins that the reaper counted from the newest end rather than trimming the wrong
+          ## side, which the count alone would pass either way.
+          ../check_node.sh kind-worker "cat $dir/*.log" 'newest' 5
   - finally:
     - delete:
         file: nodewright.yaml

--- a/k8s-tests/operator-agent/reap_old_logs/nodewright.yaml
+++ b/k8s-tests/operator-agent/reap_old_logs/nodewright.yaml
@@ -32,11 +32,4 @@ spec:
       configMap:
         apply.sh: |-
           #!/bin/bash
-          sleep 1
-          if [ $(ls /var/log/skyhook/reap-old-logs-agent-operator/shellscript/1.1.1/*.log | wc -l) -eq 5 ]; then
-            echo "5 logs found. After this should still be 5."
-            exit 0
-          else
-            echo "Not enough logs yet. Erroring to produce more."
-            exit 1
-          fi
+          echo "reap-old-logs: this attempt's log is the newest of the set"


### PR DESCRIPTION
## Description

closes #488

`chainsaw/reap-old-logs-agent-operator` fails on every run. The test drove log accumulation by failing on purpose until 5 log files existed, which only worked while a failing package was retried without bound. Package stages now run under a finite Job `backoffLimit` (`JOB_BACKOFF_LIMIT`, default 3), so a stage gets 4 attempts and can produce at most 4 logs. It asks for 5, so it parks at `erroring` and both asserts time out.

The operator is behaving as designed here; the bounded budget is intentional and already documented in `operator/RELEASE_NOTES.md`. This is a stale test, not an operator regression, and nothing in this PR changes operator behaviour.

It went unnoticed because Agent CI only triggers on `agent/**`, so it never ran against the operator-only Jobs migration (#459). The last green Agent CI run was 2026-08-07; the failure appeared on the next PR that happened to touch `agent/`.

## What changed

The test no longer depends on how many attempts a failing stage gets.

- **`nodewright.yaml`** — `apply.sh` succeeds on the first attempt instead of crash-looping.
- **`chainsaw-test.yaml`** — a setup step seeds 7 surplus `.log` files on the node, and the final step asserts what survived.

```
../check_node.sh kind-worker "mkdir -p $dir && touch $dir/shellscript_run.sh-seed-{1,2,3,4,5,6,7}.log && ls $dir/*.log | wc -l" '^7$' 2
../check_node.sh kind-worker "ls -rt $dir/*.log | wc -l" '^5$' 5
../check_node.sh kind-worker "cat $dir/*.log" 'newest' 5
```

Counting survivors rather than naming them is what lets the seeds share an mtime second, which leaves their order among themselves arbitrary. `ls -rt` means a failure prints the set in the order the reaper judged it.

## This is the first version of the test that reaches the trim path

The old script exited 0 at exactly 5 logs, so `cleanup_old_logs`' `log_files[5:]` slice was always empty and nothing was ever reaped. The behaviour the test is named for has never been covered until now.

The surviving-log grep also pins the *direction* of the trim, which the count alone would pass either way: one attempt writes 4 logs (apply and config, each with its check step) and only the apply step echoes, making it the oldest of the four. Finding it among the survivors proves the reaper counted from the newest end.

## Agent CI could not see this suite

`agent-ci.yaml` is the only workflow that runs `operator-agent-tests`, but its path filters did not include `k8s-tests/operator-agent/**`. As opened, this PR fixed a test that CI would not run. Both the `pull_request` and `push` filters now include that directory, so the suite is exercised whenever it changes.

This narrows the blind spot rather than closing it: the original break came from an operator-only change (#459), and Agent CI still does not watch `operator/**`. That is a CI-budget call worth its own issue rather than a release-eve change.

## Review follow-up

CodeRabbit flagged the seed filenames. Its stated failure mode does not apply to the Python agent this suite runs (that reaper sorts by mtime and never parses the name, which three green local runs confirm), but the concern is real for the Go agent in `agent/go/internal/flags/logs.go`, which skips logs whose timestamp will not parse and which #221 plans to point at this suite. Seeds now carry real timestamps, so they reap correctly under either ranking. Details on the thread.

## Verification

Full `operator-agent-tests` suite against a local kind cluster, `AGENT_IMAGE=ghcr.io/nvidia/nodewright/agent:v6.4.2`:

```
--- PASS: chainsaw/dont-write-logs-agent-operator (28.92s)
--- PASS: chainsaw/reap-old-logs-agent-operator (30.42s)
--- PASS: chainsaw/simple-agent-operator (28.86s)
--- PASS: chainsaw/interrupt-agent-operator (50.27s)
- Passed  tests 4 / Failed 0
```

30s against the 486s failure in CI. `yamllint -c ci/yamllint.yaml` clean.

The assertions were confirmed to bite rather than pass vacuously: an intermediate revision failed on a wrong expected count (`Data: 1, Check: ^4$`), which is how the 4-logs-per-attempt behaviour was found.

## Found while here, not fixed

The agent writes stderr to `{log_path}.err` (`controller.py:260`), but `cleanup_old_logs` globs `{step}-*.log`, which can never match a name ending in `.err`. Nothing else deletes them, so they accumulate one per attempt forever on every node. Unrelated to this test and left for its own issue.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.