### PR TITLE
fix(operator): wait for evicted pods to terminate before interrupt

### DIFF
--- a/docs/architecture/interrupt-flow.md
+++ b/docs/architecture/interrupt-flow.md
@@ -146,7 +146,7 @@ The fields map to Kubernetes drain behavior:
 - `deleteEmptyDirData`: when `false`, pods with `emptyDir` volumes block drain. The default is `true`.
 - `force`: when `false`, pods without a managing controller block drain. The default is `true`.
 - `ignoreDaemonSets`: when `true`, DaemonSet-managed pods are skipped during drain. The default is `true`.
-- `timeout`: bounds how long a node may spend draining, measured from the first evict or delete until the node is drained. Unset or zero means no timeout, so a pod that never finishes terminating holds the node in `in_progress` indefinitely. When the timeout expires, the node is marked `erroring` and package stages do not proceed on that node.
+- `timeout`: bounds how long a node may spend draining, measured from drain start — the first pass that finds the node not yet drained, which is before any evict or delete is issued — until the node is drained. Unset or zero means no timeout, so a pod that never finishes terminating holds the node in `in_progress` indefinitely. When the timeout expires, the node is marked `erroring` and package stages do not proceed on that node.
 - `gracePeriod`: overrides the grace period used for eviction or direct deletion. Unset uses each pod's own `terminationGracePeriodSeconds`.
 
 The operator also skips pods that tolerate the `node.kubernetes.io/unschedulable`
@@ -175,10 +175,10 @@ the node stays in `in_progress`, no further evict or delete is issued for it,
 and the interrupt does not run until the pod object is gone. This matches
 `kubectl drain`, which waits for the pods it selected to disappear.
 
-Only pods the operator would have evicted itself are waited on. The exclusions
-above still apply while a pod is terminating, so a DaemonSet pod mid-rollout, a
-`kube-system` pod, or one of the operator's own package pods never holds up a
-drain.
+Only pods the operator selected for eviction or deletion are waited on. The
+exclusions above still apply while a pod is terminating, so a DaemonSet pod
+mid-rollout, a `kube-system` pod, or one of the operator's own package pods never
+holds up a drain.
 
 Because drain now waits out termination, a workload's
 `terminationGracePeriodSeconds` is on the critical path for every interrupt, and

--- a/docs/architecture/interrupt-flow.md
+++ b/docs/architecture/interrupt-flow.md
@@ -146,25 +146,45 @@ The fields map to Kubernetes drain behavior:
 - `deleteEmptyDirData`: when `false`, pods with `emptyDir` volumes block drain. The default is `true`.
 - `force`: when `false`, pods without a managing controller block drain. The default is `true`.
 - `ignoreDaemonSets`: when `true`, DaemonSet-managed pods are skipped during drain. The default is `true`.
-- `timeout`: bounds how long a node may spend draining. Unset or zero means no timeout. When the timeout expires, the node is marked `erroring` and package stages do not proceed on that node.
+- `timeout`: bounds how long a node may spend draining, measured from the first evict or delete until the node is drained. Unset or zero means no timeout, so a pod that never finishes terminating holds the node in `in_progress` indefinitely. When the timeout expires, the node is marked `erroring` and package stages do not proceed on that node.
 - `gracePeriod`: overrides the grace period used for eviction or direct deletion. Unset uses each pod's own `terminationGracePeriodSeconds`.
 
-The operator also skips pods that are already terminating, pods that tolerate
-the `node.kubernetes.io/unschedulable` taint, mirror/static pods, pods in
-`kube-system`, and its own package pods — identified by the
-`nodewright.nvidia.com/name` and `nodewright.nvidia.com/package` labels stamped on
-every package pod, so they remain exempt even if an admission controller
-rewrites or strips their tolerations. The label exemption only applies to
-pods in the operator's own namespace, so workloads elsewhere cannot opt out
+The operator also skips pods that tolerate the `node.kubernetes.io/unschedulable`
+taint, mirror/static pods, pods in `kube-system`, and its own package pods —
+identified by the `nodewright.nvidia.com/name` and `nodewright.nvidia.com/package`
+labels stamped on every package pod, so they remain exempt even if an admission
+controller rewrites or strips their tolerations. The label exemption only applies
+to pods in the operator's own namespace, so workloads elsewhere cannot opt out
 of drain by copying the labels. These exclusions are not user-configurable.
 
 Compared to earlier releases, the default drain filter now follows Kubernetes
 matching more closely: the unschedulable toleration check uses Kubernetes
 `ToleratesTaint` semantics, DaemonSet pods are identified from the controller
-owner reference, and already-terminating or mirror/static pods are ignored.
+owner reference, and mirror/static pods are ignored.
 
 `podNonInterruptLabels` remains a pre-drain barrier. Matching pods must finish
 or move away before the operator starts the configurable drain step.
+
+### When Drain Is Complete
+
+Drain is complete once the pods it selected have actually left the node, not
+once their evictions were accepted. A pod that has an eviction or delete in
+flight keeps a `deletionTimestamp` while the kubelet works through its
+`terminationGracePeriodSeconds`, and the operator treats it as still present:
+the node stays in `in_progress`, no further evict or delete is issued for it,
+and the interrupt does not run until the pod object is gone. This matches
+`kubectl drain`, which waits for the pods it selected to disappear.
+
+Only pods the operator would have evicted itself are waited on. The exclusions
+above still apply while a pod is terminating, so a DaemonSet pod mid-rollout, a
+`kube-system` pod, or one of the operator's own package pods never holds up a
+drain.
+
+Because drain now waits out termination, a workload's
+`terminationGracePeriodSeconds` is on the critical path for every interrupt, and
+a pod that cannot finish terminating — a stuck finalizer, an unresponsive
+kubelet — blocks the node's interrupt until it is cleared. Set
+`spec.drainConfig.timeout` to bound that wait; there is no default.
 
 ### Recovering From a Drain Timeout
 

--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -152,7 +152,7 @@ For the full commit-level log see CHANGELOG.md.
   fired. Terminating pods now block drain, matching `kubectl drain`. The exclusions
   (DaemonSet, `kube-system`, mirror/static, unschedulable-tolerating, and the
   operator's own package pods) still apply while a pod terminates, so drain only ever
-  waits on pods it would have evicted itself.
+  waits on pods it selected for eviction or deletion.
 
   **Expect interrupts to start later than they used to** — by roughly the longest
   `terminationGracePeriodSeconds` among the pods on the node. `spec.drainConfig.timeout`

--- a/operator/RELEASE_NOTES.md
+++ b/operator/RELEASE_NOTES.md
@@ -144,6 +144,23 @@ For the full commit-level log see CHANGELOG.md.
 
 ### Bug Fixes
 
+- **Drain now completes when the evicted pods have terminated, not when their
+  evictions were accepted.** A pod carrying a `deletionTimestamp` was classified as
+  ignorable, so one pass evicted and the next — two seconds later — saw everything
+  terminating and reported the node drained. A workload with a 30s
+  `terminationGracePeriodSeconds` was roughly 2s into shutdown when the interrupt
+  fired. Terminating pods now block drain, matching `kubectl drain`. The exclusions
+  (DaemonSet, `kube-system`, mirror/static, unschedulable-tolerating, and the
+  operator's own package pods) still apply while a pod terminates, so drain only ever
+  waits on pods it would have evicted itself.
+
+  **Expect interrupts to start later than they used to** — by roughly the longest
+  `terminationGracePeriodSeconds` among the pods on the node. `spec.drainConfig.timeout`
+  now measures time-to-drain rather than time-to-accept-evictions, and it still has no
+  default: a pod that can never finish terminating (stuck finalizer, unresponsive
+  kubelet) holds the node in `in_progress` until it is cleared. Set a `timeout` if you
+  need that wait bounded.
+
 - **The migration now touches only the keys the operator owns, not the whole
   `skyhook.nvidia.com/` prefix.** The metadata prefix is the product's domain name,
   so users legitimately carry their own node labels and annotations under it. The

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -616,6 +616,87 @@ var _ = Describe("skyhook controller tests", func() {
 			Expect(drained).To(BeTrue())
 		})
 
+		It("should not report drained while an evicted pod is still terminating", func() {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "workload",
+					Namespace: "default",
+					// The finalizer stands in for a pod that has accepted its eviction but has
+					// not finished terminating, which is what drain now has to wait out.
+					Finalizers: []string{"nodewright.nvidia.com/test-hold"},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:       "ReplicaSet",
+							Name:       "workload-rs",
+							Controller: ptr(true),
+						},
+					},
+				},
+				Spec: corev1.PodSpec{
+					NodeName: "node-a",
+					Containers: []corev1.Container{
+						{Name: "workload", Image: "busybox"},
+					},
+				},
+				Status: corev1.PodStatus{Phase: corev1.PodRunning},
+			}
+
+			deleteCount := 0
+			baseClient := fakeDrainClient(pod)
+			testClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					deleteCount++
+					return c.Delete(ctx, obj, opts...)
+				},
+			})
+
+			r, err := NewSkyhookReconciler(testClient.Scheme(), testClient, testClient, k8sfake.NewClientset(), events.NewFakeRecorder(10), opts)
+			Expect(err).ToNot(HaveOccurred())
+
+			node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-a"}}
+			skyhook := &v1alpha1.NodeWright{
+				ObjectMeta: metav1.ObjectMeta{Name: "drain-terminating"},
+				Spec: v1alpha1.NodeWrightSpec{
+					DrainConfig: &v1alpha1.DrainConfig{
+						DisableEviction: ptr(true),
+					},
+					Packages: v1alpha1.Packages{},
+				},
+			}
+			skyhookNode, err := wrapper.NewSkyhookNode(node, skyhook)
+			Expect(err).ToNot(HaveOccurred())
+
+			_package := &v1alpha1.Package{
+				PackageRef: v1alpha1.PackageRef{Name: "pkg", Version: "1.0.0"},
+			}
+
+			drained, err := r.DrainNode(ctx, skyhookNode, _package)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(drained).To(BeFalse())
+			Expect(deleteCount).To(Equal(1))
+
+			terminating := &corev1.Pod{}
+			Expect(testClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "workload"}, terminating)).To(Succeed())
+			Expect(terminating.DeletionTimestamp).ToNot(BeNil())
+
+			isDrained, err := r.IsDrained(ctx, skyhookNode)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(isDrained).To(BeFalse())
+
+			drained, err = r.DrainNode(ctx, skyhookNode, _package)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(drained).To(BeFalse())
+			Expect(deleteCount).To(Equal(1))
+
+			terminating.Finalizers = nil
+			Expect(testClient.Update(ctx, terminating)).To(Succeed())
+			Expect(apierrors.IsNotFound(testClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "workload"}, &corev1.Pod{}))).To(BeTrue())
+
+			drained, err = r.DrainNode(ctx, skyhookNode, _package)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(drained).To(BeTrue())
+		})
+
 		It("should wait without deleting unmanaged pods when force is false", func() {
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{

--- a/operator/internal/drain/drain.go
+++ b/operator/internal/drain/drain.go
@@ -149,10 +149,6 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 		return Decision{Action: ActionIgnore, Reason: ReasonPhase}
 	}
 
-	if pod.DeletionTimestamp != nil {
-		return Decision{Action: ActionIgnore, Reason: ReasonTerminating}
-	}
-
 	// Package pods normally dodge drain via toleratesUnschedulable below, but
 	// some admission controllers rewrite or strip pod tolerations, so the
 	// operator's own in-flight pods are also recognized by the labels stamped
@@ -178,6 +174,15 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 
 	if isMirrorPod(pod) {
 		return Decision{Action: ActionIgnore, Reason: ReasonMirrorPod}
+	}
+
+	// A pod that has already accepted its eviction still holds the node's resources
+	// until the kubelet finishes killing it, so it blocks rather than being ignored:
+	// drain is done when the workloads are gone, not when the evictions were accepted.
+	// This sits below the exemptions above so that drain only ever waits on pods it
+	// would have evicted itself, which is what kubectl drain waits for.
+	if pod.DeletionTimestamp != nil {
+		return Decision{Action: ActionBlock, Reason: ReasonTerminating}
 	}
 
 	if controllerRef == nil && !options.Force {

--- a/operator/internal/drain/drain.go
+++ b/operator/internal/drain/drain.go
@@ -180,7 +180,8 @@ func DecidePod(pod *corev1.Pod, options Options) Decision {
 	// until the kubelet finishes killing it, so it blocks rather than being ignored:
 	// drain is done when the workloads are gone, not when the evictions were accepted.
 	// This sits below the exemptions above so that drain only ever waits on pods it
-	// would have evicted itself, which is what kubectl drain waits for.
+	// would have selected for eviction or deletion itself, which is what kubectl drain
+	// waits for.
 	if pod.DeletionTimestamp != nil {
 		return Decision{Action: ActionBlock, Reason: ReasonTerminating}
 	}

--- a/operator/internal/drain/drain_test.go
+++ b/operator/internal/drain/drain_test.go
@@ -44,6 +44,7 @@ func int64Ptr(value int64) *int64 {
 var _ = Describe("DecidePod", func() {
 	controller := true
 	const daemonSetKind = "DaemonSet"
+	terminatingTimestamp := metav1.NewTime(time.Date(2026, time.June, 2, 12, 0, 0, 0, time.UTC))
 
 	basePod := func() *corev1.Pod {
 		return &corev1.Pod{
@@ -94,16 +95,77 @@ var _ = Describe("DecidePod", func() {
 		Expect(decision.BlocksDrain()).To(BeFalse())
 	})
 
-	It("should ignore pods that are already terminating", func() {
+	It("should block on evictable pods that are already terminating", func() {
 		pod := basePod()
-		deletionTimestamp := metav1.NewTime(time.Date(2026, time.June, 2, 12, 0, 0, 0, time.UTC))
-		pod.DeletionTimestamp = &deletionTimestamp
+		pod.DeletionTimestamp = &terminatingTimestamp
 
 		decision := DecidePod(pod, DefaultOptions())
 
-		Expect(decision).To(Equal(Decision{Action: ActionIgnore, Reason: ReasonTerminating}))
-		Expect(decision.BlocksDrain()).To(BeFalse())
+		Expect(decision).To(Equal(Decision{Action: ActionBlock, Reason: ReasonTerminating}))
+		Expect(decision.BlocksDrain()).To(BeTrue())
+		Expect(decision.RequiresAction()).To(BeFalse())
 	})
+
+	It("should report terminating ahead of the other blocking reasons", func() {
+		pod := basePod()
+		pod.DeletionTimestamp = &terminatingTimestamp
+		pod.OwnerReferences = nil
+		options := DefaultOptions()
+		options.Force = false
+
+		decision := DecidePod(pod, options)
+
+		Expect(decision).To(Equal(Decision{Action: ActionBlock, Reason: ReasonTerminating}))
+	})
+
+	DescribeTable("should keep exempt pods ignored while they terminate",
+		func(mutate func(*corev1.Pod), expectedDecision Decision) {
+			pod := basePod()
+			pod.DeletionTimestamp = &terminatingTimestamp
+			mutate(pod)
+			options := DefaultOptions()
+			options.PackageNamespace = "skyhook"
+
+			decision := DecidePod(pod, options)
+
+			Expect(decision).To(Equal(expectedDecision))
+			Expect(decision.BlocksDrain()).To(BeFalse())
+		},
+		Entry("finished pods",
+			func(pod *corev1.Pod) { pod.Status.Phase = corev1.PodSucceeded },
+			Decision{Action: ActionIgnore, Reason: ReasonPhase},
+		),
+		Entry("the operator's own package pods",
+			func(pod *corev1.Pod) {
+				pod.Namespace = "skyhook"
+				pod.Labels = map[string]string{
+					"nodewright.nvidia.com/name":    "my-skyhook",
+					"nodewright.nvidia.com/package": "pkg-1.0.0",
+				}
+			},
+			Decision{Action: ActionIgnore, Reason: ReasonSkyhookPackage},
+		),
+		Entry("pods tolerating the unschedulable taint",
+			func(pod *corev1.Pod) {
+				pod.Spec.Tolerations = []corev1.Toleration{{Key: corev1.TaintNodeUnschedulable}}
+			},
+			Decision{Action: ActionIgnore, Reason: ReasonUnschedulableToleration},
+		),
+		Entry("daemonset pods",
+			func(pod *corev1.Pod) { pod.OwnerReferences[0].Kind = daemonSetKind },
+			Decision{Action: ActionIgnore, Reason: ReasonDaemonSet},
+		),
+		Entry("kube-system pods",
+			func(pod *corev1.Pod) { pod.Namespace = "kube-system" },
+			Decision{Action: ActionIgnore, Reason: ReasonKubeSystem},
+		),
+		Entry("mirror pods",
+			func(pod *corev1.Pod) {
+				pod.Annotations = map[string]string{MirrorPodAnnotationKey: "mirror-id"}
+			},
+			Decision{Action: ActionIgnore, Reason: ReasonMirrorPod},
+		),
+	)
 
 	It("should never drain pods that tolerate the unschedulable taint", func() {
 		pod := basePod()


### PR DESCRIPTION
## Description

Closes #534.

`DecidePod` classified any pod carrying a `deletionTimestamp` as ignorable, and `BlocksDrain()` is defined as "not ignored", so a terminating pod neither got re-evicted (correct) nor blocked drain (incorrect). `IsDrained` returned true as soon as every evictable pod merely *had* a `deletionTimestamp`. With the 2s requeue: pass 1 evicts, pass 2 sees everything terminating and reports the node drained, and the interrupt fires. A pod with a 30s `terminationGracePeriodSeconds` was ~2s into shutdown when the node rebooted.

Terminating pods now return `ActionBlock`. Both call sites already do the right thing with that — `IsDrained` counts the pod as still present, and the `DrainNode` switch maps `ActionBlock` to `waitingForPods` without re-evicting. This matches `kubectl drain`, which waits for the pods it selected to disappear.

### Beyond the one-line fix in the issue: the check also moves below the exemptions

The issue suggested flipping `drain.go:153` in place. Doing only that would be unsafe. The terminating check sat second, *above* the package-pod, unschedulable-toleration, DaemonSet, `kube-system`, and mirror-pod filters, so `ActionBlock` there would make a terminating DaemonSet pod mid-rollout — or one of the operator's own package pods — block drain. The package-pod exemption exists precisely so the operator does not deadlock on itself. `kubectl drain` does not wait on pods it did not select either, so the check now sits below every exemption and above the other block reasons:

```
phase           -> ignore
package pod     -> ignore
tolerates unsch -> ignore
daemonset       -> ignore
kube-system     -> ignore
mirror pod      -> ignore
terminating     -> BLOCK    <- moved here
unmanaged       -> block
emptyDir        -> block
-> evict / delete
```

No new patterns are introduced; this reuses the existing `ActionBlock` / `BlocksDrain()` / `RequiresAction()` split that already distinguishes "still here, don't act on it" for unmanaged and `emptyDir` pods.

### On the drain timeout

`drainConfig.timeout` now measures time-to-drain rather than time-to-accept-evictions, which reads like the wait it was meant to bound.

Its semantics are deliberately **unchanged**: unset or zero is still no timeout, so a pod that can never finish terminating (stuck finalizer, unresponsive kubelet) holds the node in `in_progress` until it is cleared. The issue raised a default timeout as a caveat worth deciding — I left it out on purpose. Introducing one would newly mark PDB-gated drains `erroring` (recovery being `kubectl nodewright reset`), which is a behavior change with its own blast radius and belongs in its own PR rather than riding along on a correctness fix. The docs now say plainly that there is no default and point at `spec.drainConfig.timeout` for bounding the wait.

### Tests

Each new test was confirmed failing before the fix and passing after.

- `internal/drain/drain_test.go` — a terminating evictable pod blocks (`BlocksDrain()` true, `RequiresAction()` false); `terminating` is reported ahead of the other block reasons; a six-entry table asserts every exemption still ignores a pod that happens to be terminating (finished, package pod, unschedulable-tolerating, DaemonSet, `kube-system`, mirror). Seven of these failed pre-fix.
- `internal/controller/skyhook_controller_test.go` — a pod held in `Terminating` by a finalizer: `DrainNode` deletes it once, then reports not-drained across subsequent passes **without re-deleting**, and only returns `true` once the pod object is actually gone. Failed pre-fix with `Expected true to be false`.

`make unit-tests`: 15 suites, all passed. `make fmt` / `make vet` / license-header check clean, with no generated-file churn. `make lint` could not run locally — the checked-in `golangci-lint` is built with go1.26 and refuses the go1.27 target; leaving that to CI.

No chainsaw e2e was added: asserting "the interrupt had not started yet" is inherently timing-dependent, and the existing `nodewright/interrupt` suite already covers the drain path (its fixtures use `terminationGracePeriodSeconds: 5`, so it simply takes ~5s longer per node).

### Docs

- `docs/architecture/interrupt-flow.md` — dropped "already terminating" from the skip list, added a **When Drain Is Complete** section covering the wait-for-termination contract and the fact that only pods the operator would have evicted itself are waited on, and expanded the `timeout` bullet.
- `operator/RELEASE_NOTES.md` — entry under Bug Fixes. Users will notice interrupts starting later, by roughly the longest `terminationGracePeriodSeconds` on the node, so this is a surprise worth recording rather than a silent restoration of intended behavior.

Builds on #536 (the cordon-before-drain fix); the two together define the intended cordon → drain → interrupt ordering, though they are independent changes.

## Checklist

- [X] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/skyhook/blob/main/CONTRIBUTING.md).
- [X] My commits are signed off (`git commit -s`) per the [DCO](https://developercertificate.org/).
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.