### PR TITLE
fix(ci): grant Renovate read access to vulnerability alerts

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -40,6 +40,12 @@ jobs:
       pull-requests: write
       issues: write
       statuses: write
+      # Grants read access to Dependabot vulnerability alerts, not just code
+      # scanning as the name suggests. Renovate needs it to raise prioritized
+      # security updates and to bypass minimumReleaseAge for a CVE fix; without
+      # it the run logs "Cannot access vulnerability alerts" and silently skips
+      # both.
+      security-events: read
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1


### PR DESCRIPTION
## Description

The Renovate job did not request `security-events: read`, so every run logs `Cannot access vulnerability alerts` and silently skips all alert-driven work.

`config:recommended` enables `vulnerabilityAlerts` by default. Without the permission Renovate cannot raise a prioritized security update, and `minimumReleaseAge: "3 days"` is not bypassed for a CVE fix. That is the specific gap #494 was filed to close ("a Go stdlib CVE fixed in a patch release produces no PR here and no signal at all"), so the capability was missing from the moment #520 landed.

#494 called this permission out as required, alongside `statuses: write`, based on the NVIDIA/aicr rollout. It appears to have been dropped in `457a6a94 fix(ci): limit Renovate permissions`.

Ordinary version-based updates were unaffected and are working: the same dry run proposed `renovate/go-toolchain` and `renovate/kubernetes` normally, ran `make notices` as a post-upgrade task, and saved all three notice files.

The added comment is deliberate. `security-events` reads as code-scanning-only, so a future permissions audit would plausibly trim it again the same way; the comment names the constraint that makes it necessary.

Closes #526.

## Validation

- `actionlint .github/workflows/renovate.yaml` (no findings)
- `yamllint -c ci/yamllint.yaml .github/workflows/renovate.yaml` (clean)

Discovered via a manual dry run of the merged workflow: https://github.com/NVIDIA/nodewright/actions/runs/32752909714

This change cannot be verified before merge, because scheduled and dispatched workflows only run from the default branch. After merge, re-dispatch and confirm the warning is gone:

```
gh workflow run renovate.yaml --repo NVIDIA/nodewright -f dryRun=true -f logLevel=debug
```

No documentation update is required. `CONTRIBUTING.md` and `docs/contributing/release-process.md` are the only Renovate references and neither enumerates the workflow permission set, so both remain accurate.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
