### PR TITLE
chore(deps): adopt Renovate for Go toolchain updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,78 +19,14 @@
 
 version: 2
 updates:
-  # Operator + CLI Go module (vendored; Dependabot re-runs `go mod vendor`).
-  - package-ecosystem: "gomod"
-    directory: "/operator"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    labels: ["dependencies", "component/operator"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-        exclude-patterns:
-          # klog has independent versioning.
-          - "k8s.io/klog/v2"
-      golang-x:
-        patterns:
-          - "golang.org/x/*"
-
-  # Go rewrite of the agent.
-  - package-ecosystem: "gomod"
-    directory: "/agent/go"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    labels: ["dependencies", "component/agent"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-    groups:
-      kubernetes:
-        patterns:
-          - "k8s.io/*"
-          - "sigs.k8s.io/*"
-        exclude-patterns:
-          - "k8s.io/klog/v2"
-      golang-x:
-        patterns:
-          - "golang.org/x/*"
-
-  # Python agent package.
-  - package-ecosystem: "pip"
-    directory: "/agent/skyhook-agent"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
-    labels: ["dependencies", "component/agent"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
   # GitHub Actions used by the workflows.
+  # Renovate owns every other ecosystem. It cannot update workflow files with
+  # the repository GITHUB_TOKEN, so Dependabot deliberately remains here.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
-    labels: ["dependencies", "component/ci"]
-    commit-message:
-      prefix: "chore"
-      include: "scope"
-
-  # Base images in the container Dockerfiles.
-  - package-ecosystem: "docker"
-    directories:
-      - "/containers/**"
-    schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 5
     labels: ["dependencies", "component/ci"]
     commit-message:
       prefix: "chore"

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -128,4 +128,4 @@
 
 - name: "dependencies"
   color: "0366d6"
-  description: "Dependency update (Dependabot)"
+  description: "Dependency update (Dependabot or Renovate)"

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -32,6 +32,24 @@
 
   packageRules: [
     {
+      // Dependency notices are release artifacts. Refresh them once after all
+      // updates on a branch, and commit only the three generated outputs.
+      matchManagers: ["gomod", "pep621"],
+      postUpgradeTasks: {
+        commands: ["make notices"],
+        fileFilters: [
+          "THIRD_PARTY_NOTICES.md",
+          "operator/THIRD_PARTY_NOTICES.md",
+          "agent/THIRD_PARTY_NOTICES.md",
+        ],
+        executionMode: "branch",
+        installTools: {
+          golang: {},
+          python: {},
+        },
+      },
+    },
+    {
       // Both go.mod files are the toolchain source of truth for CI and release
       // builds. Updating them as one group prevents cross-component skew.
       groupName: "Go toolchain",

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,93 @@
+{
+  // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+  // SPDX-License-Identifier: Apache-2.0
+
+  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+
+  extends: [
+    "config:recommended",
+    ":semanticCommits",
+    ":semanticCommitTypeAll(chore)",
+    ":semanticCommitScope(deps)",
+  ],
+
+  // Keep coverage aligned with the ecosystems previously owned by Dependabot.
+  // GitHub Actions remains enabled for extraction so the rule below can record
+  // the intentional handoff back to Dependabot in the validated config.
+  enabledManagers: ["dockerfile", "github-actions", "gomod", "pep621"],
+  dependencyDashboard: false,
+  prConcurrentLimit: 10,
+  prHourlyLimit: 10,
+  rebaseWhen: "behind-base-branch",
+  labels: ["dependencies"],
+
+  // Give newly published artifacts time to be withdrawn before proposing them.
+  minimumReleaseAge: "3 days",
+  internalChecksFilter: "strict",
+
+  // Both Go modules are vendored and all builds use -mod=vendor. Keep module
+  // metadata and vendor trees in the same commit as every dependency update.
+  postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths", "gomodVendor"],
+  ignorePaths: ["**/vendor/**"],
+
+  packageRules: [
+    {
+      // Both go.mod files are the toolchain source of truth for CI and release
+      // builds. Updating them as one group prevents cross-component skew.
+      groupName: "Go toolchain",
+      matchManagers: ["gomod"],
+      matchDepNames: ["go"],
+      matchDepTypes: ["golang"],
+      rangeStrategy: "bump",
+      addLabels: ["component/operator", "component/agent"],
+    },
+    {
+      // Do not let a module update raise the go directive as a side effect.
+      // Toolchain changes belong in the standalone group above.
+      matchManagers: ["gomod"],
+      constraintsFiltering: "strict",
+    },
+    {
+      groupName: "kubernetes",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["k8s.io/**", "sigs.k8s.io/**", "!k8s.io/klog/v2"],
+    },
+    {
+      groupName: "golang-x",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["golang.org/x/**"],
+    },
+    {
+      matchManagers: ["gomod"],
+      matchFileNames: ["operator/**"],
+      addLabels: ["component/operator"],
+    },
+    {
+      matchManagers: ["gomod"],
+      matchFileNames: ["agent/go/**"],
+      addLabels: ["component/agent"],
+    },
+    {
+      matchManagers: ["pep621"],
+      matchFileNames: ["agent/skyhook-agent/**"],
+      addLabels: ["component/agent"],
+    },
+    {
+      // The Python compatibility floor is a support decision, not a dependency.
+      matchManagers: ["pep621"],
+      matchDepTypes: ["requires-python"],
+      enabled: false,
+    },
+    {
+      matchManagers: ["dockerfile"],
+      matchFileNames: ["containers/**"],
+      addLabels: ["component/ci"],
+    },
+    {
+      // The workflow token cannot update .github/workflows without a PAT or
+      // GitHub App. Dependabot remains the owner of action-version updates.
+      matchManagers: ["github-actions"],
+      enabled: false,
+    },
+  ],
+}

--- a/.github/workflows/merge-gate.yaml
+++ b/.github/workflows/merge-gate.yaml
@@ -3,7 +3,7 @@
 
 name: Merge Gate
 
-# Checks that block merges: license verification on Go dependency changes.
+# Checks that block merges: dependency licenses and Renovate configuration.
 # Modeled on NVIDIA/aicr's merge-gate.yaml.
 
 on:
@@ -22,6 +22,7 @@ jobs:
     timeout-minutes: 1
     outputs:
       deps: ${{ steps.filter.outputs.deps }}
+      renovate: ${{ steps.filter.outputs.renovate }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -34,6 +35,31 @@ jobs:
               - 'operator/go.mod'
               - 'operator/go.sum'
               - 'operator/vendor/**'
+            renovate:
+              - '.github/dependabot.yml'
+              - '.github/renovate.json5'
+              - '.github/workflows/renovate.yaml'
+              - 'Makefile'
+
+  # ---------------------------------------------------------------------------
+  # Renovate configuration — runs only when dependency automation changes.
+  # ---------------------------------------------------------------------------
+  validate-renovate:
+    needs: [check-paths]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        if: needs.check-paths.outputs.renovate == 'true'
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Validate Renovate configuration
+        if: needs.check-paths.outputs.renovate == 'true'
+        run: make renovate-config-check
+      - name: Skip Renovate validation
+        if: needs.check-paths.outputs.renovate != 'true'
+        run: echo "No dependency automation changes — Renovate validation not required"
 
   # ---------------------------------------------------------------------------
   # License verification — runs only when dependency files change.

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -60,4 +60,5 @@ jobs:
           RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
           RENOVATE_ONBOARDING: "false"
+          RENOVATE_ALLOWED_COMMANDS: '["^make notices$"]'
           LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -40,7 +40,6 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
-      security-events: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+name: Renovate
+
+on:
+  schedule:
+    # The three-day release cooldown plus weekday runs keeps new Go patches
+    # within the issue's one-week detection window.
+    - cron: "0 5 * * 1-5"
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: Renovate log level
+        default: info
+        type: choice
+        options:
+          - debug
+          - info
+          - warn
+      dryRun:
+        description: Run without creating branches or pull requests
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
+
+jobs:
+  renovate:
+    name: Renovate
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      statuses: write
+      security-events: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Configure dry-run mode
+        if: ${{ inputs.dryRun }}
+        run: echo "RENOVATE_DRY_RUN=full" >> "$GITHUB_ENV"
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@e09d604f8f803bb527bd8321ed5be06c460b8682  # v46.2.2
+        with:
+          # Keep this in lockstep with RENOVATE_IMAGE in the root Makefile.
+          renovate-version: "44@sha256:e6b93e709ca64495ab9307350b260064276ee02d15c6886387fd2d42c926623b"
+        env:
+          RENOVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
+          RENOVATE_ONBOARDING: "false"
+          LOG_LEVEL: ${{ inputs.logLevel || 'info' }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,7 +79,7 @@ Prefer the Makefile over raw `go test` / `golangci-lint` invocations. The target
 
 Renovate owns Go module, Go toolchain, Python, and container dependency updates. Dependabot owns GitHub Actions updates because the token used by the self-hosted Renovate workflow cannot modify workflow files.
 
-The `go` directives in `operator/go.mod` and `agent/go/go.mod` are the source of truth for the toolchain used by CI and release builds. Renovate updates both directives in one standalone pull request, then runs `go mod tidy` and `go mod vendor` so vendored builds remain reproducible.
+The `go` directives in `operator/go.mod` and `agent/go/go.mod` are the source of truth for the toolchain used by CI and release builds. Renovate updates both directives in one standalone pull request, then runs `go mod tidy`, `go mod vendor`, and `make notices` so vendored builds and third-party notices remain reproducible.
 
 Before changing `.github/renovate.json5`, run `make renovate-config-check`. The Renovate workflow can also be dispatched manually with `dryRun` enabled to inspect proposed updates without creating branches or pull requests.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,16 @@ make license-header-check   # the same gate CI runs
 
 Prefer the Makefile over raw `go test` / `golangci-lint` invocations. The targets encode `-mod=vendor`, license-header formatting, envtest setup, and CRD/deepcopy generation ordering; calling the tools directly skips some of that and produces drift. Run `make help` to see what is available.
 
+### Dependency updates
+
+Renovate owns Go module, Go toolchain, Python, and container dependency updates. Dependabot owns GitHub Actions updates because the token used by the self-hosted Renovate workflow cannot modify workflow files.
+
+The `go` directives in `operator/go.mod` and `agent/go/go.mod` are the source of truth for the toolchain used by CI and release builds. Renovate updates both directives in one standalone pull request, then runs `go mod tidy` and `go mod vendor` so vendored builds remain reproducible.
+
+Before changing `.github/renovate.json5`, run `make renovate-config-check`. The Renovate workflow can also be dispatched manually with `dryRun` enabled to inspect proposed updates without creating branches or pull requests.
+
+Renovate uses the repository's `GITHUB_TOKEN`, not a PAT or GitHub App. GitHub therefore holds CI runs from Renovate-created pull requests for maintainer approval before they start.
+
 ### How your pull request gets reviewed
 
 - **Reviewers are assigned automatically** from [`.github/CODEOWNERS`](.github/CODEOWNERS) based on the paths you touched. You do not need to find a reviewer yourself.

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@
 
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
+DOCKER_CMD ?= docker
+
+# Keep this digest in lockstep with renovate-version in the workflow so local
+# and CI validation run the same Renovate build that creates update PRs.
+RENOVATE_IMAGE := ghcr.io/renovatebot/renovate:44@sha256:e6b93e709ca64495ab9307350b260064276ee02d15c6886387fd2d42c926623b
 
 
 .PHONY: help
@@ -42,6 +47,14 @@ build: ## Build operator and agent.
 test: ## Run tests for operator and agent.
 	$(MAKE) -C operator test
 	$(MAKE) -C agent test
+
+.PHONY: renovate-config-check
+renovate-config-check: ## Validate the Renovate configuration with the pinned runner image.
+	$(DOCKER_CMD) run --rm \
+		-v "$(CURDIR):/repo:ro" \
+		-w /repo \
+		$(RENOVATE_IMAGE) \
+		renovate-config-validator .github/renovate.json5
 
 ##@ Formatting
 

--- a/Makefile
+++ b/Makefile
@@ -92,10 +92,12 @@ license-header-check: ## Check license headers for all code.
 
 .PHONY: notices
 notices: ## Regenerate operator/, agent/, and root THIRD_PARTY_NOTICES.md files.
+	$(MAKE) -C operator go-licenses
 	@python3 scripts/generate-notices.py all
 
 .PHONY: notices-operator
 notices-operator: ## Regenerate only operator/THIRD_PARTY_NOTICES.md.
+	$(MAKE) -C operator go-licenses
 	@python3 scripts/generate-notices.py operator
 
 .PHONY: notices-agent

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -484,9 +484,8 @@ make notices-agent      # agent Python deps
 make notices-rollup     # root rollup (run after the two above)
 ```
 
-Prerequisites:
+The operator notice targets install `go-licenses` into `operator/bin/` when needed. Other prerequisites:
 
-- `go-licenses` — installed via `make -C operator go-licenses` (writes `operator/bin/go-licenses`).
 - Python 3 — required for the generator script and the agent pass's pip-licenses venv.
 
 The agent pass caches a Python venv at `agent/.notices-venv`. First run installs `pip-licenses` and the agent's pinned deps (~30s). Subsequent runs reuse the venv (~2s).
@@ -500,6 +499,7 @@ Run `make notices` and commit the refreshed file(s) whenever you:
 
 ### CI behavior
 
+- **Renovate** (`.github/workflows/renovate.yaml`): Go and Python dependency branches run `make notices` after artifact updates and commit the refreshed notice files with the dependency change.
 - **Merge gate** (`.github/workflows/merge-gate.yaml`): when Go dependency files change in a PR, the `verify-licenses` job runs `make -C operator license-check` to confirm every dep's license is on the approved list. The job is required and a paired skip job satisfies the check when deps don't change.
 - **Release upload** (`.github/workflows/release.yml`): every operator/agent/chart release regenerates the notices files in CI and attaches the appropriate one as a release asset:
   - `operator/v*` → `operator/THIRD_PARTY_NOTICES.md`


### PR DESCRIPTION
## Description

Closes #494.

Dependabot cannot update the `go` directive, so Go patch releases never produced a PR and dependency updates could raise the toolchain as an unrelated side effect. This adds a weekday self-hosted Renovate run that:

- treats both `go.mod` files as the toolchain source of truth and updates them together in a standalone PR
- runs `go mod tidy`, `go mod vendor`, and notice generation for dependency changes
- preserves the existing Kubernetes and `golang-x` groups, component labels, and three-day release cooldown
- keeps only GitHub Actions in Dependabot because the workflow token cannot edit workflow files
- validates the Renovate config in the merge gate and documents the ownership split

This is the repo’s first self-hosted dependency updater. It follows NVIDIA/aicr’s pinned-runner and token-permission pattern because there was no equivalent here.

An authenticated full dry run against this branch proposed `renovate/go-toolchain`, updated both modules from Go 1.26.5 to 1.27.0, generated `chore(deps): update go module directive to v1.27.0`, completed tidy/vendor generation, ran `make notices`, and included all three notice files in the proposed commit.

Validation:

- `make renovate-config-check`
- `actionlint` and repository-configured `yamllint` on the changed workflow/config files
- authenticated full Renovate dry run for the grouped Go toolchain update and post-upgrade notice task
- `make build` and `make unit-tests` in `operator/` (1,161 tests)
- operator Ginkgo suite with `--race` (1,161 tests)
- `make lint vet build` and root-container `make test` in `agent/go/` (264 specs)
- `go test -race` for non-chroot Go agent packages
- `make test` and `make build` in `agent/` (119 tests)
- root `make fmt` and `make license-header-check`

No runtime Kubernetes behavior changed, so the cluster end-to-end suites are not affected.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
