### PR TITLE
fix(ci): code-block-aware MDX sanitization in Fern workflows

### DIFF
--- a/.github/workflows/fern-docs-preview-build.yml
+++ b/.github/workflows/fern-docs-preview-build.yml
@@ -122,10 +122,27 @@ jobs:
             if git show-ref --verify --quiet "refs/tags/${tag}"; then
               mkdir -p "fern/versions/${version}-content"
               git archive "refs/tags/${tag}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
-                -e 's/{/\\{/g' \
-                -e 's/}/\\}/g' \
-                -e 's/</\&lt;/g'
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
               echo "Extracted docs from $version"
             else
               echo "::error::Tag $tag not found — cannot load frozen docs content"

--- a/.github/workflows/publish-fern-docs.yml
+++ b/.github/workflows/publish-fern-docs.yml
@@ -253,10 +253,27 @@ jobs:
             if git show-ref --verify --quiet "refs/tags/${tag}"; then
               mkdir -p "fern/versions/${version}-content"
               git archive "refs/tags/${tag}" -- docs/ | tar -x --strip-components=1 -C "fern/versions/${version}-content"
-              find "fern/versions/${version}-content" -name '*.md' -print0 | xargs -0 -r sed -i \
-                -e 's/{/\\{/g' \
-                -e 's/}/\\}/g' \
-                -e 's/</\&lt;/g'
+              # Escape {, }, < for MDX — but only outside fenced code blocks and inline code spans
+              find "fern/versions/${version}-content" -name '*.md' -print0 | while IFS= read -r -d '' f; do
+                awk '
+                  /^````*/ || /^~~~~*/ { fence = !fence; print; next }
+                  fence { print; next }
+                  {
+                    n = split($0, p, "`")
+                    out = ""
+                    for (i = 1; i <= n; i++) {
+                      if (i % 2 == 1) {
+                        gsub(/{/, "\\{", p[i])
+                        gsub(/}/, "\\}", p[i])
+                        gsub(/</, "\\&lt;", p[i])
+                      }
+                      out = out p[i]
+                      if (i < n) out = out "`"
+                    }
+                    print out
+                  }
+                ' "$f" > "${f}.tmp" && mv "${f}.tmp" "$f"
+              done
               echo "Extracted docs from $version"
             else
               echo "::error::Tag $tag not found — cannot pin frozen docs content"


### PR DESCRIPTION
## Description

Fixes #515

The frozen version content checkout step uses blind `sed` to escape `{`, `}`, `<`
for MDX. This corrupts content inside fenced code blocks — bash scripts with
`${VAR}`, Go templates with `{{.Field}}`, and JSON all render with visible
backslash escapes on the published site.

Replaces `sed` with an `awk` script that tracks fenced code block state and
skips inline code spans, matching the upstream skill template fix
(fern-documentation/scripts MR !51).

**Example — `docs/user-guide/providing-secrets.md` line 43:**
- Before (blind sed): `PGPASSWORD=$\{DB_PASSWORD\} psql -h $\{DB_HOST\}`
- After (awk): `PGPASSWORD=${DB_PASSWORD} psql -h ${DB_HOST}` (unchanged)

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.