### PR TITLE
chore(deps): annotate operator/deps.mk pins for Renovate, fix setup-envtest branch pin

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
   // Keep coverage aligned with the ecosystems previously owned by Dependabot.
   // GitHub Actions remains enabled for extraction so the rule below can record
   // the intentional handoff back to Dependabot in the validated config.
-  enabledManagers: ["dockerfile", "github-actions", "gomod", "pep621"],
+  enabledManagers: ["dockerfile", "github-actions", "gomod", "pep621", "custom.regex"],
   dependencyDashboard: false,
   prConcurrentLimit: 10,
   prHourlyLimit: 10,
@@ -29,6 +29,18 @@
   // metadata and vendor trees in the same commit as every dependency update.
   postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths", "gomodVendor"],
   ignorePaths: ["**/vendor/**"],
+
+  // deps.mk pins build tools by hand with `# renovate:` annotation comments;
+  // this manager reads those comments to propose bumps. See #522.
+  customManagers: [
+    {
+      customType: "regex",
+      managerFilePatterns: ["/^operator/deps\\.mk$/"],
+      matchStrings: [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\\s+\\w+_VERSION \\?= (?<currentValue>\\S+)",
+      ],
+    },
+  ],
 
   packageRules: [
     {
@@ -72,6 +84,20 @@
       groupName: "kubernetes",
       matchManagers: ["gomod"],
       matchPackageNames: ["k8s.io/**", "sigs.k8s.io/**", "!k8s.io/klog/v2"],
+    },
+    {
+      // The ginkgo CLI (deps.mk) and the ginkgo library (go.mod) are cut
+      // from the same tag and must never drift apart. See #522.
+      groupName: "ginkgo",
+      matchManagers: ["gomod", "custom.regex"],
+      matchDepNames: ["github.com/onsi/ginkgo/v2"],
+    },
+    {
+      // setup-envtest submodule tags are cut in lockstep with
+      // controller-runtime releases, so fold it into the same group.
+      groupName: "kubernetes",
+      matchManagers: ["custom.regex"],
+      matchDepNames: ["sigs.k8s.io/controller-runtime/tools/setup-envtest"],
     },
     {
       groupName: "golang-x",

--- a/operator/deps.mk
+++ b/operator/deps.mk
@@ -51,21 +51,37 @@ ifndef ARCH
 endif
 
 ## versions
+# renovate: datasource=github-releases depName=golangci/golangci-lint
 GOLANGCI_LINT_VERSION ?= v2.13.1
+# renovate: datasource=go depName=sigs.k8s.io/kustomize/kustomize/v5
 KUSTOMIZE_VERSION ?= v5.4.1
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools
 CONTROLLER_TOOLS_VERSION ?= v0.21.0
+# renovate: datasource=go depName=github.com/boumenot/gocover-cobertura
 GOCOVER_VERSION ?= v1.4.0
+# renovate: datasource=go depName=github.com/onsi/ginkgo/v2
 GINKGO_VERSION ?= v2.28.1
+# renovate: datasource=go depName=github.com/vektra/mockery/v3
 MOCKERY_VERSION ?= v3.7.0
+# renovate: datasource=github-releases depName=kyverno/chainsaw
 CHAINSAW_VERSION ?= v0.2.15
+# renovate: datasource=github-releases depName=helm/helm
 HELM_VERSION ?= v4.1.4
+# renovate: datasource=go depName=github.com/arttor/helmify
 HELMIFY_VERSION ?= v0.4.12
+# renovate: datasource=go depName=github.com/google/go-licenses/v2
 GO_LICENSES_VERSION ?= v2.0.1
+# renovate: datasource=go depName=github.com/google/addlicense
 ADDLICENSE_VERSION ?= v1.2.0
+# renovate: datasource=go depName=golang.org/x/vuln
 GOVULNCHECK_VERSION ?= v1.3.0
+# renovate: datasource=go depName=github.com/mikefarah/yq/v4
 YQ_VERSION ?= v4.44.3
+# renovate: datasource=go depName=sigs.k8s.io/controller-runtime/tools/setup-envtest
+ENVTEST_VERSION ?= v0.24.1
 
 ## ctlptl (local cluster + registry management)
+# renovate: datasource=github-releases depName=tilt-dev/ctlptl
 CTLPTL_VERSION ?= v0.9.4
 
 
@@ -114,7 +130,7 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) yq ## Download envtest-setup locally if necessary.
 	$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.22
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: $(LOCALBIN) gocover-cobertura
 gocover-cobertura: ## Download gocover-cobertura locally if necessary.

--- a/operator/deps.mk
+++ b/operator/deps.mk
@@ -130,7 +130,9 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 envtest: $(ENVTEST) yq ## Download envtest-setup locally if necessary.
 	$(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN)
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
+	@test -x $(LOCALBIN)/setup-envtest \
+		&& go version -m $(LOCALBIN)/setup-envtest | awk '$$1 == "mod" && $$2 == "sigs.k8s.io/controller-runtime/tools/setup-envtest" && $$3 == "$(ENVTEST_VERSION)" { found = 1 } END { exit !found }' \
+		|| GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@$(ENVTEST_VERSION)
 
 .PHONY: $(LOCALBIN) gocover-cobertura
 gocover-cobertura: ## Download gocover-cobertura locally if necessary.


### PR DESCRIPTION
Closes #522.

## Changes

- `operator/deps.mk`: added `# renovate:` annotation comments to all 14 hand-pinned build-tool
  versions, so Renovate's `custom.regex` manager can track and propose bumps for them.
- `operator/deps.mk`: replaced the branch-pinned `setup-envtest@release-0.22` with a versioned
  `ENVTEST_VERSION ?= v0.24.1` pin (`sigs.k8s.io/controller-runtime/tools/setup-envtest` is
  independently tagged as of v0.24.0, cut in lockstep with `controller-runtime`).
- `.github/renovate.json5`:
  - added `"custom.regex"` to `enabledManagers`
  - added a `customManagers` regex manager scoped to `operator/deps.mk` that reads the new
    annotation comments
  - grouped the ginkgo CLI pin (`deps.mk`) with the ginkgo library dep (`go.mod`) under a
    `ginkgo` group, so they're bumped together and can't drift apart again
  - folded the `setup-envtest` pin into the existing `kubernetes` group alongside
    `sigs.k8s.io/**`/`k8s.io/**`, since its tags move in lockstep with `controller-runtime`

## Verification

- [ ] `npx renovate-config-validator .github/renovate.json5` passes
- [ ] `make renovate-config-check` (blocked locally by a Docker credential issue unrelated to
      this change)
- [ ] A `workflow_dispatch` dry run on `renovate.yaml` proposes updates for the currently
      out-of-date tools

## Notes

Pinned values themselves are left as-is; Renovate will propose the actual version bumps once
this lands, per the issue's acceptance criteria.