### PR TITLE
fix(ci): compare commit counts against a fresh pull request read

### DIFF
--- a/.github/workflows/commit-requirements.yaml
+++ b/.github/workflows/commit-requirements.yaml
@@ -48,16 +48,51 @@ jobs:
             const { owner, repo } = context.repo;
             const number = context.payload.pull_request.number;
 
+            // The commits endpoint tops out here. Reporting success on a
+            // truncated list would clear a pull request nobody fully checked.
+            const LIST_COMMITS_CAP = 250;
+
+            // Read the pull request on both sides of the commit list, and give up
+            // if the head moved in between. `context.payload.pull_request` is a
+            // snapshot from when the event fired and a run can sit in the queue
+            // for hours, so nothing here may be paired with it: a force-push
+            // during the read window would otherwise judge one head's commits
+            // against another head's commit count. The push that moved the head
+            // queued its own run, which sees a stable head and reports for it.
+            const headBefore = (
+              await github.rest.pulls.get({ owner, repo, pull_number: number })
+            ).data.head.sha;
+
             const commits = await github.paginate(github.rest.pulls.listCommits, {
               owner, repo, pull_number: number, per_page: 100,
             });
 
-            // This endpoint tops out at 250 commits. Reporting success on a
-            // truncated list would clear a pull request nobody fully checked, so
-            // say so and fail instead.
-            const expectedCommits = context.payload.pull_request.commits;
-            const truncated =
+            const { data: pull } = await github.rest.pulls.get({
+              owner, repo, pull_number: number,
+            });
+
+            if (pull.head.sha !== headBefore) {
+              core.info(
+                `Head moved while the commits were being read (${headBefore} to ${pull.head.sha}). A later run covers the current head.`,
+              );
+              return;
+            }
+
+            const expectedCommits = pull.commits;
+            const shortfall =
               typeof expectedCommits === 'number' && commits.length < expectedCommits;
+            const truncated = shortfall && commits.length >= LIST_COMMITS_CAP;
+
+            // Short of the cap the endpoint hands back every commit the head has,
+            // so a shortfall there is the pull request's own `commits` count
+            // lagging the ref, not commits withheld from the list. Note it and
+            // check what we were given: the list is complete for this head, and
+            // returning early here would pass a violation through unreported.
+            if (shortfall && !truncated) {
+              core.info(
+                `Pull request reports ${expectedCommits} commits but the endpoint listed ${commits.length}, short of the ${LIST_COMMITS_CAP} cap. Treating the count as stale and checking the commits the endpoint returned.`,
+              );
+            }
 
             // Bots cannot run `git commit -s -S`; Renovate and Dependabot commits
             // are signed by GitHub's own key and carry no sign-off by design.
@@ -151,7 +186,7 @@ jobs:
                 '',
                 `GitHub returned ${commits.length} of this pull request's ${expectedCommits} commits, so the sign-off and signature check is incomplete and is not reporting a pass.`,
                 '',
-                'The pull request commits endpoint returns at most 250 commits. Splitting this into smaller pull requests, or rebasing to reduce the commit count, lets the check cover everything.',
+                `The pull request commits endpoint returns at most ${LIST_COMMITS_CAP} commits. Splitting this into smaller pull requests, or rebasing to reduce the commit count, lets the check cover everything.`,
                 '',
                 `The requirements themselves are unchanged and are described in [CONTRIBUTING.md](${CONTRIBUTING}).`,
               ].join('\n');


### PR DESCRIPTION
## What

`.github/workflows/commit-requirements.yaml` compared a live API read against a snapshot:

- `commits` came from `pulls.listCommits`, evaluated when the job ran.
- `expectedCommits` came from `context.payload.pull_request.commits`, frozen when the webhook fired.

Any shortfall between the two was reported as endpoint truncation, which is only one of the ways they can disagree.

On #590 the run was created at 15:39:09Z but the job did not execute until 18:36:06Z. Dependabot force-pushed a rebase in between, collapsing the branch from 3 commits to 1. The payload still said 3, the live list correctly returned 1, and the truncation branch fired: a bot-only pull request, where every commit is exempt from both checks, got a red check and a comment telling the contributor to split it up. A force-push plus any queue delay reproduces this on any pull request, so it is not specific to Dependabot.

It is also the loudest failure mode available, because the truncation branch runs before the bot filter and before any violation check.

## How

- Read the pull request on both sides of `listCommits` and return without reporting if the head moved in between, so one head's commits are never judged against another head's commit count. The push that moved the head queued its own run, which sees a stable head.
- Take the expected commit count from that fresh read instead of the event payload.
- Treat a shortfall as truncation only when the list actually hits the 250-commit cap. Below the cap the endpoint returns everything the head has, so a shortfall there is a lagging `commits` count rather than withheld commits: note it in the log and check the commits that came back.
- The truncation comment interpolates the cap constant instead of repeating `250` in prose.

## Testing

`actionlint` passes. This repo has no harness for inline `github-script` bodies, so I extracted the script and ran it against stubbed `github` / `core` / `context` objects:

| Scenario | Result |
| --- | --- |
| #590 shape: payload stale, live reads agree | passes, no comment |
| Force-push mid-read, same commit count | exits quietly, no comment |
| Force-push mid-read, replacement head above the cap | exits quietly, no comment |
| Lagging count below the cap, bot commits only | notes the stale count, passes |
| Lagging count below the cap, violating human commit | notes the stale count, still fails and comments |
| Genuine truncation, 250 listed against 300 reported | fails and comments, as before |
| Clean human commit | passes |
| Human commit with no sign-off and no signature | fails with the violation table, as before |

## Notes

The check is report-only, so nothing was ever blocked by this. What it cost was trust in the check, which is the thing that makes it worth promoting to a gate later.

Fixes #595
