### PR TITLE
docs: clarify deployment policy threshold semantics

### DIFF
--- a/docs/user-guide/deployment-policy.md
+++ b/docs/user-guide/deployment-policy.md
@@ -61,15 +61,17 @@ spec:
 A named group of nodes selected by labels with:
 
 - **Selector**: Kubernetes `LabelSelector` to match nodes
-- **Budget**: Maximum nodes in progress at once (count or percent)
+- **Budget**: Concurrency ceiling when the compartment has no `strategy` (count or percent). See [Budgets](#budgets).
 - **Strategy**: Rollout pattern (fixed, linear, or exponential)
 
 ### Budgets
 
-Defines the ceiling for concurrent nodes:
+Defines the ceiling for concurrent nodes **when the compartment has no `strategy`**:
 
 - **Count**: Fixed number (e.g., `count: 3`)
 - **Percent**: Percentage of matched nodes (e.g., `percent: 25`)
+
+When a `strategy` is set, the strategy determines batch size and this ceiling is not applied to it. See [Concurrency and failure tolerance are separate](#concurrency-and-failure-tolerance-are-separate).
 
 **Rounding for Percent**: `ceiling = max(1, int(matched_nodes × percent / 100))`
 
@@ -148,39 +150,137 @@ strategy:
 
 ## Strategy Parameters
 
-All strategies share these parameters:
+### Concurrency and failure tolerance are separate
 
-- **`initialBatch`** (≥1): Starting number of nodes (default: 1)
-- **`batchThreshold`** (1-100): Minimum success percentage to continue (default: 100)
-- **`failureThreshold`** (≥1, optional): Max consecutive failures before stopping (default: none/unlimited)
-- **`safetyLimit`** (1-100): Progress threshold for failure handling (default: 50)
+These are two independent groups of settings, and they are frequently confused with each other:
 
-### Default Values
+| Goal | Fields |
+|------|--------|
+| Control **how many nodes upgrade at once** | `budget` (`count` or `percent`), `initialBatch`, and the strategy's growth (`delta` for linear, `growthFactor` for exponential) |
+| Control **how much failure is tolerated** | `batchThreshold`, `failureThreshold`, `safetyLimit` |
 
-When strategy parameters are not specified, the operator applies these defaults:
+`batchThreshold` is not a concurrency knob. It is the pass mark a batch has to hit to count as a success. `batchThreshold: 100` says "every node in the batch must succeed"; it says nothing about how many nodes run in parallel.
 
-- `initialBatch`: 1
-- `batchThreshold`: 100
-- `safetyLimit`: 50
-- `failureThreshold`: **none** (rollout never stops due to consecutive failures)
+Which field actually sets concurrency depends on whether the compartment has a `strategy`:
 
-**Note**: `failureThreshold` is **nullable**. If omitted, the rollout will continue despite consecutive failures, only respecting batch success thresholds but never stopping the entire rollout.
+| Compartment has | Batch size comes from |
+|-----------------|-----------------------|
+| `budget` only, no `strategy` | The budget ceiling |
+| `budget` and a `strategy` | The strategy alone. **The budget does not cap the strategy's batch size.** |
+
+This surprises people, so it is worth stating plainly: once you set a `strategy`, `budget` no longer limits how many nodes run at once. It still determines the ceiling reported in `status.compartmentStatuses` and still breaks ties when a node matches more than one compartment, but it does not clamp the batch. A strategy's batch size is bounded only by the nodes left to process (and, for `exponential`, by the compartment's total node count).
+
+So to cap parallelism at a fixed number, use `fixed` with `initialBatch: N`, which upgrades up to `N` nodes at a time, fewer when fewer nodes remain. To ramp concurrency up over the course of the rollout, use `linear` or `exponential` and accept that it grows toward the size of the compartment. Use `budget` on its own, with no `strategy`, when you want a percentage-of-fleet ceiling and nothing more.
+
+### Reference
+
+| Field | Range | Default | Meaning |
+|-------|-------|---------|---------|
+| `initialBatch` | ≥ 1 | 1 | Nodes in the first batch |
+| `delta` (linear only) | ≥ 1 | 1 | Batch size increase after a successful batch |
+| `growthFactor` (exponential only) | ≥ 2 | 2 | Batch size multiplier after a successful batch |
+| `batchThreshold` | 1-100 | 100 | Percentage of a batch's **non-blocked** nodes that must succeed for the batch to count as a success |
+| `failureThreshold` | ≥ 1, nullable | none | Number of consecutive failed batches the compartment tolerates before it stops |
+| `safetyLimit` | 1-100 | 50 | Point of no return: the percentage of the compartment **completed or failed** at or above which the rollout commits to finishing, so `failureThreshold` and batch slowdown stop applying |
+
+When a parameter is omitted, the operator applies the default in the table above. `failureThreshold` is **nullable**: if you omit it, the rollout keeps going through any number of failed batches, still respecting `batchThreshold` for batch bookkeeping but never stopping on its own.
+
+`batchThreshold` is evaluated with integer division, so it interacts with how many nodes are actually scored: a batch with 5 non-blocked nodes can only score 0, 20, 40, 60, 80, or 100. Any `batchThreshold` above 80 therefore behaves identically to 100 for that batch. Pick the threshold with your smallest expected batch in mind, remembering that blocked nodes drop out of the denominator and can make a batch smaller than you planned.
+
+**`failureThreshold: 0` is invalid and the API server rejects it** with `spec...failureThreshold in body should be greater than or equal to 1`. Zero has no meaning for this field: it counts failed batches you are willing to tolerate, and the most permissive setting is not `0` but leaving the field out entirely. To stop as soon as one batch fails, use `failureThreshold: 1` together with `safetyLimit: 100`. `failureThreshold: 1` on its own only stops the rollout while it is below `safetyLimit`, which defaults to 50% progress; see [Safety Limit Behavior](#safety-limit-behavior).
+
+### What counts as a failure
+
+- A **node** counts as failed when its Status is `erroring` at the point the batch is evaluated. See [Operator Status](../architecture/operator-status.md) for how a node's Status is derived.
+- A **batch** counts as failed when the percentage of its **non-blocked** nodes that completed successfully falls below `batchThreshold`. With `batchThreshold: 100`, one erroring node fails the whole batch.
+- **Blocked nodes are excluded from the score, not counted against it.** The denominator is the batch's completed plus failed nodes, so a batch of 9 completed and 1 blocked scores 100%, not 90%. If every node in a batch is `blocked`, for example by a taint the NodeWright does not tolerate, the batch is not evaluated at all and the operator waits for those nodes to unblock.
+- **Blocked nodes do hold back rollout progress.** The progress percentage that `safetyLimit` is compared against is completed plus failed nodes over every node in the compartment, and blocked nodes sit in the denominator without ever advancing the numerator. A compartment with enough permanently blocked nodes can therefore never reach its `safetyLimit`.
+- A batch is evaluated **once it finishes**, not the moment a node starts erroring. Nodes already admitted to the batch run to completion first, so stopping happens at batch granularity and never mid-batch.
+- Stopping applies to **the compartment that failed**, not the entire NodeWright. Other compartments continue rolling out.
+- A stopped compartment stays stopped until its batch state is reset. See [Batch State Reset](#batch-state-reset).
 
 ### Safety Limit Behavior
 
-**Before safetyLimit** (e.g., < 50% progress):
+`safetyLimit` is the point of no return. It is a rollout progress percentage: below it the operator is still willing to call the whole thing off, and at or above it the operator commits to finishing. We are this far in, most of the fleet is already on the new version, so keep going.
 
-- Failures count toward `failureThreshold` (if set)
-- Batch sizes slow down (linear/exponential)
-- Reaching `failureThreshold` stops the rollout (if set)
+Progress is computed with integer division, as `(completed + failed) * 100 / total nodes in the compartment`, and the remainder is discarded. One processed node out of three is 33%, not 33.3%. On small compartments this shifts where the point of no return actually falls: with 3 nodes and the default `safetyLimit: 50`, one processed node scores 33% and the operator is still cautious, while two scores 66% and it has already committed.
 
-**After safetyLimit** (e.g., ≥ 50% progress):
+The reasoning is that a half-rolled-out fleet is its own kind of problem. Early on, stopping is cheap and failures are the best evidence you have that the change is bad, so the operator treats them seriously. Late in the rollout, stopping leaves the cluster split across two versions indefinitely, which is often worse than finishing and dealing with the handful of nodes that failed.
 
-- Rollout continues despite failures
-- Batch sizes don't slow down
-- `failureThreshold` is ignored (rollout assumed "safe enough" to complete)
+**Below `safetyLimit`** (by default, fewer than 50% of the compartment's nodes completed or failed), the operator is cautious:
 
-**Rationale**: Early failures indicate a problem. Late failures are less critical since most nodes are updated.
+- Failed batches count toward `failureThreshold`
+- For `linear` and `exponential`, batch sizes shrink after a failure: `linear` subtracts `delta`, `exponential` divides by `growthFactor`. `fixed` stays at `initialBatch`, since it never reacts to failures
+- Hitting `failureThreshold` stops the compartment
+
+**At or above `safetyLimit`**, the operator commits:
+
+- `failureThreshold` is no longer enforced, so the rollout will not stop on its own
+- For `linear` and `exponential`, batch sizes stop shrinking and keep growing as if every batch had passed. `fixed` stays at `initialBatch`, as it always does
+- Failures are still recorded in status; they just no longer change what the rollout does
+
+**If you do not want a point of no return, set `safetyLimit: 100`.** This is the most common surprise with these settings. At the default of 50, a rollout that is already past halfway runs to the end no matter what `failureThreshold` says, so `failureThreshold: 1` on its own means "stop at the first failed batch, but only during the first half of the rollout", not "stop at the first failure".
+
+---
+
+## Common Configurations
+
+### Parallel rollout, no failures tolerated
+
+Nodes upgrade in parallel with concurrency ramping up, and the compartment stops the moment any batch contains a failed node, at any point in the rollout.
+
+```yaml
+budget:
+  percent: 25              # reported as the compartment ceiling; does NOT cap the ramp below
+strategy:
+  exponential:
+    initialBatch: 1        # start with a single canary node
+    growthFactor: 2        # 1 -> 2 -> 4 -> 8 ... grows toward the compartment size
+    batchThreshold: 100    # every node in a batch must succeed
+    failureThreshold: 1    # one failed batch stops the compartment
+    safetyLimit: 100       # enforce failureThreshold for the entire rollout
+```
+
+Use `failureThreshold: 1` rather than `0`; see [Reference](#reference).
+
+The exponential ramp here is deliberately unbounded: each successful batch doubles until the compartment is done. If you need a hard ceiling on concurrency, use the fixed-parallelism form below instead, because `budget` will not impose one while a `strategy` is set.
+
+### Fixed parallelism, no failures tolerated
+
+Same failure handling, but a bounded number of nodes at a time instead of a ramp. With a `strategy` set, `initialBatch` is what actually caps concurrency, so set it to the ceiling you want.
+
+```yaml
+budget:
+  count: 10
+strategy:
+  fixed:
+    initialBatch: 10       # the real concurrency cap: up to 10 nodes at a time
+    batchThreshold: 100
+    failureThreshold: 1
+    safetyLimit: 100
+```
+
+### Tolerate some failures, slow down instead of stopping
+
+Useful for large fleets where a few bad nodes should not halt the rollout.
+
+```yaml
+budget:
+  percent: 20
+strategy:
+  linear:
+    initialBatch: 5
+    delta: 5               # grows 5 -> 10 -> 15 ...; budget does not cap this
+    batchThreshold: 90     # a batch passes if 90% of its non-blocked nodes succeed
+    safetyLimit: 100       # keep slowing down on failure for the whole rollout
+    # failureThreshold omitted: never stop, just shrink batches on failure
+```
+
+`safetyLimit` gates the slowdown as well as `failureThreshold`. Leaving it at the default 50 means the rollout hits its point of no return halfway through and batch sizes stop shrinking on failure from there on.
+
+### Excluding nodes from the rollout
+
+Deployment Policy has no exclusion field. Exclude individual nodes with the `nodewright.nvidia.com/ignore` label, or scope the whole rollout with the NodeWright's `nodeSelectors`. See [Node Selection](custom-resource.md#the-nodewrightnvidiacomignore-label).
 
 ---
 


### PR DESCRIPTION
## Description

A user configuring a rollout for "parallel upgrades with no allowed failures" landed on `batchThreshold: 100` + `failureThreshold: 0`. Both halves of that are wrong, and `docs/user-guide/deployment-policy.md` did not give them enough to notice:

1. **`failureThreshold: 0` is rejected by the API server.** The CRD schema sets `minimum: 1` (`operator/api/nodewright/v1alpha1/deployment_policy_types.go`). The field counts failed batches that are *tolerated*, so the most permissive setting is omitting it, not zero, and the strictest is `1`. The docs said "≥1, optional" in a bullet list, which is easy to skim past and does not explain why `0` is meaningless.

2. **`failureThreshold` stops being enforced halfway through the rollout.** `EvaluateBatchResult` only sets `ShouldStop` while `progressPercent < safetyLimit`, and `safetyLimit` defaults to 50. So `failureThreshold: 1` on its own means "stop at the first failed batch, but only during the first half of the rollout". Getting the intended behavior requires `safetyLimit: 100`. The same gate also controls the linear/exponential batch-size slowdown, which the docs mentioned but never connected to a recommended setting.

3. **`batchThreshold` was being read as a concurrency knob.** It is the pass mark a batch must hit. Concurrency is `min(budget ceiling, current strategy batch size)`.

### Changes to `docs/user-guide/deployment-policy.md`

- New "Concurrency and failure tolerance are separate" section with a table splitting the concurrency fields (`budget`, `initialBatch`, `delta`, `growthFactor`) from the failure-tolerance fields (`batchThreshold`, `failureThreshold`, `safetyLimit`), plus the effective-concurrency formula.
- Replaced the parameter bullet list with a reference table giving range, default and meaning per field. `delta` and `growthFactor` were not previously listed in this section.
- Explicit callout that `failureThreshold: 0` is invalid, with the rejection message and the reason.
- Note that `batchThreshold` is evaluated with integer division, so a 5-node batch can only score 0/20/40/60/80/100 and any threshold above 80 behaves identically to 100.
- New "What counts as a failure" section: a node fails when its Status is `erroring`; blocked nodes are not failures and an all-blocked batch is not evaluated at all; batches are evaluated on completion, so stopping is at batch granularity and never mid-batch; stopping applies to the failing compartment, not the whole NodeWright; a stopped compartment stays stopped until batch state is reset.
- Highlighted `safetyLimit: 100` in the existing Safety Limit section, and noted that `safetyLimit` gates the batch-size slowdown as well as `failureThreshold`.
- New "Common Configurations" section with three worked recipes (parallel with zero tolerance, fixed parallelism with zero tolerance, tolerate-and-slow-down), and a pointer to `nodewright.nvidia.com/ignore` for excluding individual nodes from a rollout.

### Verification

Claims were derived from the code, not from a cluster run: `EvaluateBatchResult` / `CalculateBatchSize` in `operator/api/nodewright/v1alpha1/deployment_policy_types.go`, `GetNodesForNextBatch` / `EvaluateCurrentBatch` in `operator/internal/wrapper/compartment.go`, the batch-evaluation call site in `operator/internal/controller/cluster_state_v2.go`, and the generated CRD schema under `operator/config/crd/bases/`.

Documentation only. No behavior change, no code touched, so no `RELEASE_NOTES.md` entry.

## Checklist

- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/nodewright/blob/main/CONTRIBUTING.md).
- [x] My commits are signed off per the [DCO](https://developercertificate.org/) **and** cryptographically signed: `git commit -s -S`.
- [x] New or existing tests cover these changes. (N/A: documentation only.)
- [x] The documentation is up to date with these changes.
