### PR TITLE
fix(chart): fully qualify alpine/kubectl image for short-name-enforcing runtimes

### DIFF
--- a/chart/templates/cleanup-skyhooks-job.yaml
+++ b/chart/templates/cleanup-skyhooks-job.yaml
@@ -57,7 +57,7 @@ spec:
         emptyDir: {}
       containers:
       - name: cleanup
-        image: {{ .Values.webhook.removalImage | default "alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
+        image: {{ .Values.webhook.removalImage | default "docker.io/alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
         imagePullPolicy: Always
         env:
         - name: KUBECACHEDIR

--- a/chart/templates/cleanup-webhook-job.yaml
+++ b/chart/templates/cleanup-webhook-job.yaml
@@ -56,7 +56,7 @@ spec:
         emptyDir: {}
       containers:
       - name: cleanup
-        image: {{ .Values.webhook.removalImage | default "alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
+        image: {{ .Values.webhook.removalImage | default "docker.io/alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
         imagePullPolicy: Always
         env:
         - name: KUBECACHEDIR

--- a/chart/templates/selector-migration-job.yaml
+++ b/chart/templates/selector-migration-job.yaml
@@ -71,7 +71,7 @@ spec:
         emptyDir: {}
       containers:
       - name: selector-migration
-        image: {{ .Values.webhook.removalImage | default "alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
+        image: {{ .Values.webhook.removalImage | default "docker.io/alpine/kubectl" }}{{- if .Values.webhook.removalDigest }}{{- if .Values.webhook.removalTag }}:{{ .Values.webhook.removalTag | default "latest" }}@{{ .Values.webhook.removalDigest }}{{- else }}@{{ .Values.webhook.removalDigest }}{{- end }}{{- else }}:{{ .Values.webhook.removalTag | default "latest" }}{{- end }}
         imagePullPolicy: Always
         env:
         - name: KUBECACHEDIR

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -175,7 +175,8 @@ webhook:
   ## pre-delete hooks and the selector-migration pre-upgrade hook). Pinned to a
   ## maintained, versioned, multi-arch alpine/kubectl release; keep the tag in
   ## skew with the supported Kubernetes range and bump per docs/contributing/release-process.md.
-  removalImage: alpine/kubectl
+  ## Keep the registry host explicit: short-name-enforcing runtimes reject unqualified references.
+  removalImage: docker.io/alpine/kubectl
   removalTag: 1.36.2
   removalDigest: "sha256:01d138ce994b684abc62d9cfdff44de42a4c8996dcc12626dd0193afc3fb5a95"
 

--- a/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
+++ b/k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml
@@ -253,7 +253,7 @@ spec:
           helm template test-release ${CHART} -n nodewright \
             -s templates/selector-migration-job.yaml
         check:
-          "(contains($stdout, 'image: alpine/kubectl'))": true
+          "(contains($stdout, 'image: docker.io/alpine/kubectl'))": true
           ## must stay digest-pinned, not a floating tag
           "(contains($stdout, '@sha256:'))": true
           "(contains($stdout, 'bitnami'))": false


### PR DESCRIPTION
## Summary

The maintenance-job kubectl image (the `selector-migration` pre-upgrade hook and the webhook/skyhook cleanup pre-delete hooks) was referenced by the short name `alpine/kubectl`. Container runtimes that enforce short-name resolution (e.g. OCI OKE) reject the ambiguous reference, so the PreSync hook Job fails with `ErrImagePull`, exhausts its backoff/deadline, and blocks the entire ArgoCD Application sync before the operator or CRDs ever install.

Fixes #481

## Changes

- `chart/values.yaml`: `webhook.removalImage` default is now `docker.io/alpine/kubectl` (tag/digest pinning unchanged), with a one-line comment on why the registry host must stay explicit.
- `chart/templates/{selector-migration-job,cleanup-webhook-job,cleanup-skyhooks-job}.yaml`: the inline `default "alpine/kubectl"` fallbacks are qualified the same way (covers `removalImage: ""`).
- `k8s-tests/chainsaw/helm/helm-template-test/chainsaw-test.yaml`: the image assertion now checks for `image: docker.io/alpine/kubectl`.

No docs updates needed: `docs/contributing/release-process.md` already uses `docker://docker.io/alpine/kubectl` in its skopeo pinning instructions, and there is no kustomize mirror of these Helm-only hook Jobs under `operator/config/`.

## Testing

- `helm template` renders `docker.io/alpine/kubectl:1.36.2@sha256:01d138ce…` in all three hook Jobs, both with default values and with `--set webhook.removalImage=""` (fallback path).
- chainsaw `helm-template` test passes locally against a kind cluster (it asserts the updated image line, digest pinning, and selector-migration script behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)