### PR TITLE
fix(ci): derive the chart registry namespace from the repository

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -266,10 +266,12 @@ jobs:
         env:
           CHART_NAME: ${{ steps.chart-metadata.outputs.name }}
           CHART_VERSION: ${{ steps.chart-metadata.outputs.version }}
+          IMAGE_NAME: ${{ github.repository }}
         run: |
           set -euo pipefail
 
-          chart_repo="ghcr.io/nvidia/nodewright/charts"
+          # Lowercase for Docker compliance
+          chart_repo="ghcr.io/$(echo "${IMAGE_NAME}" | tr '[:upper:]' '[:lower:]')/charts"
           chart_subject="${chart_repo}/${CHART_NAME}"
           # `helm push` writes "Pushed:" and "Digest:" to stderr (helm 3.16+),
           # so capture both streams or awk sees an empty string.

--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -451,8 +451,8 @@ cosign verify-attestation \
 #### Helm chart
 
 ```bash
-CHART=ghcr.io/nvidia/nodewright/charts/skyhook-operator
-TAG=v0.15.1
+CHART=ghcr.io/nvidia/nodewright/charts/nodewright
+TAG=v0.19.0
 DIGEST=$(docker buildx imagetools inspect "${CHART}:${TAG}" --format '{{json .Manifest}}' | jq -r '.digest')
 SUBJECT="${CHART}@${DIGEST}"
 IDENTITY='^https://github.com/NVIDIA/nodewright/\.github/workflows/release\.yml@refs/tags/chart/.*$'
@@ -480,7 +480,7 @@ Use the same command pattern for each released artifact:
 |----------|-----------------------|
 | GHCR operator image | `ghcr.io/nvidia/nodewright/operator@sha256:<digest>` |
 | GHCR agent image | `ghcr.io/nvidia/nodewright/agent@sha256:<digest>` |
-| GHCR Helm chart | `ghcr.io/nvidia/nodewright/charts/skyhook-operator@sha256:<digest>` |
+| GHCR Helm chart | `ghcr.io/nvidia/nodewright/charts/nodewright@sha256:<digest>` |
 
 ## Common Commands
 


### PR DESCRIPTION
## What

Two small fixes in the release path.

**1. `release.yml` no longer hardcodes the GHCR namespace.**

The chart publish job pinned `chart_repo="ghcr.io/nvidia/nodewright/charts"` as a literal, while the other three publishers (`operator-ci.yaml`, `agent-ci.yaml`, `agentless-container.yaml`) all derive their namespace from `${{ github.repository }}` and lowercase it. Now all four agree.

No behavior change today: `NVIDIA/nodewright` lowercases to `nvidia/nodewright`, so the chart still publishes to exactly `ghcr.io/nvidia/nodewright/charts/nodewright`.

**2. The Helm chart verification example in `docs/contributing/release-process.md` pointed at an artifact that was never published.**

It said `charts/skyhook-operator:v0.15.1`. Both halves were wrong: OCI chart publishing started at `chart/v0.16.0`, and the chart was renamed `skyhook-operator` → `nodewright` in that same release, so `charts/skyhook-operator` never existed on ghcr at all. Confirmed against the registry, which holds exactly `v0.16.0` through `v0.19.0` under `charts/nodewright`. The example now points at the current chart release and runs as written.

## Why now

GHCR packages are owned by the **org**, not the repository, and there is no registry-side redirect. If this repository ever moves org, the three derived publishers follow it automatically and the one literal does not: images would land in the new namespace while the chart job kept targeting a package the new owner's `GITHUB_TOKEN` has no write access to. Worth removing regardless of whether a move happens.

## Notes for review

- No new patterns introduced. The `IMAGE_NAME: ${{ github.repository }}` + `tr '[:upper:]' '[:lower:]'` shape is copied verbatim from `operator-ci.yaml`, including the env var name, so a grep for `IMAGE_NAME` finds all four publishers.
- Deliberately out of scope: `chart/values.yaml` defaults, README/docs install commands, and the `SECURITY.md` cosign identity all stay literal. Those are user-facing copy-pasteable strings, or describe immutable properties of already-signed artifacts, and templating them would make them worse. Same for the `if: github.repository == 'NVIDIA/nodewright'` guards, whose entire purpose is "canonical repo only".
- Also out of scope: `.gitlab-ci.yml` hardcodes the ghcr pull paths for the NGC mirror jobs, which are dormant while NGC distribution is paused. Note that `"org": "nvidia"` in that file is the **NGC** org, not GitHub, and should not be touched.
- No `RELEASE_NOTES.md` entry: nothing for a user to do, and no behavior they will notice.

## Testing

- `actionlint .github/workflows/release.yml` reports nothing new. The one `SC2086` it flags locally is pre-existing on `main` at line 53 and is not a CI gate: the workflow runs `./actionlint -color -shellcheck=`, which disables shellcheck.
- The rendered `chart_repo` is unchanged for this repo, so the next `chart/v*` tag exercises it end to end.