### PR TITLE
docs: require an explicit chart version on every OCI install/upgrade

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -29,7 +29,7 @@ NodeWright currently uses a single shared image pull secret for all packages, an
 # The chart is distributed as an OCI artifact on GitHub Container Registry.
 # Helm 3.8+ supports OCI natively — no `helm repo add` needed.
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.19.0 \
+  --version <chart-version> \  # latest: https://github.com/NVIDIA/nodewright/releases?q=chart
   --namespace nodewright \
   --create-namespace \
   --set imagePullSecret=node-init-secret
@@ -42,7 +42,7 @@ Omit `--set imagePullSecret=node-init-secret` if you're pulling from public regi
 >
 > ```bash
 > helm upgrade <release-name> oci://ghcr.io/nvidia/nodewright/charts/nodewright \
->   --version v0.19.0 --namespace <existing-namespace>
+>   --version <chart-version> --namespace <existing-namespace>  # latest: https://github.com/NVIDIA/nodewright/releases?q=chart
 > ```
 >
 > Keeping the old release name (e.g. `skyhook`) is fine — the chart works either way.
@@ -93,9 +93,9 @@ Set these at install time with `helm install`, or on an existing release with
 `helm upgrade`. When changing a setting on a release you already have, pass
 **both** of these or you will change more than you meant to:
 
-- `--version` pinned to the chart version you are already running. Without it,
-  `helm upgrade` against an OCI chart resolves to the newest published version,
-  so flipping a cleanup flag would also upgrade the operator.
+- `--version` pinned to the chart version you are already running (`helm list -n nodewright`
+  shows it). Without it, `helm upgrade` against this OCI chart fails outright — GHCR
+  doesn't support resolving an unpinned "latest" install or upgrade.
 - `--reuse-values`, so the values you set at install time (an
   `imagePullSecret`, say) survive. Without it Helm starts from the chart
   defaults and applies only your `--set` flags.
@@ -103,14 +103,14 @@ Set these at install time with `helm install`, or on an existing release with
 ```bash
 # Disable automatic cleanup and manage resources manually
 helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.19.0 --reuse-values \
+  --version <chart-version> --reuse-values \  # installed: helm list -n nodewright
   --namespace nodewright --set cleanup.enabled=false
 ```
 
 ```bash
 # Adjust the cleanup job timeout
 helm upgrade nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
-  --version v0.19.0 --reuse-values \
+  --version <chart-version> --reuse-values \  # installed: helm list -n nodewright
   --namespace nodewright --set cleanup.jobTimeoutSeconds=180
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,14 +27,15 @@ operator pod cannot pull and the wait in the next step times out. See
 
 ```bash
 helm install nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright \
+  --version <chart-version> \  # latest: https://github.com/NVIDIA/nodewright/releases?q=chart
   --namespace nodewright \
   --create-namespace
 ```
 
-This installs the **latest** chart, which is what you want here: the examples you
-just cloned track the main branch, so both come from the same place. For a real
-deployment, pin `--version` — see
-[Installation](installation.md#install-nodewright).
+`--version` is required — GHCR doesn't support installing an OCI chart without
+pinning one. Any recent chart release works for this quickstart. For a real
+deployment, see [Installation](installation.md#install-nodewright) for more on
+pinning intentionally.
 
 Wait for it to come up:
 


### PR DESCRIPTION
## Description

`quickstart.md`'s `helm install` example omits `--version` and claims that installs "the latest chart." Verified this is false for this chart's GHCR-hosted OCI registry:

```
$ helm template nodewright oci://ghcr.io/nvidia/nodewright/charts/nodewright --namespace nodewright
Error: Unable to locate any tags in provided repository: oci://ghcr.io/nvidia/nodewright/charts/nodewright
```

A specific, known tag (`--version v0.19.0`) pulls fine anonymously — the failure is specific to resolving an unpinned/"latest" reference. `installation.md`'s "Cleanup options" section makes the same incorrect claim in prose. Likely inherited from the chart's pre-OCI home on `helm.ngc.nvidia.com` (a classic index.yaml repo, where unpinned installs genuinely do resolve to the newest entry) — that behavior doesn't carry over to OCI.

Fixes both:
- Requires an explicit `--version` everywhere, since there's no working unpinned fallback.
- Replaces the hardcoded `--version v0.19.0` pins (which would just go stale on every release) with a `<chart-version>` placeholder and a pointer to where to find the right value:
  - Fresh install/upgrade to newest: the [Releases page](https://github.com/NVIDIA/nodewright/releases?q=chart)
  - Cleanup operations (need the version *already running*, not latest): `helm list -n nodewright`

Fixes #569

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off per the [DCO](https://developercertificate.org/) **and** cryptographically signed: `git commit -s -S`.
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.