### PR TITLE
docs: add a quickstart and move install out of the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 **NodeWright** is a Kubernetes-aware package manager for cluster administrators to safely modify and maintain underlying host declaratively at scale.
 
+**New here?** Start with the **[Quickstart](docs/getting-started/quickstart.md)** to install NodeWright and run a package on one node in about five minutes, or the **[Overview](docs/getting-started/overview.md)** for what NodeWright is and when to reach for it. Full docs live in [`docs/`](docs/README.md).
+
 > **Note:** NodeWright is being renamed from Skyhook, and the rename has now landed for the core surfaces. The Helm chart, operator image, CLI (`kubectl nodewright`), and the CRDs (`nodewright.nvidia.com/v1alpha1`, Kind `NodeWright`; `DeploymentPolicy` moves to the same group) are published under `nodewright`. Existing `skyhook.nvidia.com`/`Skyhook` resources keep working during the transition: the operator auto-imports them to NodeWright and preserves per-node state (no package re-run), and legacy writes emit a deprecation warning. See the [migration guide](docs/getting-started/migration.md).
 >
 > **Distribution change (v0.16.0+):** NodeWright is now distributed exclusively through GitHub Container Registry (`ghcr.io`) — both the container images and the Helm chart (as an OCI artifact). Publication to `nvcr.io` / the NGC Helm repository (`helm.ngc.nvidia.com`) is paused and is planned to return in a future release. **Existing users installing from NGC need to switch to the OCI install below.** See [Distribution: ghcr.io only (for now)](docs/contributing/release-process.md#distribution-ghcrio-only-for-now) for the full story.
@@ -58,146 +60,19 @@ NodeWright works in any Kubernetes environment (self-managed, on-prem, cloud) an
 
 There are a few pre-built generalist packages available at [NVIDIA/nodewright-packages](https://github.com/NVIDIA/nodewright-packages)
 
-## Installation via Helm
-
-Install NodeWright quickly using Helm without downloading the repository:
-
-### Prerequisites
-
-- Kubernetes cluster (tested on v1.30+)
-- Helm 3.x installed
-- Container registry access credentials (if using private registries)
-
-### Install NodeWright
+## Installation
 
 ```bash
-# The chart is distributed as an OCI artifact on GitHub Container Registry.
-# Helm 3.8+ supports OCI natively — no `helm repo add` needed.
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
   --version v0.18.0 \
   --namespace nodewright \
   --create-namespace
 ```
 
-> **Where things live:** chart at `oci://ghcr.io/nvidia/nodewright/charts/nodewright`, operator image at `ghcr.io/nvidia/nodewright/operator`, agent image at `ghcr.io/nvidia/nodewright/agent`. NGC / `nvcr.io` distribution is paused — see [docs/contributing/release-process.md#distribution-ghcrio-only-for-now](docs/contributing/release-process.md#distribution-ghcrio-only-for-now).
->
-> **Migrating from `helm repo add skyhook https://helm.ngc.nvidia.com/...`?** Run `helm repo remove skyhook` and use the OCI install above. If you also want to keep the existing in-cluster release name (e.g. `skyhook`), substitute it for `nodewright` in the `helm install` command — the chart works either way.
->
-> **Already installed in the `skyhook` namespace?** Stay there. The documented namespace for **new** installs moved from `skyhook` to `nodewright`, but Kubernetes namespaces cannot be renamed in place and Helm cannot move a release between namespaces, so there is nothing to migrate and no deadline. `kubectl nodewright` finds the operator in either namespace automatically. See [docs/getting-started/migration.md#install-namespace](docs/getting-started/migration.md#install-namespace-skyhook---nodewright).
+Then run a package on one node with the [Quickstart](docs/getting-started/quickstart.md).
 
-### Configure Image Pull Secrets (if needed)
-
-If you're using private container registries, create the necessary secrets:
-
-```bash
-kubectl create secret generic node-init-secret \
-  --from-file=.dockerconfigjson=${HOME}/.docker/config.json \
-  --type=kubernetes.io/dockerconfigjson \
-  --namespace nodewright
-```
-
-**Note:** NodeWright currently uses a single shared image pull secret for all packages, and agent/operator containers. If you need access to multiple registries, combine the credentials into one `dockerconfigjson` secret with multiple registry auths.
-
-### Verify Installation
-
-```bash
-# Check that the operator is running
-kubectl get pods -n nodewright
-
-# or Wait for the deployment to be available first
-kubectl wait --for=condition=Available deployment -l control-plane=controller-manager -n nodewright --timeout=300s
-
-# Then wait for the operator pod to be ready
-kubectl wait --for=condition=Ready pod -l control-plane=controller-manager -n nodewright --timeout=300s
-
-# Verify the Ready condition
-kubectl get pods -l control-plane=controller-manager -n nodewright -o jsonpath='{.items[0].status.conditions[?(@.type=="Ready")].status}'
-
-# Verify the CRDs are installed
-kubectl get crd | grep nodewright
-
-# Verify packages are working
-kubectl apply -f - <<EOF
-apiVersion: nodewright.nvidia.com/v1alpha1
-kind: NodeWright
-metadata:
-  name: nodewright-sample
-spec:
-  nodeSelectors:
-    matchExpressions:
-      - key: node-role.kubernetes.io/control-plane
-        operator: DoesNotExist
-  packages:
-    something-important:
-      version: 1.1.1
-      image: ghcr.io/nvidia/skyhook-packages/shellscript
-      configMap:
-        apply.sh: |-
-          #!/bin/bash
-          echo "hello world" > /skyhook-hello-world
-          sleep 10
-        apply_check.sh: |-
-          #!/bin/bash
-                     cat /skyhook-hello-world | wc -l | grep -q 1
-           sleep 10
-EOF
-
-# Wait for the NodeWright to complete
-kubectl wait --for=jsonpath='{.status.status}'=complete nodewright/nodewright-sample --timeout=300s
-
-# Check the status
-kubectl describe nodewright nodewright-sample
-```
-
-### Uninstalling
-
-**Automatic Cleanup (Default):** By default, the Helm chart includes a pre-delete hook that automatically cleans up all NodeWright and DeploymentPolicy resources before uninstalling:
-
-```bash
-# Uninstall the chart (cleanup happens automatically)
-helm uninstall nodewright --namespace nodewright
-```
-
-The pre-delete hook will:
-
-- Delete all NodeWright resources
-- Delete all DeploymentPolicy resources  
-- Complete quickly if no resources exist
-- Wait for finalizers to be processed if resources exist
-- Proceed with uninstall even if cleanup times out (job deadline: 2 minutes)
-
-**Configuration Options:**
-
-To disable automatic cleanup and manage resources manually:
-
-```bash
-helm install nodewright ./chart --namespace nodewright --set cleanup.enabled=false
-```
-
-To adjust the job timeout:
-
-```bash
-helm install nodewright ./chart --namespace nodewright \
-  --set cleanup.jobTimeoutSeconds=180
-```
-
-**Manual Cleanup (if needed):**
-
-If you disabled automatic cleanup or need to clean up resources manually:
-
-```bash
-# Delete all NodeWright resources first
-kubectl delete nodewrights.nodewright.nvidia.com --all
-kubectl delete deploymentpolicies.nodewright.nvidia.com --all
-
-# Delete all DeploymentPolicy resources
-kubectl delete deploymentpolicies --all
-
-# Then uninstall the chart
-helm uninstall nodewright --namespace nodewright
-```
-
-**Why cleanup matters:** If you uninstall while NodeWright CRs with finalizers still exist, it can leave resources in a broken state that may cause reinstall issues.
+Image pull secrets, private registries, cleanup options, and uninstall are all
+covered in [Installation](docs/getting-started/installation.md).
 
 ## Monitoring and Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,7 @@ This directory contains user and operator documentation for NodeWright. Here you
 ## Getting Started
 
 - [Overview](getting-started/overview.md): What NodeWright is and how it works.
+- [Quickstart](getting-started/quickstart.md): Install NodeWright and run a hello-world package on one node.
 - [Installation](getting-started/installation.md): Install NodeWright via Helm.
 - [Migration from Skyhook](getting-started/migration.md): Transition guide from Skyhook to NodeWright.
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,7 +38,9 @@ helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
 Omit `--set imagePullSecret=node-init-secret` if you're pulling from public registries only.
 
 > **Where things live:** chart at `oci://ghcr.io/nvidia/nodewright/charts/nodewright`, operator image at `ghcr.io/nvidia/nodewright/operator`, agent image at `ghcr.io/nvidia/nodewright/agent`.
-> **Migrating from `helm repo add skyhook https://helm.ngc.nvidia.com/...`?** Run `helm repo remove skyhook` and use the OCI install above.
+> **Migrating from `helm repo add skyhook https://helm.ngc.nvidia.com/...`?** Run `helm repo remove skyhook` and use the OCI install above. If you want to keep the existing in-cluster release name (e.g. `skyhook`), substitute it for `nodewright` in the `helm install` command — the chart works either way.
+>
+> **Already installed in the `skyhook` namespace?** Stay there. The documented namespace for **new** installs moved from `skyhook` to `nodewright`, but Kubernetes namespaces cannot be renamed in place and Helm cannot move a release between namespaces, so there is nothing to migrate and no deadline. `kubectl nodewright` finds the operator in either namespace automatically. See [Install namespace](migration.md#install-namespace-skyhook---nodewright).
 
 ## Verify Installation
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -64,6 +64,45 @@ By default, the Helm chart includes a pre-delete hook that automatically cleans 
 helm uninstall nodewright --namespace nodewright
 ```
 
+The pre-delete hook will:
+
+- Delete all NodeWright resources
+- Delete all DeploymentPolicy resources
+- Complete quickly if no resources exist
+- Wait for finalizers to be processed if resources exist
+- Proceed with uninstall even if cleanup times out (job deadline: 2 minutes)
+
+### Cleanup options
+
+To disable automatic cleanup and manage resources manually:
+
+```bash
+helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --namespace nodewright --set cleanup.enabled=false
+```
+
+To adjust the cleanup job timeout:
+
+```bash
+helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --namespace nodewright --set cleanup.jobTimeoutSeconds=180
+```
+
+### Manual cleanup
+
+If you disabled automatic cleanup, or need to clean up by hand:
+
+```bash
+# Delete all NodeWright and DeploymentPolicy resources first
+kubectl delete nodewrights.nodewright.nvidia.com --all
+kubectl delete deploymentpolicies.nodewright.nvidia.com --all
+
+# Then uninstall the chart
+helm uninstall nodewright --namespace nodewright
+```
+
+**Why cleanup matters:** uninstalling while NodeWright CRs with finalizers still exist can leave resources in a broken state that causes problems on reinstall.
+
 For more details on explicit package uninstall, see [Uninstall](../user-guide/uninstall.md).
 
 ## Related

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -38,7 +38,14 @@ helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
 Omit `--set imagePullSecret=node-init-secret` if you're pulling from public registries only.
 
 > **Where things live:** chart at `oci://ghcr.io/nvidia/nodewright/charts/nodewright`, operator image at `ghcr.io/nvidia/nodewright/operator`, agent image at `ghcr.io/nvidia/nodewright/agent`.
-> **Migrating from `helm repo add skyhook https://helm.ngc.nvidia.com/...`?** Run `helm repo remove skyhook` and use the OCI install above. If you want to keep the existing in-cluster release name (e.g. `skyhook`), substitute it for `nodewright` in the `helm install` command — the chart works either way.
+> **Migrating from `helm repo add skyhook https://helm.ngc.nvidia.com/...`?** Run `helm repo remove skyhook`, then point your existing release at the OCI chart. Because the release already exists, this is an **upgrade, not an install** — `helm install` fails on a name that is already in use:
+>
+> ```bash
+> helm upgrade <release-name> oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+>   --version v0.18.0 --namespace <existing-namespace>
+> ```
+>
+> Keeping the old release name (e.g. `skyhook`) is fine — the chart works either way.
 >
 > **Already installed in the `skyhook` namespace?** Stay there. The documented namespace for **new** installs moved from `skyhook` to `nodewright`, but Kubernetes namespaces cannot be renamed in place and Helm cannot move a release between namespaces, so there is nothing to migrate and no deadline. `kubectl nodewright` finds the operator in either namespace automatically. See [Install namespace](migration.md#install-namespace-skyhook---nodewright).
 
@@ -68,25 +75,32 @@ helm uninstall nodewright --namespace nodewright
 
 The pre-delete hook will:
 
-- Delete all NodeWright resources
-- Delete all DeploymentPolicy resources
+- Delete all NodeWright resources, and legacy Skyhook resources if any remain
+- Delete DeploymentPolicy resources in both API groups
 - Complete quickly if no resources exist
 - Wait for finalizers to be processed if resources exist
-- Proceed with uninstall even if cleanup times out (job deadline: 2 minutes)
+
+Each delete is best-effort — a failing one does not fail the hook. The **job as a
+whole** is bounded by `cleanup.jobTimeoutSeconds` (default 120), and that bound is
+a hard deadline: if a finalizer keeps the job waiting past it, the job is killed
+and marked `Failed`, which fails the pre-delete hook and so fails
+`helm uninstall`. If that happens, clean up by hand using the commands below and
+re-run the uninstall with `--no-hooks`.
 
 ### Cleanup options
 
-To disable automatic cleanup and manage resources manually:
+Set these at install time with `helm install`, or on an existing release with
+`helm upgrade`. To disable automatic cleanup and manage resources manually:
 
 ```bash
-helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
   --namespace nodewright --set cleanup.enabled=false
 ```
 
 To adjust the cleanup job timeout:
 
 ```bash
-helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
   --namespace nodewright --set cleanup.jobTimeoutSeconds=180
 ```
 
@@ -95,9 +109,13 @@ helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
 If you disabled automatic cleanup, or need to clean up by hand:
 
 ```bash
-# Delete all NodeWright and DeploymentPolicy resources first
-kubectl delete nodewrights.nodewright.nvidia.com --all
-kubectl delete deploymentpolicies.nodewright.nvidia.com --all
+# Delete all NodeWright and DeploymentPolicy resources first. This mirrors what
+# the pre-delete hook does: a migrated cluster can still hold legacy resources,
+# and their finalizers block uninstall just as the current ones do.
+kubectl delete nodewrights --all --ignore-not-found
+kubectl delete skyhooks --all --ignore-not-found
+kubectl delete deploymentpolicies.nodewright.nvidia.com --all --ignore-not-found
+kubectl delete deploymentpolicies.skyhook.nvidia.com --all --ignore-not-found
 
 # Then uninstall the chart
 helm uninstall nodewright --namespace nodewright

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -90,17 +90,27 @@ re-run the uninstall with `--no-hooks`.
 ### Cleanup options
 
 Set these at install time with `helm install`, or on an existing release with
-`helm upgrade`. To disable automatic cleanup and manage resources manually:
+`helm upgrade`. When changing a setting on a release you already have, pass
+**both** of these or you will change more than you meant to:
+
+- `--version` pinned to the chart version you are already running. Without it,
+  `helm upgrade` against an OCI chart resolves to the newest published version,
+  so flipping a cleanup flag would also upgrade the operator.
+- `--reuse-values`, so the values you set at install time (an
+  `imagePullSecret`, say) survive. Without it Helm starts from the chart
+  defaults and applies only your `--set` flags.
 
 ```bash
+# Disable automatic cleanup and manage resources manually
 helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --version v0.18.0 --reuse-values \
   --namespace nodewright --set cleanup.enabled=false
 ```
 
-To adjust the cleanup job timeout:
-
 ```bash
+# Adjust the cleanup job timeout
 helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --version v0.18.0 --reuse-values \
   --namespace nodewright --set cleanup.jobTimeoutSeconds=180
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,10 +27,14 @@ operator pod cannot pull and the wait in the next step times out. See
 
 ```bash
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.18.0 \
   --namespace nodewright \
   --create-namespace
 ```
+
+This installs the **latest** chart, which is what you want here: the examples you
+just cloned track the main branch, so both come from the same place. For a real
+deployment, pin `--version` — see
+[Installation](installation.md#install-nodewright).
 
 Wait for it to come up:
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,0 +1,173 @@
+# Quickstart
+
+Install NodeWright and run a hello-world package on a single node. Should take
+about five minutes.
+
+This is the fast path. [Installation](installation.md) covers private registries,
+image pull secrets, and uninstall in full.
+
+## Prerequisites
+
+- A Kubernetes cluster you can `kubectl` into (v1.30+)
+- Helm 3.8+ (needed for native OCI support)
+- A node you are willing to have NodeWright touch
+
+## 1. Install the operator
+
+```bash
+helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --version v0.18.0 \
+  --namespace nodewright \
+  --create-namespace
+```
+
+Wait for it to come up:
+
+```bash
+kubectl wait --for=condition=Available deployment \
+  -l control-plane=controller-manager -n nodewright --timeout=300s
+```
+
+If you pull from a private registry, you need an image pull secret first — see
+[Installation](installation.md#configure-image-pull-secrets-if-needed).
+
+## 2. Pick one node
+
+The example targets nodes carrying a label that nothing has yet, so applying it
+does nothing until you opt a node in. Pick one and label it:
+
+```bash
+kubectl get nodes
+kubectl label node <node-name> nodewright.nvidia.com/quickstart=true
+```
+
+> **Why this way.** A NodeWright with an empty `nodeSelectors` matches **every
+> node in the cluster**. Starting from a label you apply by hand keeps the blast
+> radius at exactly one node while you are finding your feet.
+
+## 3. Apply the hello world
+
+```bash
+kubectl apply -f examples/simple/scr.yaml
+```
+
+That is [`examples/simple/scr.yaml`](../../examples/simple/scr.yaml):
+
+```yaml
+apiVersion: nodewright.nvidia.com/v1alpha1
+kind: NodeWright
+metadata:
+  name: demo
+spec:
+  nodeSelectors:
+    matchLabels:
+      nodewright.nvidia.com/quickstart: "true"
+  packages:
+    hello-world:
+      version: 1.1.0
+      image: ghcr.io/nvidia/skyhook-packages/shellscript
+      configMap:
+        config.yaml: |-
+          #!/bin/bash
+          sleep 1
+          echo "Hello, config!"
+        config_check.yaml: |-
+          #!/bin/bash
+          sleep 1
+          echo "Hello, config check!"
+```
+
+## 4. Watch it run
+
+```bash
+kubectl get nodewright demo -w
+```
+
+You are waiting for `status` to reach `complete`. While it works, the operator
+creates a Job on your node for each stage:
+
+```bash
+kubectl get pods -n nodewright -l nodewright.nvidia.com/name=demo
+```
+
+To see the script's output, read the log of the container named for the stage:
+
+```bash
+kubectl logs -n nodewright <pod-name> -c hello-world-config
+```
+
+You should see `Hello, config!`. Finished Jobs are garbage-collected after a
+while, so look reasonably promptly — or use
+[`kubectl nodewright package logs`](../user-guide/cli.md), which retrieves them
+for you.
+
+The record of what ran lives on the **node**, not on the CR:
+
+```bash
+kubectl get node <node-name> \
+  -o jsonpath='{.metadata.annotations.nodewright\.nvidia\.com/nodeState_demo}'
+```
+
+## What just happened
+
+### The custom resource
+
+Four parts of that manifest did all the work. Every field is covered in
+[The NodeWright Custom Resource](../user-guide/custom-resource.md).
+
+| Part | What it did |
+|---|---|
+| `nodeSelectors` | Chose which nodes to act on. Empty means *all* nodes — always set it deliberately. |
+| `packages` | The unit of work. The map key (`hello-world`) is the package name. |
+| `image` + `version` | `version` is the tag **and** the operator's ordering key, so it must be semver and the tag must not be inlined into `image`. |
+| `configMap` | Configuration handed to the package. The `shellscript` package treats these keys as scripts, which is why no image build was needed. |
+
+Two knobs you did not set are worth knowing before you go near a real cluster:
+`interruptionBudget` defaults to **100%** — every matching node at once — and
+`interrupt` is what makes a package cordon and drain a node before it runs.
+
+### The lifecycle
+
+The package moved through the install lane: **apply**, then **config**. Because
+it declared no `interrupt`, it stopped there and the node was never cordoned or
+drained. [Lifecycle of a NodeWright](../architecture/lifecycle.md) has the whole
+picture.
+
+The part worth internalising is what your two configMap keys were:
+
+```text
+config.yaml         →  the config stage's WORK step
+config_check.yaml   →  the config stage's CHECK step
+```
+
+**Every work step has a paired check step, and the stage is not done until the
+check passes.** That is not a naming convention — the operator runs them as
+consecutive init containers in the same pod, so Kubernetes itself stops at the
+first one that fails. `interrupt` is the sole exception, having no check step.
+
+## Clean up
+
+```bash
+kubectl delete -f examples/simple/scr.yaml
+kubectl label node <node-name> nodewright.nvidia.com/quickstart-
+```
+
+Deleting the CR does **not** undo what a package did to the host. This one only
+echoed text, so there is nothing to undo — but for real packages that is the
+distinction between removing a NodeWright and
+[uninstalling](../user-guide/uninstall.md) its packages.
+
+To remove the operator entirely:
+
+```bash
+helm uninstall nodewright --namespace nodewright
+```
+
+## Next steps
+
+- [Overview](overview.md) — what NodeWright is for and when to reach for it
+- [The NodeWright Custom Resource](../user-guide/custom-resource.md) — every field
+- [Lifecycle of a NodeWright](../architecture/lifecycle.md) — how a rollout actually runs
+- [Interrupt Flow](../architecture/interrupt-flow.md) — cordon, drain, reboot
+- [Deployment Policy](../user-guide/deployment-policy.md) — shaping a rollout across many nodes
+- [`examples/`](../../examples/) — including an interrupt example with real workloads

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -11,8 +11,19 @@ image pull secrets, and uninstall in full.
 - A Kubernetes cluster you can `kubectl` into (v1.30+)
 - Helm 3.8+ (needed for native OCI support)
 - A node you are willing to have NodeWright touch
+- A clone of this repository, for the example manifest in step 3:
+
+```bash
+git clone https://github.com/NVIDIA/nodewright.git
+cd nodewright
+```
 
 ## 1. Install the operator
+
+Pulling from a **private registry?** Create the image pull secret first, then add
+`--set imagePullSecret=node-init-secret` to the command below — otherwise the
+operator pod cannot pull and the wait in the next step times out. See
+[Installation](installation.md#configure-image-pull-secrets-if-needed).
 
 ```bash
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
@@ -27,9 +38,6 @@ Wait for it to come up:
 kubectl wait --for=condition=Available deployment \
   -l control-plane=controller-manager -n nodewright --timeout=300s
 ```
-
-If you pull from a private registry, you need an image pull secret first — see
-[Installation](installation.md#configure-image-pull-secrets-if-needed).
 
 ## 2. Pick one node
 

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -6,6 +6,8 @@ navigation:
     contents:
       - page: Overview
         path: getting-started/overview.md
+      - page: Quickstart
+        path: getting-started/quickstart.md
       - page: Installation
         path: getting-started/installation.md
       - page: Migration from Skyhook

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# Skyhook Examples
+# NodeWright Examples
 
-This directory contains sample manifests and usage patterns for Skyhook. Use these examples to learn how to configure, test, and extend Skyhook in your own clusters.
+This directory contains sample manifests and usage patterns for NodeWright. Use these examples to learn how to configure, test, and extend NodeWright in your own clusters.
 
 ## Included Examples
 
@@ -10,7 +10,7 @@ This directory contains sample manifests and usage patterns for Skyhook. Use the
     - Once launched do `kubectl exec -ti debug-pod sh -c 'chroot /host bash'`
     - You will then be on the host as root
     - Once done, exit and run `kubectl delete po/debug-pod` to remove the pod
-- `simple/`: Minimal working examples of Skyhook Custom Resources and package configurations.
-- `interrupt-wait-for-pod/`: Example showing how to use interrupts and wait-for-pod logic with Skyhook.
+- `simple/`: The hello-world NodeWright used by the [quickstart](../docs/getting-started/quickstart.md).
+- `interrupt-wait-for-pod/`: Example showing how to use interrupts and wait-for-pod logic with NodeWright.
 
 Feel free to use, modify, or extend these examples for your own use cases! 

--- a/examples/debug_pod.yaml
+++ b/examples/debug_pod.yaml
@@ -67,7 +67,15 @@ spec:
     key: node.kubernetes.io/unreachable
     operator: Exists
     tolerationSeconds: 300
+  # runtime-required taint. Both keys are listed so this pod schedules onto a
+  # gated node regardless of operator version: the default key moved from
+  # skyhook.nvidia.com to nodewright.nvidia.com in operator v0.18.0, and the
+  # legacy key stays tolerated until v0.20.0.
+  # operator < 0.18.0
   - key: skyhook.nvidia.com
+    operator: Exists
+  # operator >= 0.18.0
+  - key: nodewright.nvidia.com
     operator: Exists
   # tolerate nvidia.com/gpu=present:NoSchedule
   - effect: NoSchedule

--- a/examples/interrupt-wait-for-pod/demo.md
+++ b/examples/interrupt-wait-for-pod/demo.md
@@ -56,8 +56,17 @@ kubectl apply -f examples/interrupt-wait-for-pod/workload.yaml
 kubectl apply -f examples/interrupt-wait-for-pod/non-workload.yaml
 ```
 
-The DaemonSet lands only on the two labelled nodes. The ReplicaSet spreads across
-all three.
+The DaemonSet lands one pod on each of the two labelled nodes — that placement is
+guaranteed, and it is what the demo depends on. The ReplicaSet is only there as a
+contrast; the scheduler may not give it one pod per node, which does not matter
+because its pods never block. Check where things landed before continuing:
+
+```bash
+kubectl get pods -o wide -l app=nodewright-demo-workload
+kubectl get pods -o wide -l app=nodewright-demo-non-workload
+```
+
+You want one node with no `nodewright-demo-workload` pod on it.
 
 ### 2. Apply the NCR
 
@@ -99,8 +108,9 @@ kubectl get pods -n nodewright -o wide -l nodewright.nvidia.com/name=demo
 kubectl delete -f examples/interrupt-wait-for-pod/workload.yaml
 ```
 
-Once those pods are gone, the barrier lifts. NodeWright now cordons, drains and
-interrupts the remaining two nodes, and the NCR reaches `complete` on all three.
+Once those pods are gone, the barrier lifts. NodeWright drains and interrupts the
+remaining two nodes — they were already cordoned — and the NCR reaches
+`complete` on all three.
 
 ```bash
 kubectl get nodewright demo -o jsonpath='{.status.status}'

--- a/examples/interrupt-wait-for-pod/demo.md
+++ b/examples/interrupt-wait-for-pod/demo.md
@@ -21,9 +21,9 @@ kubectl apply -f demo/scr.yaml
 ```
 
 Wait for work to finish on the one node that doesn't have workload pods on it.
-Note how it DOES NOT taint/schedule skyhook work on nodes WITH workload pods.
+Note how it DOES NOT taint/schedule NodeWright work on nodes WITH workload pods.
 
-Show status in Skyhook SCR that it is complete on the one node but unkown on other two and overall state is unkown.
+Show status in NodeWright CR that it is complete on the one node but unkown on other two and overall state is unkown.
 
 Remove workload pods
 ```

--- a/examples/interrupt-wait-for-pod/demo.md
+++ b/examples/interrupt-wait-for-pod/demo.md
@@ -1,35 +1,139 @@
-Bring up node group with name: `demo` and 3 nodes
+# Demo: waiting for workload pods before an interrupt
 
-Label two of them so workload can go on
-```
-kubectl label node/ip-10-255-9-251.us-west-2.compute.internal demo=user-workload
+This example demonstrates `podNonInterruptLabels` — the mechanism that stops
+NodeWright from disrupting workloads you care about.
+
+A package that declares an `interrupt` needs the node cordoned and drained before
+it runs. `podNonInterruptLabels` puts a **barrier in front of that drain**: while
+any pod matching those labels is still running on a node, NodeWright will not
+drain it and will not start the interrupt. It waits.
+
+Note the barrier sits *after* the cordon, not before it. A waiting node is
+already cordoned, so nothing new schedules onto it while NodeWright waits for
+your workload to finish — it just is not evicted.
+
+The point of the demo is the contrast: two workloads run on the same nodes, one
+matching the labels and one not, and only the matching one holds work back.
+
+## What is in this directory
+
+| File | What it is |
+|---|---|
+| `scr.yaml` | The NodeWright Custom Resource (NCR). One package with `interrupt: reboot`, and `podNonInterruptLabels` matching `app: nodewright-demo-workload`. |
+| `workload.yaml` | A DaemonSet whose pods carry `app: nodewright-demo-workload` — **matches** the barrier, so it blocks. Pinned to nodes labelled `demo=user-workload`. |
+| `non-workload.yaml` | A ReplicaSet whose pods carry `app: nodewright-demo-non-workload` — **does not match**, so it gets drained like any other pod. |
+
+The NCR selects nodes with `eks.amazonaws.com/nodegroup: demo`. That label is
+EKS-specific; on another provider, change `spec.nodeSelectors` to something your
+nodes actually carry.
+
+## Setup
+
+Bring up a node group named `demo` with 3 nodes, then label two of them so the
+blocking workload has somewhere to land:
+
+```bash
+kubectl label node/<node-1> demo=user-workload
+kubectl label node/<node-2> demo=user-workload
 ```
 
-Show which nodes have labels
-```
-for node in $(kubectl get nodes | cut -d" " -f 1); do echo $node; kubectl label --list node/${node} | grep demo; done
+Confirm which nodes got the label:
+
+```bash
+for node in $(kubectl get nodes -o name); do
+  echo "$node"; kubectl label --list "$node" | grep demo
+done
 ```
 
-Apply workload
-```
-kubectl apply -f demo/workload.yaml
-```
+You should end up with two labelled nodes and one unlabelled.
 
-Apply SCR
-```
-kubectl apply -f demo/scr.yaml
-```
+## Run it
 
-Wait for work to finish on the one node that doesn't have workload pods on it.
-Note how it DOES NOT taint/schedule NodeWright work on nodes WITH workload pods.
+### 1. Start the workloads
 
-Show status in NodeWright CR that it is complete on the one node but unkown on other two and overall state is unkown.
-
-Remove workload pods
-```
-kubectl delete -f demo/workload.yaml
+```bash
+kubectl apply -f examples/interrupt-wait-for-pod/workload.yaml
+kubectl apply -f examples/interrupt-wait-for-pod/non-workload.yaml
 ```
 
-Note how it now DOES drain, taint and schedule onto other nodes.
+The DaemonSet lands only on the two labelled nodes. The ReplicaSet spreads across
+all three.
 
-Status in SCR is now complete on ALL nodes and complete overall.
+### 2. Apply the NCR
+
+```bash
+kubectl apply -f examples/interrupt-wait-for-pod/scr.yaml
+```
+
+### 3. Watch the third node finish, and the other two wait
+
+```bash
+kubectl get nodewright demo -w
+```
+
+Work completes on the **one node without workload pods**. The other two sit
+waiting: the DaemonSet pod on each matches `podNonInterruptLabels`, so the drain
+never starts. Note that the non-workload ReplicaSet pods on that third node were
+drained without complaint — they do not match the barrier.
+
+Where to look:
+
+```bash
+# Per-node status: complete on one node, still in progress on the other two
+kubectl get nodewright demo -o jsonpath='{.status.nodeStatus}' | jq
+
+# Overall status stays short of complete while any node is unfinished
+kubectl get nodewright demo -o jsonpath='{.status.status}'
+
+# Cordon state. Selected nodes are cordoned up front, including the two that
+# are waiting — the barrier holds back the drain, not the cordon.
+kubectl get nodes
+
+# The package pods the operator created, and which node each is pinned to
+kubectl get pods -n nodewright -o wide -l nodewright.nvidia.com/name=demo
+```
+
+### 4. Remove the blocking workload
+
+```bash
+kubectl delete -f examples/interrupt-wait-for-pod/workload.yaml
+```
+
+Once those pods are gone, the barrier lifts. NodeWright now cordons, drains and
+interrupts the remaining two nodes, and the NCR reaches `complete` on all three.
+
+```bash
+kubectl get nodewright demo -o jsonpath='{.status.status}'
+```
+
+## Where the state actually lives
+
+The NCR's `status` is the operator's published summary. The authoritative
+per-package record is an annotation on each **node**:
+
+```bash
+kubectl get node <node-name> \
+  -o jsonpath='{.metadata.annotations.nodewright\.nvidia\.com/nodeState_demo}' | jq
+```
+
+If a node is not progressing and you want to know why, the NCR's conditions are
+usually the fastest answer — they surface ignored nodes, untolerated taints, and
+a missing deployment policy:
+
+```bash
+kubectl get nodewright demo -o jsonpath='{.status.conditions}' | jq
+```
+
+## Clean up
+
+```bash
+kubectl delete -f examples/interrupt-wait-for-pod/scr.yaml
+kubectl delete -f examples/interrupt-wait-for-pod/non-workload.yaml
+kubectl delete -f examples/interrupt-wait-for-pod/workload.yaml   # if still present
+```
+
+## Related
+
+- [Interrupt Flow](../../docs/architecture/interrupt-flow.md) — the full cordon → drain → interrupt sequence, and how `podNonInterruptLabels` differs from the configurable drain
+- [The NodeWright Custom Resource](../../docs/user-guide/custom-resource.md) — every field used here
+- [Lifecycle of a NodeWright](../../docs/architecture/lifecycle.md) — what the operator does between apply and complete

--- a/examples/interrupt-wait-for-pod/non-workload.yaml
+++ b/examples/interrupt-wait-for-pod/non-workload.yaml
@@ -17,17 +17,17 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  name: skyhook-demo-non-workload
+  name: nodewright-demo-non-workload
   namespace: default
 spec:
   replicas: 3
   selector:
     matchLabels:
-      app: skyhook-demo-non-workload
+      app: nodewright-demo-non-workload
   template:
     metadata:
       labels:
-        app: skyhook-demo-non-workload
+        app: nodewright-demo-non-workload
     spec:
       nodeSelector:
         eks.amazonaws.com/nodegroup: demo

--- a/examples/interrupt-wait-for-pod/scr.yaml
+++ b/examples/interrupt-wait-for-pod/scr.yaml
@@ -14,16 +14,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skyhook.nvidia.com/v1alpha1
-kind: Skyhook
+apiVersion: nodewright.nvidia.com/v1alpha1
+kind: NodeWright
 metadata:
   labels:
-    app.kubernetes.io/part-of: skyhook-operator
-    app.kubernetes.io/created-by: skyhook-operator
+    app.kubernetes.io/part-of: nodewright-operator
+    app.kubernetes.io/created-by: nodewright-operator
   name: demo
   annotations:
-    skyhook.nvidia.com/pause: "false"
-    skyhook.nvidia.com/disable: "false"
+    nodewright.nvidia.com/pause: "false"
+    nodewright.nvidia.com/disable: "false"
 spec:
   nodeSelectors:
     matchLabels:
@@ -32,7 +32,7 @@ spec:
     percent: 100
   podNonInterruptLabels:
     matchLabels:
-      app: skyhook-demo-workload
+      app: nodewright-demo-workload
   packages:
     baz:
       version: 1.1.0

--- a/examples/interrupt-wait-for-pod/workload.yaml
+++ b/examples/interrupt-wait-for-pod/workload.yaml
@@ -17,16 +17,16 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: skyhook-demo-workload
+  name: nodewright-demo-workload
   namespace: default
 spec:
   selector:
     matchLabels:
-      app: skyhook-demo-workload
+      app: nodewright-demo-workload
   template:
     metadata:
       labels:
-        app: skyhook-demo-workload
+        app: nodewright-demo-workload
     spec:
       nodeSelector:
         demo: user-workload

--- a/examples/simple/scr.yaml
+++ b/examples/simple/scr.yaml
@@ -14,22 +14,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: skyhook.nvidia.com/v1alpha1
-kind: Skyhook
+# The hello-world example used by docs/getting-started/quickstart.md.
+#
+# The node selector below matches nothing until you label a node, which keeps
+# the blast radius at one node:
+#
+#   kubectl label node <node> nodewright.nvidia.com/quickstart=true
+
+apiVersion: nodewright.nvidia.com/v1alpha1
+kind: NodeWright
 metadata:
   labels:
-    app.kubernetes.io/part-of: skyhook-operator
-    app.kubernetes.io/created-by: skyhook-operator
+    app.kubernetes.io/part-of: nodewright-operator
+    app.kubernetes.io/created-by: nodewright-operator
   name: demo
   annotations:
-    skyhook.nvidia.com/pause: "false"
-    skyhook.nvidia.com/disable: "false"
+    nodewright.nvidia.com/pause: "false"
+    nodewright.nvidia.com/disable: "false"
 spec:
   nodeSelectors:
     matchLabels:
-      skyhook.nvidia.com/test-node: skyhooke2e
+      nodewright.nvidia.com/quickstart: "true"
   packages:
-    baz:
+    hello-world:
       version: 1.1.0
       image: ghcr.io/nvidia/skyhook-packages/shellscript
       configMap:


### PR DESCRIPTION
## What

Adds `docs/getting-started/quickstart.md` — a five-minute path from "I have a cluster" to "a package ran on a node", which the docs did not have. Moves the install walkthrough out of the README, and brings the examples onto NodeWright naming.

## The quickstart

Install → label one node → apply `examples/simple/scr.yaml` → watch it run → **what just happened**.

That last section is the point of the page. It names the four parts of the manifest that did the work and the two stages the package moved through, then links to [the custom resource reference](docs/user-guide/custom-resource.md) and [the lifecycle doc](docs/architecture/lifecycle.md) rather than restating them. It also surfaces the two defaults most likely to bite someone moving from the quickstart to a real cluster: an empty `nodeSelectors` matches every node, and an omitted `interruptionBudget` means 100%.

It ties the example's own configMap keys to the work/check pairing, which makes the concept concrete on the first read:

```text
config.yaml         →  the config stage's WORK step
config_check.yaml   →  the config stage's CHECK step
```

## README

Removes the ~137-line install walkthrough. It duplicated `installation.md`, and ended in an inline sample whose `apply_check.sh` was mis-indented and could not have run as written. What replaces it is the single `helm install` command plus links to the quickstart and the installation guide, and a "new here?" line near the top pointing at the quickstart and overview.

The uninstall detail the README carried and `installation.md` did not — the `cleanup.enabled` and `cleanup.jobTimeoutSeconds` chart options, and the manual cleanup sequence — moved into `installation.md`.

I then audited every removed line against the destinations rather than trusting that. Two notes had landed nowhere and are restored in `af493431`: that a release migrating off NGC can keep its existing in-cluster release name, and that an install already in the `skyhook` namespace should stay there. The second mattered — `migration.md` documents it in full, but with the README section gone nothing in the install flow pointed there. Two further removals were checked and are genuinely covered: the nvcr.io/NGC pause is still in the README's distribution notice, and the jsonpath readiness probe is redundant with the `kubectl wait --for=condition=Ready pod` beside it.

## Examples

- **`examples/simple`** is the quickstart's hello world. Its selector was `skyhook.nvidia.com/test-node: skyhooke2e`, an e2e label no new user could match. It now keys off a label the guide has them apply, so the blast radius is one node they chose rather than whatever carries a test label.
- **`examples/interrupt-wait-for-pod`** moves to the NodeWright group and kind. Its `app: skyhook-demo-workload` labels are renamed alongside — safe here because the example owns *both* ends of that selector, unlike the blanket-rename trap `migration.md` warns about.
- **`examples/debug_pod.yaml`** now tolerates both runtime-required taint keys, commented with which operator versions each covers. The default moved in v0.18.0 and the legacy key stays tolerated until v0.20.0, so a debug pod carrying both schedules onto a gated node either way.

## Verification

- **Both example CRs validated against the generated CRD schema** — group, kind, scope, required fields, the package-name pattern, semver, and the no-inline-tag/digest rule. Not just "the YAML parses".
- markdownlint clean over all 108 tracked markdown files; yamllint clean
- Every internal link and anchor resolves

## Notes for review

- `ghcr.io/nvidia/skyhook-packages/shellscript` is deliberately unchanged — that is the published image path, confirmed against what the chainsaw suites actually pull. Only the GitHub repo moved to `nodewright-packages`.
- **Pre-existing inconsistency, not fixed here:** `docs/getting-started/overview.md` links the packages repo as `NVIDIA/skyhook-packages` while `README.md` and `CONTRIBUTING.md` link `NVIDIA/nodewright-packages`. Out of scope for this PR; happy to fix separately.
- No `RELEASE_NOTES.md` entry — docs-only, no behavior change.
