### PR TITLE
docs: record the runtimeRequiredCordonAfter CLI surface

### DIFF
--- a/docs/user-guide/cli.md
+++ b/docs/user-guide/cli.md
@@ -431,6 +431,32 @@ kubectl nodewright node ignore "test-node-.*"
 kubectl nodewright node unignore worker-1
 ```
 
+#### Node Status Columns
+
+`node status` reports two cordon columns alongside the rollout state. They appear
+in the default table, in `-o wide`, and as fields in `-o json` / `-o yaml`:
+
+| Column | JSON field | Meaning |
+|--------|------------|---------|
+| `CORDONED` | `cordoned` | The node's `spec.unschedulable`, whatever set it — a NodeWright interrupt mid-flight, a persistent runtime-required cordon, or a `kubectl cordon` of your own. |
+| `RUNTIME-REQUIRED-CORDON` | `runtimeRequiredCordon` | The node carries the `nodewright.nvidia.com/runtimeRequiredCordon` annotation, so the cordon came from a NodeWright with `spec.runtimeRequired: true` and `spec.runtimeRequiredCordonAfter: true`. |
+
+Read them together to tell a transient cordon from one that is waiting on you:
+
+- `CORDONED=true`, `RUNTIME-REQUIRED-CORDON=false` — the operator uncordons this
+  node itself once every NodeWright holding a `nodewright.nvidia.com/cordon_*`
+  annotation on it has finished, unless the cordon is one you applied yourself.
+- `CORDONED=true`, `RUNTIME-REQUIRED-CORDON=true` — the cordon will not clear on
+  its own. It survives later NodeWright interrupts and `kubectl nodewright reset`,
+  and only an external actor can release it. See
+  [runtime-required.md](runtime-required.md#what-happens-when-the-taint-is-removed)
+  for the patch that clears both the annotation and the cordon.
+
+Against an operator that predates `spec.runtimeRequiredCordonAfter` the annotation
+is never set, so `RUNTIME-REQUIRED-CORDON` reads `false` on every node. That is
+accurate, not degraded — no such cordon can exist — so the columns need no operator
+version gate.
+
 #### Node Flags
 
 | Command | Flag | Description |

--- a/operator/cmd/cli/RELEASE_NOTES.md
+++ b/operator/cmd/cli/RELEASE_NOTES.md
@@ -5,6 +5,33 @@ For the full commit-level log see CHANGELOG.md.
 
 ## Unreleased
 
+### Changed
+
+- **`node status` now reports two cordon columns, `CORDONED` and
+  `RUNTIME-REQUIRED-CORDON`.** They appear in the default table, in `-o wide`, and
+  as the `cordoned` and `runtimeRequiredCordon` fields in `-o json` / `-o yaml`.
+  `CORDONED` is the node's `spec.unschedulable`, whatever applied it.
+  `RUNTIME-REQUIRED-CORDON` is the presence of the
+  `nodewright.nvidia.com/runtimeRequiredCordon` annotation, which the operator sets
+  when a `runtimeRequired` NodeWright also sets `spec.runtimeRequiredCordonAfter:
+  true`. Read together they distinguish a cordon the operator will release itself
+  from one that persists across later NodeWright interrupts and
+  `kubectl nodewright reset` until an external actor clears it. See
+  [docs/user-guide/cli.md](../../../docs/user-guide/cli.md#node-status-columns) for
+  the columns and
+  [docs/user-guide/runtime-required.md](../../../docs/user-guide/runtime-required.md#what-happens-when-the-taint-is-removed)
+  for how to release the persistent cordon.
+
+  **If you parse the table output positionally, check your parser.** Both columns
+  are appended, so the existing columns keep their positions, but anything reading
+  the last field now gets a boolean. JSON and YAML consumers are unaffected — the
+  fields are additive.
+
+  No operator version gate applies. An operator without
+  `spec.runtimeRequiredCordonAfter` never sets the annotation, so
+  `RUNTIME-REQUIRED-CORDON` reads `false` everywhere, which is accurate rather than
+  degraded: no such cordon can exist.
+
 ## cli/v0.3.0 - 2026-08-17
 
 ### Breaking Changes


### PR DESCRIPTION
## Description

#401 added `CORDONED` and `RUNTIME-REQUIRED-CORDON` columns to `kubectl nodewright node status`, but the only human-authored note about them landed in `operator/RELEASE_NOTES.md`. The CLI is released on its own schedule, so `operator/cmd/cli/RELEASE_NOTES.md` and `docs/user-guide/cli.md` are where a CLI user actually looks — and both were silent about the new output.

This is docs-only; no behavior changes.

**`operator/cmd/cli/RELEASE_NOTES.md`** — new `### Changed` entry under Unreleased:

- What the two columns are and where they surface: the default table, `-o wide`, and the `cordoned` / `runtimeRequiredCordon` fields in `-o json` / `-o yaml`.
- What each actually reads — `CORDONED` is the node's `spec.unschedulable` whatever applied it; `RUNTIME-REQUIRED-CORDON` is the presence of the `nodewright.nvidia.com/runtimeRequiredCordon` annotation.
- A caveat for anyone scraping the table: both columns are **appended**, so existing columns keep their positions, but a parser reading the last field now gets a boolean. JSON/YAML consumers are unaffected — the fields are additive.

**`docs/user-guide/cli.md`** — new `#### Node Status Columns` subsection under Node Commands: a column / JSON field / meaning table, plus how to read the two together to tell a cordon the operator will release itself from one that persists until an external actor clears it, linking to `runtime-required.md` for the release patch.

### Two judgment calls for reviewers

**No compatibility-matrix row.** `node status` is already ✅ Full in both matrix columns and the behavior is not version-gated: an operator without `spec.runtimeRequiredCordonAfter` never sets the annotation, so `RUNTIME-REQUIRED-CORDON` reads `false` everywhere — accurate rather than degraded, since no such cordon can exist. I documented that reasoning in both files rather than adding a matrix entry. Happy to move it into the matrix if you'd rather it be discoverable there.

**No version number named.** The operator entry for `runtimeRequiredCordonAfter` is still under Unreleased and there is no `operator/v0.19.0` tag yet, so the docs say "an operator that predates `spec.runtimeRequiredCordonAfter`" rather than asserting a version. Worth making concrete once the tag lands.

### Follow-up

The feature is shipping on `release/v0.19.x`. This targets `main`; it likely wants a cherry-pick onto the release branch so the shipped CLI notes carry the entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off per the [DCO](https://developercertificate.org/) **and** cryptographically signed: `git commit -s -S`.
- [ ] New or existing tests cover these changes. — N/A, docs-only.
- [x] The documentation is up to date with these changes.