### PR TITLE
fix(ci): stop labeler applying component/operator and component/ci to every PR

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -19,12 +19,13 @@
 # .github/workflows/triage.yaml.
 
 # Operator (controller-manager), excluding the CLI which lives under it.
-# The '!' exclude lives in any-glob-to-any-file (not all-globs-to-all-files) so a
-# PR touching both operator core and CLI still gets this label; an all-globs
-# negation would drop it whenever any CLI file is present.
+# A '!' glob must sit under all-globs-to-any-file: the match is per file, so a
+# PR touching both operator core and CLI still gets this label. Under
+# any-glob-to-any-file a negated glob is satisfied by any file outside the
+# excluded path, which labels every PR (see #553).
 component/operator:
   - changed-files:
-      - any-glob-to-any-file:
+      - all-globs-to-any-file:
           - 'operator/**'
           - '!operator/cmd/cli/**'
 
@@ -45,13 +46,16 @@ component/chart:
 
 component/ci:
   - changed-files:
-      # The '!' vendor exclude stays in any-glob-to-any-file so a PR mixing a
-      # vendored Makefile with real CI changes still gets the label.
       - any-glob-to-any-file:
           - '.github/**'
           - 'scripts/**'
           - '.gitlab-ci.yml'
+      # Vendored trees carry Makefiles, so the exclude is paired with each
+      # glob under all-globs-to-any-file (same reason as component/operator).
+      - all-globs-to-any-file:
           - '**/Makefile'
+          - '!**/vendor/**'
+      - all-globs-to-any-file:
           - '**/*.mk'
           - '!**/vendor/**'
 


### PR DESCRIPTION
Fixes #553

`actions/labeler` v5+ evaluates a negated glob under `any-glob-to-any-file` as "any changed file outside the excluded path". Combined with OR across globs, `component/operator` and `component/ci` matched almost every PR.

The `!` globs now sit under `all-globs-to-any-file`, where the match is per file. A PR touching both operator core and CLI still gets `component/operator`, as the old comment intended. For `component/ci` the vendor exclude is paired with each Makefile glob, since `all-globs-to-any-file` cannot express a union with a shared exclusion. Both comments are rewritten to state the rule.

I checked the result against the labeler match semantics with minimatch on the cases from the issue:

| Changed files | main | this PR |
| --- | --- | --- |
| `docs/**` only | doc, component/operator, component/ci | doc |
| `.github/workflows/renovate.yaml` | component/operator, component/ci | component/ci |
| operator core + `operator/cmd/cli/**` | component/operator, component/cli, component/ci | component/operator, component/cli |
| `operator/cmd/cli/**` only | component/operator, component/cli, component/ci | component/cli |
| root `Makefile` | component/operator, component/ci | component/ci |
| `operator/vendor/**/Makefile` only | component/operator, component/ci | component/operator |

The last row is expected: a vendored file under `operator/` is still an operator change, and no vendor-only PRs appear in the history.

I did not add a self-check workflow for the config. The table above is reproducible with a few lines of Node. I can add it under `scripts/` if you want it enforced in CI.
