### PR TITLE
fix(operator): keep observed generation stable on deletion

### DIFF
--- a/operator/internal/controller/skyhook_controller.go
+++ b/operator/internal/controller/skyhook_controller.go
@@ -2387,12 +2387,10 @@ func (r *SkyhookReconciler) HandleFinalizer(ctx context.Context, skyhook Skyhook
 				return false, utilerrors.NewAggregate(errs)
 			}
 
-			// Bump ObservedGeneration and write status BEFORE removing the finalizer:
+			// Write status BEFORE removing the finalizer:
 			// removing the last finalizer lets the apiserver delete the object
 			// immediately, so a status update afterward would race that deletion into a
-			// spurious NotFound. (The bump keeps the finalizer-removal Patch below from
-			// re-triggering add-finalizer logic.)
-			skyhook.GetSkyhook().Status.ObservedGeneration = skyhook.GetSkyhook().Status.ObservedGeneration + 1
+			// spurious NotFound.
 			if err := r.Status().Update(ctx, skyhook.GetSkyhook().NodeWright); err != nil {
 				return false, fmt.Errorf("error updating nodewright status: %w", err)
 			}
@@ -3452,6 +3450,7 @@ func (r *SkyhookReconciler) removeRuntimeRequiredTaints(ctx context.Context, nod
 			return nil
 		}
 
+		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		current, changed := node, false
 		for i := range taintsToRemove {
 			// RemoveTaint always returns a nil error.
@@ -3474,7 +3473,6 @@ func (r *SkyhookReconciler) removeRuntimeRequiredTaints(ctx context.Context, nod
 			current.Spec.Unschedulable = true
 		}
 
-		patch := client.MergeFromWithOptions(node.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		if err := r.Patch(ctx, current, patch); err != nil {
 			return fmt.Errorf("patching node: %w", err)
 		}

--- a/operator/internal/controller/skyhook_controller_test.go
+++ b/operator/internal/controller/skyhook_controller_test.go
@@ -1569,6 +1569,16 @@ var _ = Describe("skyhook controller tests", func() {
 		Expect(runtimeRequiredCordonAfterEnabled([]SkyhookNodes{sh1, sh2})).To(BeTrue())
 	})
 	Context("HandleRuntimeRequired with runtimeRequiredCordonAfter", func() {
+		newRuntimeRequiredReconciler := func() *SkyhookReconciler {
+			return &SkyhookReconciler{
+				Client:   k8sClient,
+				uncached: k8sClient,
+				dal:      dal.New(k8sClient, nil),
+				recorder: operator.recorder,
+				opts:     opts,
+			}
+		}
+
 		It("should cordon the node and remove the taint when runtimeRequiredCordonAfter is true", func() {
 			node := &corev1.Node{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1594,7 +1604,7 @@ var _ = Describe("skyhook controller tests", func() {
 				&v1alpha1.DeploymentPolicyList{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+			Expect(newRuntimeRequiredReconciler().HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
 
 			updated := &corev1.Node{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
@@ -1630,7 +1640,7 @@ var _ = Describe("skyhook controller tests", func() {
 				&v1alpha1.DeploymentPolicyList{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+			Expect(newRuntimeRequiredReconciler().HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
 
 			updated := &corev1.Node{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
@@ -1665,7 +1675,7 @@ var _ = Describe("skyhook controller tests", func() {
 				&v1alpha1.DeploymentPolicyList{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+			Expect(newRuntimeRequiredReconciler().HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
 
 			updated := &corev1.Node{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
@@ -1699,7 +1709,7 @@ var _ = Describe("skyhook controller tests", func() {
 				&v1alpha1.DeploymentPolicyList{},
 			)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(operator.HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
+			Expect(newRuntimeRequiredReconciler().HandleRuntimeRequired(ctx, cs, &corev1.NodeList{Items: []corev1.Node{*node}})).To(Succeed())
 
 			updated := &corev1.Node{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: node.Name}, updated)).To(Succeed())
@@ -4767,7 +4777,6 @@ var _ = Describe("HandleFinalizer merge patch", func() {
 			},
 			"packages": map[string]interface{}{
 				"pkg-a": map[string]interface{}{
-					"name":    "pkg-a",
 					"version": "1.0.0",
 					"image":   "ghcr.io/org/pkg-a",
 					"resources": map[string]interface{}{
@@ -4814,6 +4823,7 @@ var _ = Describe("HandleFinalizer merge patch", func() {
 		Expect(ok).To(BeTrue())
 		pkgA, ok := pkgs["pkg-a"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
+		Expect(pkgA).ToNot(HaveKey("name"), "an omitted package name must remain absent")
 		res, ok := pkgA["resources"].(map[string]interface{})
 		Expect(ok).To(BeTrue())
 
@@ -4874,6 +4884,105 @@ var _ = Describe("HandleFinalizer merge patch", func() {
 		live := &v1alpha1.NodeWright{}
 		err = k8sClient.Get(ctx, types.NamespacedName{Name: name}, live)
 		Expect(apierrors.IsNotFound(err)).To(BeTrue(), "object should be reaped once finalizer is removed")
+	})
+
+	It("keeps observedGeneration stable when finalizer removal is retried", func() {
+		const name = "finalizer-observed-generation-test"
+		const concurrentFinalizer = "example.com/concurrent-cleanup"
+		const generation int64 = 7
+		deletionTimestamp := metav1.Now()
+
+		nw := &v1alpha1.NodeWright{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Generation:        generation,
+				DeletionTimestamp: &deletionTimestamp,
+				Finalizers:        []string{SkyhookFinalizer, concurrentFinalizer},
+			},
+			Spec: v1alpha1.NodeWrightSpec{
+				NodeSelector: metav1.LabelSelector{MatchLabels: map[string]string{"test-finalizer": name}},
+				Packages: v1alpha1.Packages{
+					"pkg-a": {
+						PackageRef: v1alpha1.PackageRef{Name: "pkg-a", Version: "1.0.0"},
+						Image:      "ghcr.io/org/pkg-a",
+					},
+				},
+			},
+			Status: v1alpha1.NodeWrightStatus{
+				ObservedGeneration: generation,
+				Conditions: []metav1.Condition{{
+					Type:               wrapper.SkyhookConditionDeletionBlocked,
+					Status:             metav1.ConditionTrue,
+					ObservedGeneration: generation,
+					LastTransitionTime: metav1.Now(),
+					Reason:             "TestBlocked",
+					Message:            "removed when deletion can proceed",
+				}},
+			},
+		}
+
+		buildDeletingState := func(current *v1alpha1.NodeWright) *clusterState {
+			state, err := BuildState(
+				&v1alpha1.NodeWrightList{Items: []v1alpha1.NodeWright{*current}},
+				&corev1.NodeList{},
+				&v1alpha1.DeploymentPolicyList{},
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(state.skyhooks).To(HaveLen(1))
+			return state
+		}
+
+		testScheme := runtime.NewScheme()
+		Expect(v1alpha1.AddToScheme(testScheme)).To(Succeed())
+		baseClient := fake.NewClientBuilder().
+			WithScheme(testScheme).
+			WithStatusSubresource(nw).
+			WithObjects(nw).
+			Build()
+		patches := 0
+		conflictClient := interceptor.NewClient(baseClient, interceptor.Funcs{
+			Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+				patches++
+				if patches == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: v1alpha1.GroupVersion.Group, Resource: "nodewrights"},
+						name,
+						fmt.Errorf("simulated concurrent finalizer write"),
+					)
+				}
+				return c.Patch(ctx, obj, patch, opts...)
+			},
+		})
+		r := &SkyhookReconciler{
+			Client:   conflictClient,
+			uncached: baseClient,
+			dal:      dal.New(conflictClient, nil),
+			recorder: operator.recorder,
+			opts:     opts,
+		}
+
+		state := buildDeletingState(nw)
+		handled, err := r.HandleFinalizer(ctx, state.skyhooks[0], state)
+		Expect(apierrors.IsConflict(err)).To(BeTrue())
+		Expect(handled).To(BeFalse())
+		Expect(patches).To(Equal(1))
+
+		live := &v1alpha1.NodeWright{}
+		Expect(baseClient.Get(ctx, types.NamespacedName{Name: name}, live)).To(Succeed())
+		Expect(live.Status.ObservedGeneration).To(Equal(live.Generation))
+		Expect(live.Finalizers).To(ConsistOf(SkyhookFinalizer, concurrentFinalizer))
+		Expect(live.Status.Conditions).ToNot(ContainElement(HaveField("Type", wrapper.SkyhookConditionDeletionBlocked)))
+
+		state = buildDeletingState(live)
+		handled, err = r.HandleFinalizer(ctx, state.skyhooks[0], state)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(handled).To(BeTrue())
+		Expect(patches).To(Equal(2))
+
+		Expect(baseClient.Get(ctx, types.NamespacedName{Name: name}, live)).To(Succeed())
+		Expect(live.Status.ObservedGeneration).To(Equal(live.Generation))
+		Expect(live.Status.ObservedGeneration).To(Equal(generation))
+		Expect(live.Finalizers).To(ConsistOf(concurrentFinalizer))
 	})
 
 	It("retries after concurrent metadata edits and preserves every finalizer", func() {


### PR DESCRIPTION
## Description

Removes the obsolete manual increment of `status.observedGeneration` from Phase 3 of `HandleFinalizer`.

PR #518 changed finalizer removal from a full-object update to a metadata-only optimistic-lock merge patch. The old update unintentionally bumped `metadata.generation`, and the manual status increment existed to follow that side effect. With the metadata-only patch, generation no longer moves; retaining the increment published `observedGeneration = generation + 1` and increased it again whenever finalizer removal conflicted and deletion reconciliation re-entered.

The status update remains before finalizer removal. That ordering is still required to persist removal of the `DeletionBlocked` condition and to avoid racing a status write against deletion after the last finalizer is removed.

### Regression coverage

A new isolated controller spec:

- starts a deleting NodeWright with `observedGeneration == generation`, the NodeWright finalizer, and another controller finalizer;
- forces the first optimistic-lock finalizer patch to conflict;
- verifies the status write removes `DeletionBlocked` without changing `observedGeneration`;
- re-enters finalizer cleanup and verifies the second patch succeeds, preserves the other finalizer, and still leaves `observedGeneration == generation`.

This also addresses the three non-blocking review notes from #518:

- capture the runtime-required taint patch base before the mutation callback;
- make the four `runtimeRequiredCordonAfter` specs use a direct-client DAL rather than depend on informer cache timing;
- omit `spec.packages.*.name` from the quantity-format fixture and assert the finalizer patch keeps it absent.

## Validation

- `make build` — formatting, generation, vet, license checks, lint, manager build, and CLI build pass with zero lint issues.
- `make unit-tests` — 1,190 tests pass with zero failures.
- Focused controller regression suite — 12/12 specs pass.

Fixes #580
Follow-up to #518 and its maintainer review: https://github.com/NVIDIA/nodewright/pull/518#pullrequestreview-5118572900

## Checklist

- [x] I am familiar with the contributing guidelines.
- [x] The commit is signed and includes a DCO sign-off.
- [x] New and existing tests cover the change.
- [x] Existing release-note guidance remains accurate.