### PR TITLE
fix(licenses): resolve notices tags across all refs, not just reachable ones

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -3,8 +3,8 @@
 Combined third-party notices for Skyhook (operator, CLI, agent).
 
 Operator tag: `operator/v0.19.0`
-Agent tag: `agent/v6.4.1`
-Chart tag: `chart/v0.15.1`
+Agent tag: `agent/v6.4.2`
+Chart tag: `chart/v0.19.0`
 
 ## Operator + CLI
 
@@ -17538,7 +17538,7 @@ Apache license:
 
 ## Agent
 
-Agent tag: `agent/v6.4.1`
+Agent tag: `agent/v6.4.2`
 
 ### Python Dependencies
 

--- a/agent/THIRD_PARTY_NOTICES.md
+++ b/agent/THIRD_PARTY_NOTICES.md
@@ -1,6 +1,6 @@
 # Third-Party Notices — Skyhook Agent
 
-Agent tag: `agent/v6.4.1`
+Agent tag: `agent/v6.4.2`
 
 ## Python Dependencies
 

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -553,6 +553,10 @@ Run `make notices` and commit the refreshed file(s) whenever you:
 - Bump a Go dependency (changes to `operator/go.mod`, `operator/go.sum`, or `operator/vendor/`).
 - Bump a Python dependency (changes to `agent/skyhook-agent/pyproject.toml` or `agent/vendor/`).
 
+The `Operator tag:` / `Agent tag:` / `Chart tag:` lines name the newest final release of each component, so they also go stale when a release is cut.
+
+Tag resolution reads the local clone, so run `git fetch --tags` before `make notices`; a clone missing a recent tag will stamp an older version. The generator considers every tag rather than only those reachable from the current branch, because agent and chart releases are tagged on release branches and so are never reachable from `main`. Prerelease tags are skipped: git ranks `v0.17.0-rc.1` above `v0.17.0` unless `versionsort.suffix` is configured, which this repo does not configure, so an open release candidate would otherwise be stamped as the shipped release.
+
 ### CI behavior
 
 - **Renovate** (`.github/workflows/renovate.yaml`): Go and Python dependency branches run `make notices` after artifact updates and commit the refreshed notice files with the dependency change.

--- a/scripts/generate-notices.py
+++ b/scripts/generate-notices.py
@@ -53,12 +53,37 @@ GO_PLATFORMS = (
 )
 
 
+def latest_final_tag(prefix: str, tags) -> str:
+    """Newest final release tag for `prefix`, or "unreleased" if there is none.
+
+    Prereleases are filtered out rather than merely sorted below: git ranks
+    `v0.17.0-rc.1` above `v0.17.0` unless versionsort.suffix is configured,
+    which this repo does not do, so an open RC would otherwise be stamped as
+    the release. `tags` must already be in descending version order.
+    """
+    final = re.compile(rf"^{re.escape(prefix)}/v\d+\.\d+\.\d+$")
+    for t in tags:
+        t = t.strip()
+        if final.match(t):
+            return t
+    return "unreleased"
+
+
 def tag(prefix: str) -> str:
+    """Newest final release tag for `prefix` across all refs.
+
+    Deliberately not `git describe`: agent and chart releases are tagged on
+    release branches, so those tags are not reachable from main and describe
+    would stamp a version several releases behind. Matches the tag resolution
+    in scripts/gen-changelog.sh.
+    """
     r = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "describe", "--tags", "--abbrev=0", "--match", f"{prefix}/v*"],
+        ["git", "-C", str(REPO_ROOT), "tag", "--list", f"{prefix}/v*", "--sort=-v:refname"],
         capture_output=True, text=True, check=False,
     )
-    return r.stdout.strip() if r.returncode == 0 and r.stdout.strip() else "unreleased"
+    if r.returncode != 0:
+        return "unreleased"
+    return latest_final_tag(prefix, r.stdout.splitlines())
 
 
 def _collapse_blanks(text: str) -> str:

--- a/scripts/generate-notices_test.py
+++ b/scripts/generate-notices_test.py
@@ -36,6 +36,7 @@ _spec.loader.exec_module(generate_notices)
 
 uncovered_modules = generate_notices.uncovered_modules
 license_files = generate_notices.license_files
+latest_final_tag = generate_notices.latest_final_tag
 
 LOCAL = "github.com/NVIDIA/nodewright/operator"
 
@@ -180,6 +181,47 @@ class LicenseFilesTest(unittest.TestCase):
     def test_unknown_package_yields_nothing(self):
         self._write("linux_amd64", "example.com/pkg", "LICENSE", "a")
         self.assertEqual(license_files("example.com/other", self._caches("linux_amd64")), [])
+
+
+class LatestFinalTagTest(unittest.TestCase):
+    """The version stamp in the notices header names a shipped release, so a
+    prerelease or an unrelated component's tag must never be selected."""
+
+    def test_newest_final_wins(self):
+        self.assertEqual(
+            latest_final_tag("chart", ["chart/v0.18.0", "chart/v0.17.1", "chart/v0.17.0"]),
+            "chart/v0.18.0",
+        )
+
+    def test_prerelease_does_not_outrank_its_final(self):
+        # git ranks v0.17.0-rc.1 above v0.17.0 without versionsort.suffix, so
+        # the rc arrives first and taking head -1 unfiltered would stamp it.
+        self.assertEqual(
+            latest_final_tag("operator", ["operator/v0.17.0-rc.1", "operator/v0.17.0"]),
+            "operator/v0.17.0",
+        )
+
+    def test_test_suffix_is_also_rejected(self):
+        self.assertEqual(
+            latest_final_tag("chart", ["chart/v0.15.1-test.1", "chart/v0.15.1"]),
+            "chart/v0.15.1",
+        )
+
+    def test_only_prereleases_is_unreleased(self):
+        self.assertEqual(latest_final_tag("cli", ["cli/v0.2.0-rc.1"]), "unreleased")
+
+    def test_no_tags_is_unreleased(self):
+        self.assertEqual(latest_final_tag("agent", []), "unreleased")
+
+    def test_prefix_is_not_a_substring_match(self):
+        # "agent" must not pick up a hypothetical "agent-go" component's tags.
+        self.assertEqual(
+            latest_final_tag("agent", ["agent-go/v9.0.0", "agent/v6.4.2"]),
+            "agent/v6.4.2",
+        )
+
+    def test_blank_lines_are_ignored(self):
+        self.assertEqual(latest_final_tag("agent", ["", "agent/v6.4.2", ""]), "agent/v6.4.2")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #593

## Problem

The version stamps in the notices files named versions that were never the latest release:

| Header | Before | After |
|---|---|---|
| `Agent tag:` | `agent/v6.4.1` (2026-03-04) | `agent/v6.4.2` (2026-05-19) |
| `Chart tag:` | `chart/v0.15.1` | `chart/v0.19.0` |

`scripts/generate-notices.py` resolved tags with `git describe`, which only considers tags reachable from HEAD. Operator and CLI releases are tagged on `main`, so those stamps eventually caught up. Agent and chart releases are tagged on release branches that are not ancestors of `main`, so `git describe` could never return them, and the chart stamp drifted four minor releases behind.

Worth being explicit about: this was not ordinary staleness. Running `make notices` on a fully fetched clone still produced `chart/v0.15.1`, because the newer tag was unreachable rather than absent.

## Fix

Resolve from `git tag --list --sort=-v:refname` instead, filtered to `vX.Y.Z` finals.

The filter is the part that is easy to get wrong, so it is deliberate rather than incidental: git ranks `operator/v0.17.0-rc.1` **above** `operator/v0.17.0` unless `versionsort.suffix` is configured, and this repo does not configure it. Taking the first entry unfiltered would stamp an open release candidate as the shipped release. It only looks correct today because all four components' newest tags happen to be finals.

## Patterns

Per the repo's "use project patterns" rule, this introduces nothing new. Both pieces match existing code:

- `git tag --list --sort=-v:refname` is the tag resolution already used by `scripts/gen-changelog.sh:95` and `operator/Makefile:45`. `generate-notices.py` was the only consumer still on `git describe`.
- The `^<component>/v[0-9]+\.[0-9]+\.[0-9]+$` finals filter is copied from `gen-changelog.sh`'s `FINAL_RE`.
- `latest_final_tag()` is split out as a pure function so it is unit testable alongside `uncovered_modules()` and `license_files()`, the module's other pure helpers, which are tested the same way.

## Tests

7 new cases in `scripts/generate-notices_test.py` covering newest-final selection, `-rc.N` and `-test.N` rejection, prerelease-only and empty inputs, prefix-substring isolation, and blank lines. `make notices-test` passes 19/19, and `make notices-check` exits 0.

## Docs

`docs/contributing/release-process.md` gains a note that the stamps go stale on a release cut, that tag resolution reads the local clone and wants a `git fetch --tags` first, and why prereleases are filtered.

## Scope

Only the version stamps change. No dependency disclosure or license text moves, so there is no change to what is disclosed, only to which version the disclosure claims to describe.

Not adding a `RELEASE_NOTES.md` entry: this restores intended behavior and requires nothing of the reader at upgrade time.

## Note for reviewers

`operator/Makefile:45` (`GIT_TAG_LAST`) has the same latent prerelease-ordering bug. Left alone as out of scope, but it will misfire the first time an RC is the newest operator tag.