### PR TITLE
fix(ci): stop Renovate discarding every release for eight Go modules

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -59,12 +59,15 @@
       rangeStrategy: "bump",
       addLabels: ["component/operator", "component/agent"],
     },
-    {
-      // Do not let a module update raise the go directive as a side effect.
-      // Toolchain changes belong in the standalone group above.
-      matchManagers: ["gomod"],
-      constraintsFiltering: "strict",
-    },
+    // Do not add constraintsFiltering: "strict" here. Most of these modules
+    // resolve through the GitHub tags datasource, which carries no Go directive
+    // metadata, and strict mode discards every release whose constraints it
+    // cannot confirm. That silently dropped 100% of the releases for k8s.io/api,
+    // k8s.io/apimachinery, k8s.io/cli-runtime, k8s.io/klog/v2, onsi/ginkgo/v2,
+    // sethvargo/go-envconfig, golang.org/x/mod and prometheus/client_model, so
+    // those packages stopped receiving updates at all rather than merely being
+    // held back. The "Go toolchain" group above is what keeps go directive
+    // changes in their own PR.
     {
       groupName: "kubernetes",
       matchManagers: ["gomod"],


### PR DESCRIPTION
## Problem

`constraintsFiltering: "strict"` was discarding **100% of the candidate releases** for eight Go modules, so they silently stopped receiving updates entirely rather than merely being held back to a compatible version.

From a debug Renovate run on `main`:

```
Filtered out 645 non-matching releases out of 645 total for k8s.io/api
Filtered out 645 non-matching releases out of 645 total for k8s.io/apimachinery
Filtered out 645 non-matching releases out of 645 total for k8s.io/cli-runtime
Filtered out  34 non-matching releases out of  34 total for k8s.io/klog/v2
Filtered out  83 non-matching releases out of  83 total for github.com/onsi/ginkgo/v2
Filtered out  40 non-matching releases out of  40 total for github.com/sethvargo/go-envconfig
Filtered out  44 non-matching releases out of  44 total for golang.org/x/mod
Filtered out   8 non-matching releases out of   8 total for github.com/prometheus/client_model
```

An empty candidate list is what produces the `Found no results from datasource that look like a version` message for each of those modules, after which no update is proposed.

## Why every release fails the filter

The release objects in the debug log carry only `version` and `releaseTimestamp`, with no `constraints` field. These modules resolve through the **GitHub tags** datasource rather than the Go proxy: the results record `sourceUrl: https://github.com/kubernetes/api`, and the only proxy request made is to `proxy.golang.org/k8s.io/api/v2/@v/list`, which 404s because `k8s.io/api` has no `/v2` module path. GitHub tags carry no Go directive metadata, and strict mode discards any release whose constraints it cannot confirm.

So the filter is not rejecting `go 1.26.0` as too new for our `go 1.27.0`. It is rejecting "unknown".

The pattern in the data matches: modules where at least some releases carried constraint metadata were only partly filtered (`client-go` 646/664, `kubernetes` 703/1240, `controller-runtime` 146/159, `gomega` 66/83, `sigs.k8s.io/yaml` 5/7).

## Observed impact

PR #529 was opened as `chore(deps): update kubernetes` carrying six updates. On rebase it was rewritten down to the single `k8s.io/utils` digest bump, which survived only because digest updates take a different code path. The five Kubernetes patch updates were dropped and no replacement PR was created. It merged as a `k8s.io/utils`-only change.

## Fix

Remove the rule. Its stated intent, keeping `go` directive changes out of module PRs, is already served by the separate `Go toolchain` group, which matches `matchDepNames: ["go"]` / `matchDepTypes: ["golang"]` and updates them as their own PR. A comment is left in place of the rule because the failure is silent and the option is otherwise tempting to re-add.

## Verification

Run with the CI-pinned Renovate image (`ghcr.io/renovatebot/renovate@sha256:e6b93e70…`, the digest from `.github/workflows/renovate.yaml`) using `--platform=local --dry-run=full`.

The baseline on unmodified `main` reproduced the hosted CI run exactly, including the same partial-filter ratios, which is what makes the comparison meaningful.

| | before | after |
|---|---|---|
| `Found no results from datasource` | 8 | 0 |
| `Filtered out … releases` | 24 | 0 |
| branches proposed | none | `renovate/kubernetes` |

The proposed branch carries exactly the updates that had gone missing:

```
k8s.io/api           v0.36.3 -> v0.36.4  patch
k8s.io/apimachinery  v0.36.3 -> v0.36.4  patch
k8s.io/cli-runtime   v0.36.3 -> v0.36.4  patch
k8s.io/client-go     v0.36.3 -> v0.36.4  patch
k8s.io/kubernetes    v1.36.3 -> v1.36.4  patch
```

`renovate-config-validator` passes against the final file.

## Note on the go directive

I was not able to run a real `go get` + `go mod tidy` to prove the unblocked updates leave the `go` directive alone, because module resolution for `golang.org/x/*` is currently failing on my network. All five bumped modules declare `go 1.26.0` in their own `go.mod` and this repo is on `go 1.27.0`, and `go mod tidy` only raises the directive when a dependency requires a higher one, so it should not move. Renovate runs `gomodTidy` when it builds the branch, so the resulting PR diff will show it either way.

## Caveat

Renovate reads its config from the default branch, so this change has no effect until it is merged. The next run after merge is the real test.
