### PR TITLE
ci: retry transient registry and download failures

### DIFF
--- a/.github/actions/resolve-oci-digest/action.yml
+++ b/.github/actions/resolve-oci-digest/action.yml
@@ -27,7 +27,10 @@ inputs:
   attempts:
     description: Number of attempts before failing.
     required: false
-    default: "1"
+    # Default to retrying: registry reads reset often enough that a single
+    # attempt fails release jobs on a blip. Callers that want a hard fail on the
+    # first error pass attempts: 1 explicitly.
+    default: "3"
   retry-delay-seconds:
     description: Delay between attempts.
     required: false

--- a/.github/actions/setup-oras/action.yml
+++ b/.github/actions/setup-oras/action.yml
@@ -42,7 +42,7 @@ runs:
         tarball="${RUNNER_TEMP}/oras.tar.gz"
         bindir="${RUNNER_TEMP}/oras-bin"
 
-        curl -sSfL "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${arch}.tar.gz" -o "${tarball}"
+        curl -sSfL --retry 3 --retry-delay 5 --retry-all-errors "https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${arch}.tar.gz" -o "${tarball}"
         echo "${sha}  ${tarball}" | sha256sum -c -
 
         # Onto PATH rather than into /usr/local/bin so the install needs no root.

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -61,7 +61,7 @@ jobs:
           BASE="https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}"
           TAR="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
           TMP="$(mktemp -d)"
-          curl -fsSL -o "${TMP}/${TAR}" "${BASE}/${TAR}"
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o "${TMP}/${TAR}" "${BASE}/${TAR}"
           echo "${ACTIONLINT_SHA256}  ${TMP}/${TAR}" | sha256sum -c -
           tar -xzf "${TMP}/${TAR}" -C "${TMP}" actionlint
           mv "${TMP}/actionlint" "${PWD}/actionlint"

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -39,9 +39,14 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          GC_VERSION=$(curl -sSf https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
-          curl -sSL "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar xz --wildcards "*/git-cliff" --strip-components=1
+          GC_VERSION=$(curl -sSf --retry 3 --retry-delay 5 --retry-all-errors https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+          # Download to a file rather than piping into tar: a retried transfer
+          # restarts from byte 0, which would replay bytes into a tar already
+          # part-way through the stream.
+          curl -sSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/git-cliff.tar.gz \
+            "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/git-cliff.tar.gz --wildcards --strip-components=1 "*/git-cliff"
           sudo mv git-cliff /usr/local/bin/
 
       - name: Setup Go

--- a/.github/workflows/lint-ci.yaml
+++ b/.github/workflows/lint-ci.yaml
@@ -61,7 +61,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
+          curl -sSfL --retry 3 --retry-delay 5 --retry-all-errors "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" -o /tmp/actionlint.tgz
           echo "${ACTIONLINT_SHA256}  /tmp/actionlint.tgz" | sha256sum -c -
           tar -xzf /tmp/actionlint.tgz -C /tmp actionlint
           # -shellcheck= disables the shellcheck integration. Existing
@@ -99,7 +99,7 @@ jobs:
         if: always()
         run: |
           set -euo pipefail
-          curl -sSfL "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/lychee.tgz
+          curl -sSfL --retry 3 --retry-delay 5 --retry-all-errors "https://github.com/lycheeverse/lychee/releases/download/lychee-v${LYCHEE_VERSION}/lychee-x86_64-unknown-linux-gnu.tar.gz" -o /tmp/lychee.tgz
           echo "${LYCHEE_SHA256}  /tmp/lychee.tgz" | sha256sum -c -
           tar -xzf /tmp/lychee.tgz -C /tmp lychee
 

--- a/.github/workflows/operator-ci.yaml
+++ b/.github/workflows/operator-ci.yaml
@@ -226,8 +226,8 @@ jobs:
         env:
           KIND_BINARY_VERSION: ${{ needs.k8s-test-versions.outputs.kind-binary-version }}
         run: |
-          curl -fsSL -o /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64"
-          curl -fsSL -o /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64.sha256sum"
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/kind-linux-amd64 "https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64"
+          curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors -o /tmp/kind-linux-amd64.sha256sum "https://kind.sigs.k8s.io/dl/${KIND_BINARY_VERSION}/kind-linux-amd64.sha256sum"
           cd /tmp && sha256sum -c kind-linux-amd64.sha256sum
           sudo install /tmp/kind-linux-amd64 /usr/local/bin/kind
       - name: Create ctlptl KinD Cluster

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,9 +49,14 @@ jobs:
 
       - name: Install git-cliff
         run: |
-          GC_VERSION=$(curl -sSf https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
-          curl -sSL "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz" \
-            | tar xz --wildcards "*/git-cliff" --strip-components=1
+          GC_VERSION=$(curl -sSf --retry 3 --retry-delay 5 --retry-all-errors https://api.github.com/repos/orhun/git-cliff/releases/latest | grep '"tag_name"' | cut -d '"' -f 4)
+          # Download to a file rather than piping into tar: a retried transfer
+          # restarts from byte 0, which would replay bytes into a tar already
+          # part-way through the stream.
+          curl -sSL --retry 3 --retry-delay 5 --retry-all-errors \
+            -o /tmp/git-cliff.tar.gz \
+            "https://github.com/orhun/git-cliff/releases/download/${GC_VERSION}/git-cliff-${GC_VERSION#v}-x86_64-unknown-linux-gnu.tar.gz"
+          tar -xzf /tmp/git-cliff.tar.gz --wildcards --strip-components=1 "*/git-cliff"
           sudo mv git-cliff /usr/local/bin/
 
       - name: Generate release notes

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -55,11 +55,26 @@ make validate-kind-node-image KIND_NODE_IMAGE_VERSION=1.35.0
 
 When updating supported test versions, edit `operator/versions.yaml` first, then run the validation target and the relevant tests.
 
+The check retries a failed registry read a few times before giving up (see [Retrying Registry Reads](#retrying-registry-reads)), so a tag that genuinely does not exist takes about fifteen seconds to report rather than failing instantly.
+
+## Retrying Registry Reads
+
+Docker Hub, ghcr.io and nvcr.io all reset connections often enough that an unretried read fails a whole CI job, and the error it prints usually blames the image ("is not published") rather than the network. `scripts/retry.sh` wraps those reads so only a sustained outage stops a run:
+
+```bash
+scripts/retry.sh -- docker manifest inspect kindest/node:v1.35.0
+scripts/retry.sh --attempts 5 --delay 10 -- oras repo tags nvcr.io/nvidia/distroless/static
+```
+
+It re-runs the command until it succeeds, doubling the delay between attempts, and exits with the command's own status once the attempts run out. Only the successful attempt's stdout is emitted, so wrapping a command whose output is captured or piped to `jq` stays safe. Use it for reads only — a push or a tag move is not safe to repeat. `make validate-kind-node-image` and `scripts/latest-distroless.sh` both call it already; override the path with `RETRY=` if you need to.
+
+Workflow steps that download a pinned binary pass curl's own `--retry ... --retry-all-errors` instead, and `.github/actions/resolve-oci-digest` retries by default.
+
 ## Distroless Base Images
 
 The operator and agent images build `FROM` NVIDIA's distroless bases (`nvcr.io/nvidia/distroless/static` and `nvcr.io/nvidia/distroless/python`). CI picks the version with `scripts/latest-distroless.sh`, which asks the registry directly instead of reading `https://developer.download.nvidia.com/distroless-oss/versions.json`. That file advertises a release days before the matching image is pushed, so a build that trusts it fails with a 404 on the base image for as long as the two are out of step; the registry's tag list cannot be ahead of the images it lists.
 
-The distroless repositories are public, so the script reads them with [`oras`](https://oras.land) anonymously and no NGC credentials are involved. CI installs `oras` through `.github/actions/setup-oras`; install it locally to run the script yourself.
+The distroless repositories are public, so the script reads them with [`oras`](https://oras.land) anonymously and no NGC credentials are involved. Each `oras` call goes through `scripts/retry.sh`, so a reset connection does not fail the build. CI installs `oras` through `.github/actions/setup-oras`; install it locally to run the script yourself.
 
 ```bash
 scripts/latest-distroless.sh --repo nvcr.io/nvidia/distroless/static --major 4

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -184,21 +184,25 @@ print-k8s-test-versions-github-output: ## Print Kubernetes test versions in GitH
 	@$(MAKE) --no-print-directory yq >/dev/null
 	@YQ="$(YQ)" $(VERSIONS) --print
 
+## Docker Hub resets connections often enough that an unretried inspect fails CI
+## with "not published" for an image that is published. RETRY only wraps reads.
+RETRY ?= ../scripts/retry.sh
+
 .PHONY: validate-kind-node-image
 validate-kind-node-image: yq ## Check that the configured kindest/node image tag exists before creating a cluster.
 	@echo "Validating kindest/node:v$(KIND_NODE_IMAGE_VERSION)"
 	@if command -v $(DOCKER_CMD) >/dev/null 2>&1; then \
 		if [ "$(DOCKER_CMD)" = "podman" ]; then \
-			$(DOCKER_CMD) manifest inspect docker://kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
+			$(RETRY) -- $(DOCKER_CMD) manifest inspect docker://kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
 		else \
-			$(DOCKER_CMD) manifest inspect kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
+			$(RETRY) -- $(DOCKER_CMD) manifest inspect kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
 		fi; \
 	elif command -v docker >/dev/null 2>&1; then \
-		docker manifest inspect kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
+		$(RETRY) -- docker manifest inspect kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
 	elif command -v podman >/dev/null 2>&1; then \
-		podman manifest inspect docker://kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
+		$(RETRY) -- podman manifest inspect docker://kindest/node:v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
 	else \
-		curl -fsSL https://hub.docker.com/v2/repositories/kindest/node/tags/v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
+		curl -fsSL --retry 3 --retry-delay 5 --retry-all-errors https://hub.docker.com/v2/repositories/kindest/node/tags/v$(KIND_NODE_IMAGE_VERSION) >/dev/null; \
 	fi || { \
 		echo "kindest/node:v$(KIND_NODE_IMAGE_VERSION) is not published or cannot be inspected."; \
 		echo "Update kind.nodeImage in versions.yaml, or override KIND_NODE_IMAGE_VERSION with a published kindest/node tag."; \

--- a/scripts/latest-distroless.sh
+++ b/scripts/latest-distroless.sh
@@ -17,6 +17,9 @@
 set -euo pipefail
 
 ORAS="${ORAS:-oras}"
+# Registry reads flake often enough to fail CI on their own, and every call
+# below is a read that is safe to repeat.
+RETRY="${RETRY:-"$(dirname "$0")/retry.sh"}"
 
 _die() {
 	printf 'latest-distroless.sh: %s\n' "$*" >&2
@@ -108,14 +111,14 @@ _main() {
 
 	local tags version tag digest manifest platform missing=""
 
-	tags="$("${ORAS}" repo tags "${repo}")" || _die "could not list tags for ${repo}"
+	tags="$("${RETRY}" -- "${ORAS}" repo tags "${repo}")" || _die "could not list tags for ${repo}"
 	# A prefix like '3.13-' carries dots that would otherwise match any character.
 	version="$(printf '%s\n' "${tags}" | _latest_version "${prefix//./\\.}" "${major}")"
 	[ -n "${version}" ] || _die "no v${major}.x release tag found for ${repo} with prefix '${prefix}'"
 
 	tag="${prefix}v${version}"
 
-	digest="$("${ORAS}" manifest fetch --descriptor "${repo}:${tag}" | jq -r '.digest // empty')" ||
+	digest="$("${RETRY}" -- "${ORAS}" manifest fetch --descriptor "${repo}:${tag}" | jq -r '.digest // empty')" ||
 		_die "could not resolve a digest for ${repo}:${tag}"
 	[ -n "${digest}" ] || _die "${repo}:${tag} returned no digest"
 
@@ -124,7 +127,7 @@ _main() {
 	# Read it back by digest rather than by tag: the tag is mutable, and a re-push
 	# between the two requests would have this validate a manifest other than the
 	# one resolved above, which is the only one the build ever sees.
-	manifest="$("${ORAS}" manifest fetch "${repo}@${digest}")" ||
+	manifest="$("${RETRY}" -- "${ORAS}" manifest fetch "${repo}@${digest}")" ||
 		_die "could not read the manifest for ${repo}:${tag} (${digest})"
 	for platform in ${platforms//,/ }; do
 		printf '%s' "${manifest}" | jq -e --arg p "${platform}" \

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -88,8 +88,10 @@ _main() {
 	# Buffer stdout per attempt and only replay the winning one. Callers capture
 	# this in $(...) or pipe it to jq, and a failed attempt that already wrote a
 	# partial response would otherwise be concatenated with the retry that
-	# succeeded, producing malformed output instead of an error. stderr streams
-	# through untouched so progress and failures stay visible live.
+	# succeeded, producing malformed output instead of an error. Nothing reaches
+	# stdout unless an attempt succeeded, so a caller that misses the exit status
+	# reads nothing rather than a truncated response. stderr streams through
+	# untouched so progress and failures stay visible live.
 	local out
 	out="$(mktemp)" || _die "could not create a temporary file"
 	# shellcheck disable=SC2064 # expand out now; it is fixed for the run.
@@ -113,7 +115,6 @@ _main() {
 		[ "${wait}" -gt "${max_delay}" ] && wait="${max_delay}"
 	done
 
-	cat "${out}"
 	printf 'retry.sh: %s failed (exit %d) after %d attempts\n' \
 		"${label}" "${status}" "${attempts}" >&2
 	return "${status}"

--- a/scripts/retry.sh
+++ b/scripts/retry.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Re-run a command until it succeeds, with exponential backoff between attempts.
+#
+# CI reaches out to Docker Hub, ghcr.io, nvcr.io and GitHub releases from steps
+# that have no retry of their own, so a single reset connection fails the whole
+# job with an error that reads like a real problem ("image is not published")
+# rather than the blip it was. Wrap those fetches in this so only a sustained
+# outage stops the run.
+#
+# Reserve it for reads that are safe to repeat. A push, a tag move, or anything
+# else that mutates a registry does not belong here.
+
+set -euo pipefail
+
+_die() {
+	printf 'retry.sh: %s\n' "$*" >&2
+	exit 1
+}
+
+_usage() {
+	cat <<EOF
+Re-run a command until it succeeds, backing off between attempts.
+
+usage: scripts/retry.sh [options] -- <command> [args...]
+
+--attempts     total tries, including the first. Default 3.
+--delay        seconds to wait after the first failure. Doubles each attempt.
+               Default 5.
+--max-delay    ceiling for the backoff. Default 30.
+--label        name used in the progress lines. Default: the command.
+
+Exits with the command's own status once attempts run out, so a caller that
+distinguishes exit codes still sees the real one.
+
+  scripts/retry.sh -- docker manifest inspect kindest/node:v1.33.12
+  scripts/retry.sh --attempts 5 --label 'oras tags' -- oras repo tags "\$REPO"
+EOF
+}
+
+_main() {
+	local attempts=3 delay=5 max_delay=30 label=""
+
+	while [ $# -gt 0 ]; do
+		case "$1" in
+		--attempts)
+			attempts="${2:-}"
+			shift 2
+			;;
+		--delay)
+			delay="${2:-}"
+			shift 2
+			;;
+		--max-delay)
+			max_delay="${2:-}"
+			shift 2
+			;;
+		--label)
+			label="${2:-}"
+			shift 2
+			;;
+		-h | --help)
+			_usage
+			return 0
+			;;
+		--)
+			shift
+			break
+			;;
+		*)
+			_die "unknown argument: $1 (the command goes after --)"
+			;;
+		esac
+	done
+
+	[ $# -gt 0 ] || _die "no command given (see --help)"
+	[ -n "${label}" ] || label="$*"
+
+	local re='^[0-9]+$'
+	if ! [[ "${attempts}" =~ ${re} ]] || [ "${attempts}" -lt 1 ]; then
+		_die "--attempts must be a positive integer"
+	fi
+	[[ "${delay}" =~ ${re} ]] || _die "--delay must be a non-negative integer"
+	[[ "${max_delay}" =~ ${re} ]] || _die "--max-delay must be a non-negative integer"
+
+	# Buffer stdout per attempt and only replay the winning one. Callers capture
+	# this in $(...) or pipe it to jq, and a failed attempt that already wrote a
+	# partial response would otherwise be concatenated with the retry that
+	# succeeded, producing malformed output instead of an error. stderr streams
+	# through untouched so progress and failures stay visible live.
+	local out
+	out="$(mktemp)" || _die "could not create a temporary file"
+	# shellcheck disable=SC2064 # expand out now; it is fixed for the run.
+	trap "rm -f '${out}'" EXIT
+
+	local attempt=1 status=0 wait="${delay}"
+	while :; do
+		status=0
+		"$@" >"${out}" || status=$?
+		if [ "${status}" -eq 0 ]; then
+			cat "${out}"
+			return 0
+		fi
+		[ "${attempt}" -ge "${attempts}" ] && break
+
+		printf 'retry.sh: %s failed (exit %d), attempt %d/%d, retrying in %ds\n' \
+			"${label}" "${status}" "${attempt}" "${attempts}" "${wait}" >&2
+		sleep "${wait}"
+		attempt=$((attempt + 1))
+		wait=$((wait * 2))
+		[ "${wait}" -gt "${max_delay}" ] && wait="${max_delay}"
+	done
+
+	cat "${out}"
+	printf 'retry.sh: %s failed (exit %d) after %d attempts\n' \
+		"${label}" "${status}" "${attempts}" >&2
+	return "${status}"
+}
+
+_main "$@"


### PR DESCRIPTION
## Description

[This `e2e/lifecycle (k8s-1.33.12)` job](https://github.com/NVIDIA/nodewright/actions/runs/32424428926/job/96603476010) failed on a blip, not on anything real:

```
Get "https://production.cloudfront.docker.com/registry-v2/.../data?...": read tcp ...: read: connection reset by peer
kindest/node:v1.33.12 is not published or cannot be inspected.
Update kind.nodeImage in versions.yaml, or override KIND_NODE_IMAGE_VERSION with a published kindest/node tag.
make: *** [Makefile:190: validate-kind-node-image] Error 1
```

Docker Hub's CDN reset the connection and the whole job died, with an error that points the reader at a bad version pin. None of the registry reads or binary downloads in CI retried.

### What this does

Adds `scripts/retry.sh`, a shared wrapper that re-runs a command with doubling backoff and exits with the command's own status, then wraps the reads that actually flake:

| Surface | Change |
| --- | --- |
| `operator/Makefile` `validate-kind-node-image` | The step that failed. `operator-ci` and `agent-ci` both call this target, so both are covered. |
| `scripts/latest-distroless.sh` | All three `oras` reads. |
| `.github/actions/resolve-oci-digest` | Already had a retry loop, but defaulted to `attempts: 1` and **both callers took the default** — so it had never engaged. Now defaults to 3. |
| kind / oras / actionlint / lychee / git-cliff downloads | curl's native `--retry 3 --retry-delay 5 --retry-all-errors`. |

Two details worth a look in review:

- **`retry.sh` buffers each attempt's stdout and replays only the winning one.** Callers capture these reads in `$(...)` or pipe them to `jq`. A failed attempt that already wrote a partial response would otherwise be concatenated with the retry that succeeded — silent corruption rather than an error. The test below exercises exactly this.
- **`--retry-all-errors`, not plain `--retry`.** Plain `--retry` covers timeouts and 5xx/429; a connection reset is a transport error it does not retry. `--retry-all-errors` does, and is the failure mode we actually hit.
- The two `git-cliff` installs piped `curl` into `tar`. A retried transfer restarts at byte 0, which would replay bytes into a tar already part-way through the stream, so those now download to a file first.

### New pattern introduced

`scripts/retry.sh` is a new file, so calling it out per the contributing guidance. The retry-loop shape is not new — it is lifted from the one already in `.github/actions/resolve-oci-digest` — but that one is a composite action, and the failure here is inside a Makefile target that also runs locally, which a composite action cannot reach. A sibling of `scripts/latest-distroless.sh`, callable from both `operator/Makefile` (which already reaches into `../scripts/`) and from workflows, was the smallest thing that covers both. If reviewers would rather this live somewhere else, easy to move.

### Tradeoff

`docker manifest inspect` returns the same exit status for a connection reset and a genuinely absent tag, and separating them means parsing stderr. So a tag that really does not exist now takes ~15s to report instead of failing instantly. Documented in the doc note.

### Verification

- Gates: `shellcheck`, `actionlint` (CI-pinned 1.7.11), `yamllint`, `make license-header-check`, `markdownlint` — all clean.
- `make validate-kind-node-image` against a stub that resets once → exit 0, absorbed on attempt 2.
- `latest-distroless.sh` against a stub whose first `oras repo tags` emits a **partial** tag list (`v4.0.9\nv4.0.1`) then fails → resolves `v4.0.10` correctly. Without stdout buffering the partial output merges into the retry's and the version sort picks wrong.
- Exit codes propagate (`exit 7` → `7`); stderr streams live.

No operator, agent, chart, or CLI behavior changes — CI and developer tooling only.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [ ] New or existing tests cover these changes. — the repo has no harness for shell/CI scripts, so this was verified manually with stubbed `docker`/`oras` (see Verification above) rather than by a committed test. Happy to add one if reviewers want a home for it.
- [x] The documentation is up to date with these changes.
