### PR TITLE
test(operator): cover pure-logic gaps in the nodewright API, wrapper, version and CLI utils

### DIFF
--- a/operator/api/nodewright/v1alpha1/deployment_policy_types_test.go
+++ b/operator/api/nodewright/v1alpha1/deployment_policy_types_test.go
@@ -1,0 +1,473 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("DeploymentStrategy", func() {
+
+	Describe("getBatchThreshold", func() {
+		It("should return default 100 when receiver is nil", func() {
+			var s *DeploymentStrategy
+			Expect(s.getBatchThreshold()).To(Equal(100))
+		})
+
+		It("should return default 100 when strategy is empty", func() {
+			s := &DeploymentStrategy{}
+			Expect(s.getBatchThreshold()).To(Equal(100))
+		})
+
+		It("should return default 100 when Fixed strategy exists but BatchThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(100))
+		})
+
+		It("should return value when Fixed strategy has BatchThreshold set", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{
+					BatchThreshold: ptr.To(80),
+				},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(80))
+		})
+
+		It("should return default 100 when Linear strategy exists but BatchThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(100))
+		})
+
+		It("should return value when Linear strategy has BatchThreshold set", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{
+					BatchThreshold: ptr.To(90),
+				},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(90))
+		})
+
+		It("should return default 100 when Exponential strategy exists but BatchThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(100))
+		})
+
+		It("should return value when Exponential strategy has BatchThreshold set", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{
+					BatchThreshold: ptr.To(75),
+				},
+			}
+			Expect(s.getBatchThreshold()).To(Equal(75))
+		})
+	})
+
+	Describe("getSafetyLimit", func() {
+		It("should return default 50 when receiver is nil", func() {
+			var s *DeploymentStrategy
+			Expect(s.getSafetyLimit()).To(Equal(50))
+		})
+
+		It("should return default 50 when strategy is empty", func() {
+			s := &DeploymentStrategy{}
+			Expect(s.getSafetyLimit()).To(Equal(50))
+		})
+
+		It("should return default 50 when Fixed strategy exists but SafetyLimit is nil", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(50))
+		})
+
+		It("should return value when Fixed strategy has SafetyLimit set", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{
+					SafetyLimit: ptr.To(30),
+				},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(30))
+		})
+
+		It("should return default 50 when Linear strategy exists but SafetyLimit is nil", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(50))
+		})
+
+		It("should return value when Linear strategy has SafetyLimit set", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{
+					SafetyLimit: ptr.To(40),
+				},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(40))
+		})
+
+		It("should return default 50 when Exponential strategy exists but SafetyLimit is nil", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(50))
+		})
+
+		It("should return value when Exponential strategy has SafetyLimit set", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{
+					SafetyLimit: ptr.To(60),
+				},
+			}
+			Expect(s.getSafetyLimit()).To(Equal(60))
+		})
+	})
+
+	Describe("getFailureThreshold", func() {
+		It("should return nil when receiver is nil", func() {
+			var s *DeploymentStrategy
+			Expect(s.getFailureThreshold()).To(BeNil())
+		})
+
+		It("should return nil when strategy is empty", func() {
+			s := &DeploymentStrategy{}
+			Expect(s.getFailureThreshold()).To(BeNil())
+		})
+
+		It("should return nil when Fixed strategy exists but FailureThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{},
+			}
+			Expect(s.getFailureThreshold()).To(BeNil())
+		})
+
+		It("should return value when Fixed strategy has FailureThreshold set", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{
+					FailureThreshold: ptr.To(3),
+				},
+			}
+			Expect(s.getFailureThreshold()).To(HaveValue(Equal(3)))
+		})
+
+		It("should return nil when Linear strategy exists but FailureThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{},
+			}
+			Expect(s.getFailureThreshold()).To(BeNil())
+		})
+
+		It("should return value when Linear strategy has FailureThreshold set", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{
+					FailureThreshold: ptr.To(5),
+				},
+			}
+			Expect(s.getFailureThreshold()).To(HaveValue(Equal(5)))
+		})
+
+		It("should return nil when Exponential strategy exists but FailureThreshold is nil", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{},
+			}
+			Expect(s.getFailureThreshold()).To(BeNil())
+		})
+
+		It("should return value when Exponential strategy has FailureThreshold set", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{
+					FailureThreshold: ptr.To(2),
+				},
+			}
+			Expect(s.getFailureThreshold()).To(HaveValue(Equal(2)))
+		})
+	})
+
+	Describe("CalculateBatchSize dispatch", func() {
+		It("should delegate to the Fixed strategy", func() {
+			s := &DeploymentStrategy{
+				Fixed: &FixedStrategy{InitialBatch: ptr.To(4)},
+			}
+			Expect(s.CalculateBatchSize(10, &BatchProcessingState{})).To(Equal(4))
+		})
+
+		It("should delegate to the Linear strategy", func() {
+			s := &DeploymentStrategy{
+				Linear: &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(1), SafetyLimit: ptr.To(50)},
+			}
+			Expect(s.CalculateBatchSize(10, &BatchProcessingState{})).To(Equal(3))
+		})
+
+		It("should delegate to the Exponential strategy", func() {
+			s := &DeploymentStrategy{
+				Exponential: &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(2), SafetyLimit: ptr.To(50)},
+			}
+			Expect(s.CalculateBatchSize(10, &BatchProcessingState{})).To(Equal(2))
+		})
+
+		It("should fall back to a batch of 1 when no strategy is set", func() {
+			s := &DeploymentStrategy{}
+			Expect(s.CalculateBatchSize(10, &BatchProcessingState{})).To(Equal(1))
+		})
+	})
+
+	Describe("EvaluateBatchResult", func() {
+		It("should leave state untouched when the batch size is zero", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{BatchThreshold: ptr.To(100)}}
+			state := &BatchProcessingState{CurrentBatch: 2, ConsecutiveFailures: 1}
+
+			s.EvaluateBatchResult(state, 0, 0, 0, 10)
+
+			Expect(state.CurrentBatch).To(Equal(2))
+			Expect(state.ConsecutiveFailures).To(Equal(1))
+			Expect(state.LastBatchSize).To(BeZero())
+		})
+
+		It("should reset consecutive failures when the batch meets the threshold", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{BatchThreshold: ptr.To(100)}}
+			state := &BatchProcessingState{ConsecutiveFailures: 2, CompletedNodes: 4}
+
+			s.EvaluateBatchResult(state, 4, 4, 0, 10)
+
+			Expect(state.ConsecutiveFailures).To(BeZero())
+			Expect(state.LastBatchFailed).To(BeFalse())
+			Expect(state.LastBatchSize).To(Equal(4))
+			Expect(state.CurrentBatch).To(Equal(1))
+			Expect(state.ShouldStop).To(BeFalse())
+		})
+
+		It("should count a consecutive failure when the batch misses the threshold", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{BatchThreshold: ptr.To(100)}}
+			state := &BatchProcessingState{CompletedNodes: 3, FailedNodes: 1}
+
+			s.EvaluateBatchResult(state, 4, 3, 1, 10)
+
+			Expect(state.ConsecutiveFailures).To(Equal(1))
+			Expect(state.LastBatchFailed).To(BeTrue())
+			Expect(state.ShouldStop).To(BeFalse())
+		})
+
+		It("should stop once consecutive failures reach the threshold below the safety limit", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{
+				BatchThreshold:   ptr.To(100),
+				FailureThreshold: ptr.To(2),
+				SafetyLimit:      ptr.To(50),
+			}}
+			state := &BatchProcessingState{ConsecutiveFailures: 1, CompletedNodes: 1, FailedNodes: 1}
+
+			s.EvaluateBatchResult(state, 2, 1, 1, 10)
+
+			Expect(state.ConsecutiveFailures).To(Equal(2))
+			Expect(state.ShouldStop).To(BeTrue())
+		})
+
+		It("should not stop past the safety limit even when failures reach the threshold", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{
+				BatchThreshold:   ptr.To(100),
+				FailureThreshold: ptr.To(2),
+				SafetyLimit:      ptr.To(50),
+			}}
+			state := &BatchProcessingState{ConsecutiveFailures: 1, CompletedNodes: 7, FailedNodes: 1}
+
+			s.EvaluateBatchResult(state, 2, 1, 1, 10)
+
+			Expect(state.ConsecutiveFailures).To(Equal(2))
+			Expect(state.ShouldStop).To(BeFalse())
+		})
+
+		It("should never stop when no failure threshold is configured", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{BatchThreshold: ptr.To(100), SafetyLimit: ptr.To(50)}}
+			state := &BatchProcessingState{ConsecutiveFailures: 9}
+
+			s.EvaluateBatchResult(state, 2, 0, 2, 10)
+
+			Expect(state.ConsecutiveFailures).To(Equal(10))
+			Expect(state.ShouldStop).To(BeFalse())
+		})
+
+		It("should treat progress as zero when there are no nodes to roll out", func() {
+			s := &DeploymentStrategy{Fixed: &FixedStrategy{
+				BatchThreshold:   ptr.To(100),
+				FailureThreshold: ptr.To(1),
+				SafetyLimit:      ptr.To(50),
+			}}
+			state := &BatchProcessingState{}
+
+			s.EvaluateBatchResult(state, 2, 0, 2, 0)
+
+			Expect(state.ShouldStop).To(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("FixedStrategy CalculateBatchSize", func() {
+	It("should return the initial batch size", func() {
+		s := &FixedStrategy{InitialBatch: ptr.To(5)}
+		Expect(s.CalculateBatchSize(20, &BatchProcessingState{})).To(Equal(5))
+	})
+
+	It("should clamp to the nodes still remaining", func() {
+		s := &FixedStrategy{InitialBatch: ptr.To(5)}
+		state := &BatchProcessingState{CompletedNodes: 16, FailedNodes: 2}
+		Expect(s.CalculateBatchSize(20, state)).To(Equal(2))
+	})
+
+	It("should return zero once every node has been processed", func() {
+		s := &FixedStrategy{InitialBatch: ptr.To(5)}
+		state := &BatchProcessingState{CompletedNodes: 18, FailedNodes: 2}
+		Expect(s.CalculateBatchSize(20, state)).To(BeZero())
+	})
+})
+
+var _ = Describe("LinearStrategy CalculateBatchSize", func() {
+	It("should return zero when there are no nodes", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(1), SafetyLimit: ptr.To(50)}
+		Expect(s.CalculateBatchSize(0, &BatchProcessingState{})).To(BeZero())
+	})
+
+	It("should use the initial batch size for the first batch", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(1), SafetyLimit: ptr.To(50)}
+		Expect(s.CalculateBatchSize(100, &BatchProcessingState{})).To(Equal(3))
+	})
+
+	It("should grow by delta after a successful batch", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(2), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 4, CompletedNodes: 4}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(6))
+	})
+
+	It("should shrink by delta after a failed batch below the safety limit", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(3), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 8, LastBatchFailed: true, CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(5))
+	})
+
+	It("should never shrink below one", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(5), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 2, LastBatchFailed: true, CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(1))
+	})
+
+	It("should keep growing past the safety limit even after a failed batch", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(2), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 4, LastBatchFailed: true, CompletedNodes: 80}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(6))
+	})
+
+	It("should clamp to the nodes still remaining", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(9), Delta: ptr.To(1), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{CompletedNodes: 8}
+		Expect(s.CalculateBatchSize(10, state)).To(Equal(2))
+	})
+
+	It("should return zero once every node has been processed", func() {
+		s := &LinearStrategy{InitialBatch: ptr.To(3), Delta: ptr.To(1), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(10, state)).To(BeZero())
+	})
+})
+
+var _ = Describe("ExponentialStrategy CalculateBatchSize", func() {
+	It("should return zero when there are no nodes", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(2), SafetyLimit: ptr.To(50)}
+		Expect(s.CalculateBatchSize(0, &BatchProcessingState{})).To(BeZero())
+	})
+
+	It("should use the initial batch size for the first batch", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(2), SafetyLimit: ptr.To(50)}
+		Expect(s.CalculateBatchSize(100, &BatchProcessingState{})).To(Equal(2))
+	})
+
+	It("should multiply by the growth factor after a successful batch", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(3), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 2, CompletedNodes: 2}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(6))
+	})
+
+	It("should divide by the growth factor after a failed batch below the safety limit", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(2), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 8, LastBatchFailed: true, CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(4))
+	})
+
+	It("should fall back to the initial batch size when the growth factor is zero", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(0), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 8, CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(100, state)).To(Equal(2))
+	})
+
+	It("should cap growth at the total node count", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(4), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{LastBatchSize: 30}
+		Expect(s.CalculateBatchSize(50, state)).To(Equal(50))
+	})
+
+	It("should return zero once every node has been processed", func() {
+		s := &ExponentialStrategy{InitialBatch: ptr.To(2), GrowthFactor: ptr.To(2), SafetyLimit: ptr.To(50)}
+		state := &BatchProcessingState{CompletedNodes: 10}
+		Expect(s.CalculateBatchSize(10, state)).To(BeZero())
+	})
+})
+
+var _ = Describe("Compartment Validate", func() {
+	validBudget := DeploymentBudget{Count: ptr.To(1)}
+
+	It("should accept a compartment with a valid budget, strategy and selector", func() {
+		c := &Compartment{
+			Name:     "gpu",
+			Budget:   validBudget,
+			Strategy: &DeploymentStrategy{Fixed: &FixedStrategy{InitialBatch: ptr.To(1)}},
+			Selector: metav1.LabelSelector{MatchLabels: map[string]string{"accelerator": "gpu"}},
+		}
+		Expect(c.Validate()).To(Succeed())
+	})
+
+	It("should accept a compartment with no strategy override", func() {
+		c := &Compartment{Name: "gpu", Budget: validBudget}
+		Expect(c.Validate()).To(Succeed())
+	})
+
+	It("should reject a budget setting neither percent nor count", func() {
+		c := &Compartment{Name: "gpu"}
+		Expect(c.Validate()).To(MatchError(ContainSubstring(`compartment "gpu" budget`)))
+	})
+
+	It("should reject a strategy that sets no variant", func() {
+		c := &Compartment{Name: "gpu", Budget: validBudget, Strategy: &DeploymentStrategy{}}
+		Expect(c.Validate()).To(MatchError(ContainSubstring(`compartment "gpu" strategy`)))
+	})
+
+	It("should reject an unparsable selector", func() {
+		c := &Compartment{
+			Name:   "gpu",
+			Budget: validBudget,
+			Selector: metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: "accelerator", Operator: "NotAnOperator"},
+				},
+			},
+		}
+		Expect(c.Validate()).To(MatchError(ContainSubstring(`compartment "gpu" has invalid selector`)))
+	})
+})

--- a/operator/api/nodewright/v1alpha1/nodewright_types_test.go
+++ b/operator/api/nodewright/v1alpha1/nodewright_types_test.go
@@ -1,0 +1,340 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+)
+
+var _ = Describe("StateToStatus", func() {
+	DescribeTable("maps a package State onto a node Status",
+		func(state State, expected Status) {
+			Expect(StateToStatus(state)).To(Equal(expected))
+		},
+		Entry("complete", StateComplete, StatusComplete),
+		Entry("erroring", StateErroring, StatusErroring),
+		Entry("in_progress", StateInProgress, StatusInProgress),
+		Entry("skipped has no Status of its own", StateSkipped, StatusUnknown),
+		Entry("unknown", StateUnknown, StatusUnknown),
+		Entry("a State the operator never writes", State("nonsense"), StatusUnknown),
+	)
+})
+
+var _ = Describe("NodeWright WasUpdated", func() {
+	It("should be false for a freshly created NodeWright", func() {
+		nw := &NodeWright{ObjectMeta: metav1.ObjectMeta{Generation: 1}}
+		Expect(nw.WasUpdated()).To(BeFalse())
+	})
+
+	It("should be false once the observed generation has caught up", func() {
+		nw := &NodeWright{ObjectMeta: metav1.ObjectMeta{Generation: 3}}
+		nw.Status.ObservedGeneration = 3
+		Expect(nw.WasUpdated()).To(BeFalse())
+	})
+
+	It("should be true when the spec has moved ahead of the observed generation", func() {
+		nw := &NodeWright{ObjectMeta: metav1.ObjectMeta{Generation: 3}}
+		nw.Status.ObservedGeneration = 2
+		Expect(nw.WasUpdated()).To(BeTrue())
+	})
+})
+
+var _ = Describe("NodeWright pause and disable annotations", func() {
+	pauseKey := fmt.Sprintf("%s/pause", METADATA_PREFIX)
+	disableKey := fmt.Sprintf("%s/disable", METADATA_PREFIX)
+
+	DescribeTable("IsPaused",
+		func(annotations map[string]string, expected bool) {
+			nw := &NodeWright{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+			Expect(nw.IsPaused()).To(Equal(expected))
+		},
+		Entry("no annotations at all", nil, false),
+		Entry("unrelated annotations only", map[string]string{"other": "true"}, false),
+		Entry("pause=true", map[string]string{pauseKey: "true"}, true),
+		Entry("pause=false", map[string]string{pauseKey: "false"}, false),
+		Entry("pause set to something else", map[string]string{pauseKey: "yes"}, false),
+	)
+
+	DescribeTable("IsDisabled",
+		func(annotations map[string]string, expected bool) {
+			nw := &NodeWright{ObjectMeta: metav1.ObjectMeta{Annotations: annotations}}
+			Expect(nw.IsDisabled()).To(Equal(expected))
+		},
+		Entry("no annotations at all", nil, false),
+		Entry("unrelated annotations only", map[string]string{"other": "true"}, false),
+		Entry("disable=true", map[string]string{disableKey: "true"}, true),
+		Entry("disable=false", map[string]string{disableKey: "false"}, false),
+	)
+})
+
+var _ = Describe("NodeWright ResetCompartmentBatchStates", func() {
+	It("should report nothing to do when there are no compartment statuses", func() {
+		nw := &NodeWright{}
+		Expect(nw.ResetCompartmentBatchStates()).To(BeFalse())
+	})
+
+	It("should reset every compartment's batch state to a fresh first batch", func() {
+		nw := &NodeWright{}
+		nw.Status.CompartmentStatuses = map[string]CompartmentStatus{
+			"gpu": {BatchState: &BatchProcessingState{
+				CurrentBatch:        7,
+				ConsecutiveFailures: 3,
+				CompletedNodes:      12,
+				FailedNodes:         4,
+				ShouldStop:          true,
+				LastBatchSize:       6,
+				LastBatchFailed:     true,
+			}},
+			"cpu": {BatchState: nil},
+		}
+
+		Expect(nw.ResetCompartmentBatchStates()).To(BeTrue())
+
+		for name, cs := range nw.Status.CompartmentStatuses {
+			Expect(cs.BatchState).ToNot(BeNil(), "compartment %s", name)
+			Expect(*cs.BatchState).To(Equal(BatchProcessingState{CurrentBatch: 1}))
+		}
+	})
+})
+
+var _ = Describe("InterruptionBudget Validate", func() {
+	It("should accept a budget with only a count", func() {
+		Expect((&InterruptionBudget{Count: ptr.To(3)}).Validate()).To(Succeed())
+	})
+
+	It("should accept a budget with only a percent", func() {
+		Expect((&InterruptionBudget{Percent: ptr.To(10)}).Validate()).To(Succeed())
+	})
+
+	It("should accept an empty budget", func() {
+		Expect((&InterruptionBudget{}).Validate()).To(Succeed())
+	})
+
+	It("should reject a budget setting both count and percent", func() {
+		err := (&InterruptionBudget{Count: ptr.To(3), Percent: ptr.To(10)}).Validate()
+		Expect(err).To(MatchError(ContainSubstring("both percent and count can not be set at the same time")))
+	})
+})
+
+var _ = Describe("Interrupt ToArgs", func() {
+	decode := func(encoded string) map[string]any {
+		GinkgoHelper()
+		raw, err := base64.StdEncoding.DecodeString(encoded)
+		Expect(err).ToNot(HaveOccurred())
+		out := map[string]any{}
+		Expect(json.Unmarshal(raw, &out)).To(Succeed())
+		return out
+	}
+
+	DescribeTable("translates the CRD interrupt type to the name the agent expects",
+		func(crdType InterruptType, agentType string) {
+			interrupt := &Interrupt{Type: crdType}
+
+			encoded, err := interrupt.ToArgs()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(decode(encoded)).To(HaveKeyWithValue("type", agentType))
+			Expect(interrupt.Type).To(Equal(crdType), "ToArgs must not mutate the receiver")
+		},
+		Entry("reboot", REBOOT, "node_restart"),
+		Entry("service", SERVICE, "service_restart"),
+		Entry("noop", NOOP, "no_op"),
+		Entry("restartAllServices", RESTART_ALL_SERVICES, "restart_all_services"),
+	)
+
+	It("should carry the service list through", func() {
+		encoded, err := (&Interrupt{Type: SERVICE, Services: []string{"containerd", "kubelet"}}).ToArgs()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(decode(encoded)).To(HaveKeyWithValue("services", ConsistOf("containerd", "kubelet")))
+	})
+})
+
+var _ = Describe("NodeWrightSpec BuildGraph", func() {
+	It("should build a graph from packages with dependencies", func() {
+		spec := &NodeWrightSpec{Packages: Packages{
+			"base": Package{PackageRef: PackageRef{Name: "base", Version: "1.0.0"}},
+			"tuning": Package{
+				PackageRef: PackageRef{Name: "tuning", Version: "2.0.0"},
+				DependsOn:  map[string]string{"base": "1.0.0"},
+			},
+		}}
+
+		dependencyGraph, err := spec.BuildGraph()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(dependencyGraph).ToNot(BeNil())
+	})
+
+	It("should reject a dependency pinned to an empty version", func() {
+		spec := &NodeWrightSpec{Packages: Packages{
+			"tuning": Package{
+				PackageRef: PackageRef{Name: "tuning", Version: "2.0.0"},
+				DependsOn:  map[string]string{"base": ""},
+			},
+		}}
+
+		_, err := spec.BuildGraph()
+		Expect(err).To(MatchError(ContainSubstring("DependsOn version is empty for [base]")))
+	})
+
+	// Packages is keyed by map key, but the graph is keyed by name|version, so two
+	// entries can collide on the graph key while looking distinct in the spec.
+	It("should reject two packages that collide on name and version", func() {
+		spec := &NodeWrightSpec{Packages: Packages{
+			"tuning":      Package{PackageRef: PackageRef{Name: "tuning", Version: "2.0.0"}},
+			"tuning-copy": Package{PackageRef: PackageRef{Name: "tuning", Version: "2.0.0"}},
+		}}
+
+		_, err := spec.BuildGraph()
+		Expect(err).To(MatchError(ContainSubstring("error building graph from packages")))
+	})
+})
+
+var _ = Describe("NodeState", func() {
+
+	Describe("RemoveState", func() {
+		It("should report no change when the state map is nil", func() {
+			var ns NodeState
+			Expect(ns.RemoveState(PackageRef{Name: "foo", Version: "1.0.0"})).To(BeFalse())
+		})
+
+		It("should report no change when the package is not present", func() {
+			ns := NodeState{"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"}}
+			Expect(ns.RemoveState(PackageRef{Name: "bar", Version: "2.0.0"})).To(BeFalse())
+			Expect(ns).To(HaveLen(1))
+		})
+
+		It("should treat a version bump as a different package", func() {
+			ns := NodeState{"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"}}
+			Expect(ns.RemoveState(PackageRef{Name: "foo", Version: "1.0.1"})).To(BeFalse())
+			Expect(ns).To(HaveKey("foo|1.0.0"))
+		})
+
+		It("should remove the package and report the change", func() {
+			ns := NodeState{
+				"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"},
+				"bar|2.0.0": PackageStatus{Name: "bar", Version: "2.0.0"},
+			}
+			Expect(ns.RemoveState(PackageRef{Name: "foo", Version: "1.0.0"})).To(BeTrue())
+			Expect(ns).ToNot(HaveKey("foo|1.0.0"))
+			Expect(ns).To(HaveKey("bar|2.0.0"))
+		})
+	})
+
+	Describe("IsUninstalled", func() {
+		It("should treat a nil state map as uninstalled", func() {
+			var ns NodeState
+			Expect(ns.IsUninstalled("foo|1.0.0")).To(BeTrue())
+		})
+
+		It("should treat an absent package as uninstalled", func() {
+			ns := NodeState{"bar|2.0.0": PackageStatus{Name: "bar", Version: "2.0.0"}}
+			Expect(ns.IsUninstalled("foo|1.0.0")).To(BeTrue())
+		})
+
+		It("should treat a package still in state as not uninstalled", func() {
+			ns := NodeState{"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"}}
+			Expect(ns.IsUninstalled("foo|1.0.0")).To(BeFalse())
+		})
+	})
+
+	Describe("Contains", func() {
+		packages := Packages{
+			"foo": Package{PackageRef: PackageRef{Name: "foo", Version: "1.0.0"}},
+			"bar": Package{PackageRef: PackageRef{Name: "bar", Version: "2.0.0"}},
+		}
+
+		It("should be true when state holds every package at the spec's version", func() {
+			ns := NodeState{
+				"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"},
+				"bar|2.0.0": PackageStatus{Name: "bar", Version: "2.0.0"},
+			}
+			Expect(ns.Contains(packages)).To(BeTrue())
+		})
+
+		It("should tolerate state holding extra packages the spec dropped", func() {
+			ns := NodeState{
+				"foo|1.0.0":   PackageStatus{Name: "foo", Version: "1.0.0"},
+				"bar|2.0.0":   PackageStatus{Name: "bar", Version: "2.0.0"},
+				"stale|9.0.0": PackageStatus{Name: "stale", Version: "9.0.0"},
+			}
+			Expect(ns.Contains(packages)).To(BeTrue())
+		})
+
+		It("should be false when state holds fewer packages than the spec", func() {
+			ns := NodeState{"foo|1.0.0": PackageStatus{Name: "foo", Version: "1.0.0"}}
+			Expect(ns.Contains(packages)).To(BeFalse())
+		})
+
+		It("should be false when a spec package is missing from state", func() {
+			ns := NodeState{
+				"foo|1.0.0":   PackageStatus{Name: "foo", Version: "1.0.0"},
+				"other|1.0.0": PackageStatus{Name: "other", Version: "1.0.0"},
+			}
+			Expect(ns.Contains(packages)).To(BeFalse())
+		})
+
+		// The key already encodes the version, so a status whose Version disagrees with
+		// its own key can only come from a hand-edited or corrupted node annotation.
+		// Contains still has to reject it rather than trust the key.
+		It("should be false when a status contradicts the version in its own key", func() {
+			ns := NodeState{
+				"foo|1.0.0": PackageStatus{Name: "foo", Version: "0.9.0"},
+				"bar|2.0.0": PackageStatus{Name: "bar", Version: "2.0.0"},
+			}
+			Expect(ns.Contains(packages)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("PackageStatus predicates", func() {
+
+	DescribeTable("IsInterruptStage",
+		func(status *PackageStatus, expected bool) {
+			Expect(status.IsInterruptStage()).To(Equal(expected))
+		},
+		Entry("nil status is in no Stage", nil, false),
+		Entry("interrupt", &PackageStatus{Stage: StageInterrupt}, true),
+		Entry("uninstall-interrupt", &PackageStatus{Stage: StageUninstallInterrupt}, true),
+		Entry("apply", &PackageStatus{Stage: StageApply}, false),
+		Entry("post-interrupt", &PackageStatus{Stage: StagePostInterrupt}, false),
+	)
+
+	DescribeTable("IsActive",
+		func(status *PackageStatus, expected bool) {
+			Expect(status.IsActive()).To(Equal(expected))
+		},
+		Entry("nil status is not active", nil, false),
+		Entry("in_progress", &PackageStatus{State: StateInProgress}, true),
+		Entry("erroring", &PackageStatus{State: StateErroring}, true),
+		Entry("complete", &PackageStatus{State: StateComplete}, false),
+		Entry("skipped", &PackageStatus{State: StateSkipped}, false),
+	)
+
+	DescribeTable("IsSkipped",
+		func(status *PackageStatus, expected bool) {
+			Expect(status.IsSkipped()).To(Equal(expected))
+		},
+		Entry("nil status is not skipped", nil, false),
+		Entry("skipped", &PackageStatus{State: StateSkipped}, true),
+		Entry("complete", &PackageStatus{State: StateComplete}, false),
+	)
+})

--- a/operator/api/nodewright/v1alpha1/nodewright_types_test.go
+++ b/operator/api/nodewright/v1alpha1/nodewright_types_test.go
@@ -181,6 +181,14 @@ var _ = Describe("NodeWrightSpec BuildGraph", func() {
 		dependencyGraph, err := spec.BuildGraph()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(dependencyGraph).ToNot(BeNil())
+
+		ready, err := dependencyGraph.Next()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ready).To(Equal([]string{"base|1.0.0"}), "only the dependency-free package is ready first")
+
+		ready, err = dependencyGraph.Next("base|1.0.0")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(ready).To(Equal([]string{"tuning|2.0.0"}), "tuning unblocks once base is done")
 	})
 
 	It("should reject a dependency pinned to an empty version", func() {

--- a/operator/internal/cli/utils/utils_test.go
+++ b/operator/internal/cli/utils/utils_test.go
@@ -651,7 +651,11 @@ var _ = Describe("CLI Utility Functions", func() {
 			It("should write headers and rule even with no rows", func() {
 				out := &bytes.Buffer{}
 				Expect(OutputTable(out, cfg, nil)).To(Succeed())
-				Expect(strings.Split(strings.TrimRight(out.String(), "\n"), "\n")).To(HaveLen(2))
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines).To(HaveLen(2))
+				Expect(lines[0]).To(MatchRegexp(`^NAME\s+STATE$`))
+				Expect(lines[1]).To(MatchRegexp(`^----\s+-----$`))
 			})
 		})
 
@@ -673,6 +677,11 @@ var _ = Describe("CLI Utility Functions", func() {
 
 				out := &bytes.Buffer{}
 				Expect(OutputWide(out, narrow, rows)).To(Succeed())
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines).To(HaveLen(4))
+				Expect(lines[0]).To(MatchRegexp(`^NAME\s+STATE$`))
+				Expect(lines[2]).To(MatchRegexp(`^tuning\s+complete$`))
 				Expect(out.String()).ToNot(ContainSubstring("node-1"))
 			})
 		})

--- a/operator/internal/cli/utils/utils_test.go
+++ b/operator/internal/cli/utils/utils_test.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -585,6 +586,120 @@ var _ = Describe("CLI Utility Functions", func() {
 			namespace, found, _ := ResolveOperatorNamespace(context.Background(), nil)
 			Expect(namespace).To(Equal(DefaultNamespace))
 			Expect(found).To(BeFalse())
+		})
+	})
+
+	Describe("output helpers", func() {
+		type row struct {
+			Name  string `json:"name"`
+			State string `json:"state"`
+			Node  string `json:"node"`
+		}
+
+		cfg := TableConfig[row]{
+			Headers:     []string{"NAME", "STATE"},
+			Extract:     func(r row) []string { return []string{r.Name, r.State} },
+			WideHeaders: []string{"NODE"},
+			WideExtract: func(r row) []string { return []string{r.Node} },
+		}
+
+		rows := []row{
+			{Name: "tuning", State: "complete", Node: "node-1"},
+			{Name: "shellscript", State: "erroring", Node: "node-2"},
+		}
+
+		Describe("OutputJSON", func() {
+			It("should write indented JSON", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputJSON(out, rows)).To(Succeed())
+				Expect(out.String()).To(ContainSubstring(`"name": "tuning"`))
+			})
+
+			It("should report a value it cannot marshal", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputJSON(out, make(chan int))).To(MatchError(ContainSubstring("marshaling json")))
+			})
+		})
+
+		Describe("OutputYAML", func() {
+			It("should write YAML", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputYAML(out, rows)).To(Succeed())
+				Expect(out.String()).To(ContainSubstring("name: tuning"))
+				Expect(out.String()).To(ContainSubstring("state: erroring"))
+			})
+
+			It("should report a value it cannot marshal", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputYAML(out, make(chan int))).To(MatchError(ContainSubstring("marshaling yaml")))
+			})
+		})
+
+		Describe("OutputTable", func() {
+			It("should write the narrow headers, a rule and one line per row", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputTable(out, cfg, rows)).To(Succeed())
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines).To(HaveLen(4))
+				Expect(lines[0]).To(MatchRegexp(`^NAME\s+STATE$`))
+				Expect(lines[1]).To(MatchRegexp(`^----\s+-----$`))
+				Expect(lines[2]).To(MatchRegexp(`^tuning\s+complete$`))
+				Expect(lines[3]).To(MatchRegexp(`^shellscript\s+erroring$`))
+			})
+
+			It("should write headers and rule even with no rows", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputTable(out, cfg, nil)).To(Succeed())
+				Expect(strings.Split(strings.TrimRight(out.String(), "\n"), "\n")).To(HaveLen(2))
+			})
+		})
+
+		Describe("OutputWide", func() {
+			It("should append the wide columns", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputWide(out, cfg, rows)).To(Succeed())
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines[0]).To(MatchRegexp(`^NAME\s+STATE\s+NODE$`))
+				Expect(lines[2]).To(MatchRegexp(`^tuning\s+complete\s+node-1$`))
+			})
+
+			It("should fall back to the narrow row when no wide extractor is configured", func() {
+				narrow := TableConfig[row]{
+					Headers: []string{"NAME", "STATE"},
+					Extract: cfg.Extract,
+				}
+
+				out := &bytes.Buffer{}
+				Expect(OutputWide(out, narrow, rows)).To(Succeed())
+				Expect(out.String()).ToNot(ContainSubstring("node-1"))
+			})
+		})
+
+		Describe("OutputTableWithHeader", func() {
+			It("should print the header line and a blank line above the table", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputTableWithHeader(out, "NodeWright: demo", cfg, rows)).To(Succeed())
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines[0]).To(Equal("NodeWright: demo"))
+				Expect(lines[1]).To(BeEmpty())
+				Expect(lines[2]).To(MatchRegexp(`^NAME\s+STATE$`))
+				Expect(out.String()).ToNot(ContainSubstring("NODE"))
+			})
+		})
+
+		Describe("OutputWideWithHeader", func() {
+			It("should print the header line above the wide table", func() {
+				out := &bytes.Buffer{}
+				Expect(OutputWideWithHeader(out, "NodeWright: demo", cfg, rows)).To(Succeed())
+
+				lines := strings.Split(strings.TrimRight(out.String(), "\n"), "\n")
+				Expect(lines[0]).To(Equal("NodeWright: demo"))
+				Expect(lines[1]).To(BeEmpty())
+				Expect(lines[2]).To(MatchRegexp(`^NAME\s+STATE\s+NODE$`))
+			})
 		})
 	})
 })

--- a/operator/internal/version/version_test.go
+++ b/operator/internal/version/version_test.go
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package version
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestVersion(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "Version Suite")
+}
+
+var _ = Describe("version", func() {
+
+	// GIT_SHA and VERSION are set by ldflags at build time, so every spec that reads
+	// them has to put back whatever this binary was built with.
+	BeforeEach(func() {
+		sha, ver := GIT_SHA, VERSION
+		DeferCleanup(func() {
+			GIT_SHA, VERSION = sha, ver
+		})
+	})
+
+	Describe("IsValid", func() {
+		DescribeTable("accepts semver with or without the v prefix",
+			func(version string, expected bool) {
+				Expect(IsValid(version)).To(Equal(expected))
+			},
+			Entry("empty", "", false),
+			Entry("with v prefix", "v1.2.3", true),
+			Entry("without v prefix", "1.2.3", true),
+			Entry("major.minor only", "0.15", true),
+			Entry("prerelease", "v1.2.3-rc.1", true),
+			Entry("not a version", "dev", false),
+			Entry("trailing junk", "1.2.3.4", false),
+		)
+	})
+
+	Describe("Compare", func() {
+		DescribeTable("orders versions regardless of the v prefix",
+			func(left, right string, expected int) {
+				Expect(Compare(left, right)).To(Equal(expected))
+			},
+			Entry("equal with prefix", "v1.2.3", "v1.2.3", 0),
+			Entry("equal with the prefix missing on the left", "1.2.3", "v1.2.3", 0),
+			Entry("equal with the prefix missing on the right", "v1.2.3", "1.2.3", 0),
+			Entry("equal with the prefix missing on both", "1.2.3", "1.2.3", 0),
+			Entry("left is older", "v1.2.3", "v1.3.0", -1),
+			Entry("left is newer", "v2.0.0", "v1.9.9", 1),
+			Entry("prerelease sorts before its release", "v1.2.3-rc.1", "v1.2.3", -1),
+		)
+	})
+
+	Describe("MajorMinor", func() {
+		DescribeTable("reduces a version to major.minor",
+			func(version, expected string) {
+				Expect(MajorMinor(version)).To(Equal(expected))
+			},
+			Entry("empty", "", ""),
+			Entry("with v prefix", "v1.2.3", "v1.2"),
+			Entry("without v prefix", "1.2.3", "v1.2"),
+			Entry("already major.minor", "v0.15", "v0.15"),
+			Entry("prerelease is dropped", "v1.2.3-rc.1", "v1.2"),
+			Entry("not a version", "dev", ""),
+		)
+	})
+
+	Describe("GetVersion", func() {
+		It("should return the version the binary was built with", func() {
+			VERSION = "v0.15.0"
+			Expect(GetVersion()).To(Equal("v0.15.0"))
+		})
+	})
+
+	Describe("Summary", func() {
+		It("should combine version and git sha when both are known", func() {
+			VERSION, GIT_SHA = "v0.15.0", "abc1234"
+			Expect(Summary()).To(Equal("v0.15.0 (abc1234)"))
+		})
+
+		It("should return the version alone when the sha is unknown", func() {
+			VERSION, GIT_SHA = "v0.15.0", "unknown"
+			Expect(Summary()).To(Equal("v0.15.0"))
+		})
+
+		It("should return the version alone when the sha is empty", func() {
+			VERSION, GIT_SHA = "v0.15.0", ""
+			Expect(Summary()).To(Equal("v0.15.0"))
+		})
+	})
+})

--- a/operator/internal/wrapper/compartment_test.go
+++ b/operator/internal/wrapper/compartment_test.go
@@ -438,4 +438,31 @@ var _ = Describe("Compartment", func() {
 			Expect(names).NotTo(ContainElement("node-4"))
 		})
 	})
+
+	Context("GetNode", func() {
+		var compartment *wrapper.Compartment
+
+		BeforeEach(func() {
+			skyhook := &wrapper.Skyhook{NodeWright: &v1alpha1.NodeWright{}}
+			compartment = &wrapper.Compartment{
+				Nodes: []wrapper.SkyhookNode{
+					newMockNode(GinkgoT(), "node-1", v1alpha1.StatusWaiting, false, skyhook),
+					newMockNode(GinkgoT(), "node-2", v1alpha1.StatusWaiting, false, skyhook),
+				},
+			}
+		})
+
+		It("should return the node with the given name", func() {
+			Expect(compartment.GetNode("node-2")).ToNot(BeNil())
+			Expect(compartment.GetNode("node-2").GetNode().Name).To(Equal("node-2"))
+		})
+
+		It("should return nil for a node outside the compartment", func() {
+			Expect(compartment.GetNode("node-9")).To(BeNil())
+		})
+
+		It("should return nil when the compartment holds no nodes", func() {
+			Expect((&wrapper.Compartment{}).GetNode("node-1")).To(BeNil())
+		})
+	})
 })

--- a/operator/internal/wrapper/node_test.go
+++ b/operator/internal/wrapper/node_test.go
@@ -580,4 +580,97 @@ var _ = Describe("SkyhookNode", func() {
 			Expect(status.State).To(Equal(v1alpha1.StateComplete))
 		})
 	})
+
+	Context("Taint and RemoveTaint", func() {
+		const taintKey = "nodewright.nvidia.com/runtime-required"
+
+		newNode := func(taints ...corev1.Taint) SkyhookNode {
+			GinkgoHelper()
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-node"},
+				Spec:       corev1.NodeSpec{Taints: taints},
+			}
+			skyhook := v1alpha1.NodeWright{ObjectMeta: metav1.ObjectMeta{Name: "test-skyhook"}}
+
+			sn, err := NewSkyhookNode(node, &skyhook)
+			Expect(err).NotTo(HaveOccurred())
+			return sn
+		}
+
+		It("should add a NoSchedule taint valued with the Skyhook name", func() {
+			sn := newNode()
+
+			sn.Taint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(ConsistOf(corev1.Taint{
+				Key:    taintKey,
+				Value:  "test-skyhook",
+				Effect: corev1.TaintEffectNoSchedule,
+			}))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
+		It("should keep taints set by others when adding", func() {
+			existing := corev1.Taint{Key: "other/taint", Value: "keep", Effect: corev1.TaintEffectNoExecute}
+			sn := newNode(existing)
+
+			sn.Taint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(HaveLen(2))
+			Expect(sn.GetNode().Spec.Taints).To(ContainElement(existing))
+		})
+
+		// Re-tainting is not an error the operator can afford: reconcile is level-triggered
+		// and will call Taint on every pass, and a duplicate key is rejected by the apiserver.
+		It("should be a no-op when the taint key is already present", func() {
+			sn := newNode(corev1.Taint{Key: taintKey, Value: "someone-else", Effect: corev1.TaintEffectNoSchedule})
+
+			sn.Taint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(HaveLen(1))
+			Expect(sn.GetNode().Spec.Taints[0].Value).To(Equal("someone-else"))
+			Expect(sn.Changed()).To(BeFalse())
+		})
+
+		It("should remove only the taint with the given key", func() {
+			other := corev1.Taint{Key: "other/taint", Value: "keep", Effect: corev1.TaintEffectNoExecute}
+			sn := newNode(
+				corev1.Taint{Key: taintKey, Value: "test-skyhook", Effect: corev1.TaintEffectNoSchedule},
+				other,
+			)
+
+			sn.RemoveTaint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(ConsistOf(other))
+			Expect(sn.Changed()).To(BeTrue())
+		})
+
+		It("should be a no-op when the node carries no taints", func() {
+			sn := newNode()
+
+			sn.RemoveTaint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(BeEmpty())
+			Expect(sn.Changed()).To(BeFalse())
+		})
+
+		It("should be a no-op when the taint key is absent", func() {
+			other := corev1.Taint{Key: "other/taint", Value: "keep", Effect: corev1.TaintEffectNoExecute}
+			sn := newNode(other)
+
+			sn.RemoveTaint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(ConsistOf(other))
+			Expect(sn.Changed()).To(BeFalse())
+		})
+
+		It("should round-trip an add followed by a remove", func() {
+			sn := newNode()
+
+			sn.Taint(taintKey)
+			sn.RemoveTaint(taintKey)
+
+			Expect(sn.GetNode().Spec.Taints).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
## Description

Coverage pass over the merged CI profile, taking the easy pure-logic gaps. **Tests only — no production code is touched**, so there is no behaviour change to document and no `RELEASE_NOTES.md` entry.

### What the coverage data showed

`api/nodewright/v1alpha1` — the primary API group — has **no types tests at all**, while the legacy `api/v1alpha1` has both `skyhook_types_test.go` and `deployment_policy_types_test.go`. Its pure logic is only reached sideways, through the envtest webhook specs and e2e, so any branch a rollout doesn't happen to take was unexercised:

| | before |
|---|---|
| `StateToStatus` | 0.0% |
| `WasUpdated` | 0.0% |
| `getSafetyLimit` | 0.0% |
| `getFailureThreshold` | 42.9% |
| `Compartment.Validate` | 50.0% |
| `IsInterruptStage` / `IsActive` / `IsSkipped` | 66.7% each |

`internal/version` had no test file whatsoever, and the CLI table/YAML output helpers (`OutputYAML`, `OutputWide`, `OutputTableWithHeader`, `OutputWideWithHeader`) were all at 0% — covered only incidentally through full command tests, never directly.

### What this adds

- **`api/nodewright/v1alpha1/deployment_policy_types_test.go`** (new) — the three strategy accessors across all variants incl. nil receiver, the `CalculateBatchSize` dispatch and all three strategy implementations (first batch, growth, slowdown-below-safety-limit, the `max(1, …)` floor, remaining-node clamping, cap-at-total), `EvaluateBatchResult` (zero-batch early return, failure counting, the stop condition and both reasons it does *not* fire), and `Compartment.Validate`.
- **`api/nodewright/v1alpha1/nodewright_types_test.go`** (new) — `StateToStatus`, `WasUpdated`, the pause/disable annotation predicates, `ResetCompartmentBatchStates`, `InterruptionBudget.Validate`, `Interrupt.ToArgs` (including that it does not mutate its receiver), `BuildGraph` error paths, and the `NodeState` / `PackageStatus` predicates.
- **`internal/version/version_test.go`** (new) — first test file for the package. Specs restore `GIT_SHA` / `VERSION` via `DeferCleanup`, since ldflags set them at build time.
- **`internal/wrapper/node_test.go`** — `Taint` / `RemoveTaint`, including that re-tainting is a no-op (reconcile is level-triggered and calls `Taint` every pass; a duplicate key is rejected by the apiserver) and that neither touches taints set by others.
- **`internal/wrapper/compartment_test.go`** — `Compartment.GetNode`.
- **`internal/cli/utils/utils_test.go`** — the four output helpers plus the marshal-error paths.

Both new API test files ride the package's existing `webhook_suite_test.go` entrypoint as `Describe` blocks, exactly how `api/v1alpha1/skyhook_types_test.go` is structured. No new patterns introduced.

### Result

| File | before | after |
|---|---|---|
| `api/nodewright/v1alpha1/deployment_policy_types.go` | 81.5% | **100.0%** (130/130) |
| `api/nodewright/v1alpha1/nodewright_types.go` | 86.0% | **97.4%** (188/193) |
| `internal/version/version.go` | 68.4% | **100.0%** (19/19) |
| `internal/wrapper/node.go` | 86.2% | 92.3% |
| `internal/wrapper/compartment.go` | 90.5% | 94.0% |
| `internal/cli/utils/utils.go` | 73.7% | 80.3% |

87 statements newly covered; merged across all CI suites that moves the total from **78.7% to 79.8%**.

### Notes for review

- **Five statements were deliberately left uncovered.** The `json.Marshal` failure in `ToArgs` and the `json.Unmarshal` failure in `UnmarshalJSON` are unreachable for these types; the remaining three are loop branches in `IsComplete` / `ProgressSkipped` needing a much larger node-state fixture than the gain justifies.
- **`Contains` gets a case for a status whose `Version` contradicts its own map key.** The key already encodes the version, so this can only come from a hand-edited or corrupted node annotation — but the function does check, and nothing pinned that it keeps checking.
- **A follow-up PR removes the dead code this pass surfaced** — the legacy group's batch-strategy machinery has no callers (the wrapper uses the nodewright copies), and `graph.IsRoot` and the CLI's `ResetBatchStateForSkyhook` have none either. Deleting rather than testing it is the honest fix, so it is kept separate from this PR.

Verified locally: 337 specs across the four affected suites pass, `make lint` reports 0 issues, `make license-header-check` passes.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.